### PR TITLE
Simplify venue info display

### DIFF
--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -500,6 +500,7 @@ export default function EditProductPage() {
   const [imageUrl, setImageUrl] = useState("");
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [requirements, setRequirements] = useState("");
+  const [operationsInfo, setOperationsInfo] = useState("");
   const [deliveryIndex, setDeliveryIndex] = useState(0);
   const [deliverables, setDeliverables] = useState<
     (ProductDeliverable & { file?: File })[]
@@ -990,6 +991,7 @@ export default function EditProductPage() {
           );
           setImageUrl(p.imageUrl || "");
           setRequirements(p.requirements || "");
+          setOperationsInfo(p.operationsInfo || "");
           const idx = deliveryOptions.indexOf(p.deliveryTime || "");
           setDeliveryIndex(idx >= 0 ? idx : 0);
           setDeliverables((p.deliverables || []) as any);
@@ -1485,6 +1487,7 @@ export default function EditProductPage() {
       },
       imageUrl: img || null,
       requirements: requirements || null,
+      operationsInfo: operationsInfo || null,
       deliveryTime: deliveryOptions[deliveryIndex],
       deliverables: deliverableData,
       variations: variationData,
@@ -2221,14 +2224,26 @@ export default function EditProductPage() {
           </label>
           <label className="text-sm font-medium">Requirements</label>
           <textarea className="input" value={requirements} onChange={(e) => setRequirements(e.target.value)} />
-      <label className="text-sm font-medium">Delivery Time: {deliveryOptions[deliveryIndex]}</label>
-      <input
-        type="range"
-        min={0}
-        max={deliveryOptions.length - 1}
-        value={deliveryIndex}
-        onChange={(e) => setDeliveryIndex(Number(e.target.value))}
-      />
+          <label className="text-sm font-medium">
+            Delivery Time: {deliveryOptions[deliveryIndex]}
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={deliveryOptions.length - 1}
+            value={deliveryIndex}
+            onChange={(e) => setDeliveryIndex(Number(e.target.value))}
+          />
+          <label className="text-sm font-medium">Our Operations</label>
+          <textarea
+            className="input"
+            value={operationsInfo}
+            onChange={(e) => setOperationsInfo(e.target.value)}
+            placeholder="Arrival window, on-site timings, contact details, etc."
+          />
+          <p className="text-xs text-gray-500 -mt-1">
+            Shown beneath Delivery Time on the customer product page.
+          </p>
     </div>
   )}
 

--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -506,6 +506,30 @@ export default function EditProductPage() {
     (ProductDeliverable & { file?: File })[]
   >([]);
   const [variations, setVariations] = useState<VariationFormState[]>([]);
+  useEffect(() => {
+    setDeliverables((prev) => {
+      if (prev.length === 0) return prev;
+      const allowed = new Set(variations.map((variation) => variation.id));
+      let changed = false;
+      const next = prev.map((deliverable) => {
+        if (!Array.isArray(deliverable.variationIds)) return deliverable;
+        const filtered = deliverable.variationIds.filter((id) =>
+          allowed.has(id)
+        );
+        if (filtered.length === deliverable.variationIds.length) {
+          return deliverable;
+        }
+        changed = true;
+        if (filtered.length === 0) {
+          const clone = { ...deliverable };
+          delete clone.variationIds;
+          return clone;
+        }
+        return { ...deliverable, variationIds: filtered };
+      });
+      return changed ? next : prev;
+    });
+  }, [variations]);
   const [modifiers, setModifiers] = useState<ModifierSelectionFormState[]>([]);
   const [enabledModifierGroups, setEnabledModifierGroups] = useState<string[]>([]);
   const [seo, setSeo] = useState<ProductSEO>({});
@@ -1332,6 +1356,13 @@ export default function EditProductPage() {
       const desc = d.description?.trim();
       if (desc) item.description = desc;
       if (thumb) item.thumbnailUrl = thumb;
+      const scopedIds = Array.isArray(d.variationIds)
+        ? d.variationIds.filter(
+            (value): value is string =>
+              typeof value === "string" && value.trim().length > 0
+          )
+        : [];
+      if (scopedIds.length > 0) item.variationIds = scopedIds;
       deliverableData.push(item);
     }
 
@@ -1590,6 +1621,37 @@ export default function EditProductPage() {
 
   const updateDeliverable = (index: number, data: Partial<ProductDeliverable & { file?: File }>) => {
     setDeliverables((prev) => prev.map((d, i) => (i === index ? { ...d, ...data } : d)));
+  };
+
+  const setDeliverableVariation = (
+    index: number,
+    variationId: string,
+    checked: boolean
+  ) => {
+    setDeliverables((prev) =>
+      prev.map((deliverable, i) => {
+        if (i !== index) return deliverable;
+        const existing = Array.isArray(deliverable.variationIds)
+          ? deliverable.variationIds.filter(
+              (id): id is string => typeof id === "string" && id.trim().length > 0
+            )
+          : [];
+        const nextIds = checked
+          ? existing.includes(variationId)
+            ? existing
+            : [...existing, variationId]
+          : existing.filter((id) => id !== variationId);
+        if (nextIds.length === existing.length) {
+          return deliverable;
+        }
+        if (nextIds.length === 0) {
+          const clone = { ...deliverable };
+          delete clone.variationIds;
+          return clone;
+        }
+        return { ...deliverable, variationIds: nextIds };
+      })
+    );
   };
 
   const removeDeliverable = (index: number) => {
@@ -3135,6 +3197,45 @@ export default function EditProductPage() {
                 value={d.description || ""}
                 onChange={(e) => updateDeliverable(i, { description: e.target.value })}
               />
+              {variations.length > 0 && (
+                <div className="grid gap-2">
+                  <p className="text-xs font-medium text-gray-600">
+                    Included with
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {variations.map((variation, variationIndex) => {
+                      const label = variation.name.trim()
+                        ? variation.name.trim()
+                        : `Package ${variationIndex + 1}`;
+                      const checked = Array.isArray(d.variationIds)
+                        ? d.variationIds.includes(variation.id)
+                        : false;
+                      return (
+                        <label
+                          key={variation.id}
+                          className="flex items-center gap-2 rounded border px-2 py-1 text-xs"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={(e) =>
+                              setDeliverableVariation(
+                                i,
+                                variation.id,
+                                e.target.checked
+                              )
+                            }
+                          />
+                          {label}
+                        </label>
+                      );
+                    })}
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    Leave unticked to include with every package.
+                  </p>
+                </div>
+              )}
               <input
                 type="file"
                 onChange={(e) => updateDeliverable(i, { file: e.target.files?.[0] || undefined })}

--- a/apps/web/app/admin/products/new/ClientPage.tsx
+++ b/apps/web/app/admin/products/new/ClientPage.tsx
@@ -485,6 +485,7 @@ export default function NewProductPage() {
   const [price, setPrice] = useState("0");
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [requirements, setRequirements] = useState("");
+  const [operationsInfo, setOperationsInfo] = useState("");
   const [deliveryIndex, setDeliveryIndex] = useState(0);
   const [deliverables, setDeliverables] = useState<
     (ProductDeliverable & { file?: File })[]
@@ -1228,6 +1229,7 @@ export default function NewProductPage() {
         parking: parkingValue,
       },
       requirements: requirements || null,
+      operationsInfo: operationsInfo || null,
       deliveryTime: deliveryOptions[deliveryIndex],
       category: category || null,
       eventDate: eventDate || null,
@@ -1627,14 +1629,26 @@ export default function NewProductPage() {
           </label>
           <label className="text-sm font-medium">Requirements</label>
           <textarea className="input" value={requirements} onChange={(e) => setRequirements(e.target.value)} />
-      <label className="text-sm font-medium">Delivery Time: {deliveryOptions[deliveryIndex]}</label>
-      <input
-        type="range"
-        min={0}
-        max={deliveryOptions.length - 1}
-        value={deliveryIndex}
-        onChange={(e) => setDeliveryIndex(Number(e.target.value))}
-      />
+          <label className="text-sm font-medium">
+            Delivery Time: {deliveryOptions[deliveryIndex]}
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={deliveryOptions.length - 1}
+            value={deliveryIndex}
+            onChange={(e) => setDeliveryIndex(Number(e.target.value))}
+          />
+          <label className="text-sm font-medium">Our Operations</label>
+          <textarea
+            className="input"
+            value={operationsInfo}
+            onChange={(e) => setOperationsInfo(e.target.value)}
+            placeholder="Arrival window, on-site timings, contact details, etc."
+          />
+          <p className="text-xs text-gray-500 -mt-1">
+            Shown beneath Delivery Time on the customer product page.
+          </p>
     </div>
       )}
 

--- a/apps/web/app/admin/products/new/ClientPage.tsx
+++ b/apps/web/app/admin/products/new/ClientPage.tsx
@@ -491,6 +491,30 @@ export default function NewProductPage() {
     (ProductDeliverable & { file?: File })[]
   >([]);
   const [variations, setVariations] = useState<VariationFormState[]>([]);
+  useEffect(() => {
+    setDeliverables((prev) => {
+      if (prev.length === 0) return prev;
+      const allowed = new Set(variations.map((variation) => variation.id));
+      let changed = false;
+      const next = prev.map((deliverable) => {
+        if (!Array.isArray(deliverable.variationIds)) return deliverable;
+        const filtered = deliverable.variationIds.filter((id) =>
+          allowed.has(id)
+        );
+        if (filtered.length === deliverable.variationIds.length) {
+          return deliverable;
+        }
+        changed = true;
+        if (filtered.length === 0) {
+          const clone = { ...deliverable };
+          delete clone.variationIds;
+          return clone;
+        }
+        return { ...deliverable, variationIds: filtered };
+      });
+      return changed ? next : prev;
+    });
+  }, [variations]);
   const [modifiers, setModifiers] = useState<ModifierSelectionFormState[]>([]);
   const [enabledModifierGroups, setEnabledModifierGroups] = useState<string[]>([]);
   const [seo, setSeo] = useState<ProductSEO>({});
@@ -1269,6 +1293,12 @@ export default function NewProductPage() {
       const desc = d.description?.trim();
       if (desc) item.description = desc;
       if (thumb) item.thumbnailUrl = thumb;
+      const scopedIds = Array.isArray(d.variationIds)
+        ? d.variationIds.filter(
+            (id): id is string => typeof id === "string" && id.trim().length > 0
+          )
+        : [];
+      if (scopedIds.length > 0) item.variationIds = scopedIds;
       deliverableData.push(item);
     }
     let seoImage = "";
@@ -1316,6 +1346,36 @@ export default function NewProductPage() {
   };
   const updateDeliverable = (index: number, data: Partial<ProductDeliverable & { file?: File }>) => {
     setDeliverables((prev) => prev.map((d, i) => (i === index ? { ...d, ...data } : d)));
+  };
+  const setDeliverableVariation = (
+    index: number,
+    variationId: string,
+    checked: boolean
+  ) => {
+    setDeliverables((prev) =>
+      prev.map((deliverable, i) => {
+        if (i !== index) return deliverable;
+        const existing = Array.isArray(deliverable.variationIds)
+          ? deliverable.variationIds.filter(
+              (id): id is string => typeof id === "string" && id.trim().length > 0
+            )
+          : [];
+        const nextIds = checked
+          ? existing.includes(variationId)
+            ? existing
+            : [...existing, variationId]
+          : existing.filter((id) => id !== variationId);
+        if (nextIds.length === existing.length) {
+          return deliverable;
+        }
+        if (nextIds.length === 0) {
+          const clone = { ...deliverable };
+          delete clone.variationIds;
+          return clone;
+        }
+        return { ...deliverable, variationIds: nextIds };
+      })
+    );
   };
   const removeDeliverable = (index: number) => {
     setDeliverables((prev) => prev.filter((_, i) => i !== index));
@@ -2495,6 +2555,45 @@ export default function NewProductPage() {
                 value={d.description || ""}
                 onChange={(e) => updateDeliverable(i, { description: e.target.value })}
               />
+              {variations.length > 0 && (
+                <div className="grid gap-2">
+                  <p className="text-xs font-medium text-gray-600">
+                    Included with
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {variations.map((variation, variationIndex) => {
+                      const label = variation.name.trim()
+                        ? variation.name.trim()
+                        : `Package ${variationIndex + 1}`;
+                      const checked = Array.isArray(d.variationIds)
+                        ? d.variationIds.includes(variation.id)
+                        : false;
+                      return (
+                        <label
+                          key={variation.id}
+                          className="flex items-center gap-2 rounded border px-2 py-1 text-xs"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={(e) =>
+                              setDeliverableVariation(
+                                i,
+                                variation.id,
+                                e.target.checked
+                              )
+                            }
+                          />
+                          {label}
+                        </label>
+                      );
+                    })}
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    Leave unticked to include with every package.
+                  </p>
+                </div>
+              )}
               <input
                 type="file"
                 onChange={(e) => updateDeliverable(i, { file: e.target.files?.[0] || undefined })}

--- a/apps/web/app/admin/users/ClientPage.tsx
+++ b/apps/web/app/admin/users/ClientPage.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { functions } from '@/lib/firebase';
+import { functions, ensureFirebase } from '@/lib/firebase';
 import { httpsCallable } from 'firebase/functions';
 import { adminListUsers, adminUpdateUser } from '@/lib/admin';
 import {
@@ -15,6 +15,12 @@ import {
 } from '@/lib/roles';
 import { useRoleGate } from '@/hooks/useRoleGate';
 import CRMRecordForm from '@/components/CRMRecordForm';
+import { collection, getDocs } from 'firebase/firestore';
+
+interface ProductSummary {
+  id: string;
+  name: string;
+}
 
 /**
  * Admin Users Management
@@ -29,6 +35,7 @@ interface AdminUser {
   crmStatus?: string;
   discount?: number;
   roles?: UserRoles;
+  suggestedProductId?: string | null;
   [key: string]: any;
 }
 
@@ -39,6 +46,8 @@ export default function AdminUsersPage() {
   const [activeTab, setActiveTab] = useState<'client' | 'prospect' | 'outreach'>('client');
   const [showForm, setShowForm] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [products, setProducts] = useState<ProductSummary[]>([]);
+  const [outreachProductFilter, setOutreachProductFilter] = useState('');
   const canEditRoles = useMemo(() => !!roles?.admin, [roles]);
 
   useEffect(() => {
@@ -63,6 +72,37 @@ export default function AdminUsersPage() {
       }
     })();
   }, [allowed, guardLoading]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { db } = await ensureFirebase();
+        if (!db) {
+          return;
+        }
+        const snapshot = await getDocs(collection(db, 'products'));
+        const list: ProductSummary[] = snapshot.docs
+          .map((docSnap) => {
+            const data = docSnap.data() as Record<string, any>;
+            const rawName = typeof data?.name === 'string' ? data.name.trim() : '';
+            return {
+              id: docSnap.id,
+              name: rawName.length > 0 ? rawName : 'Untitled product',
+            };
+          })
+          .sort((a, b) => a.name.localeCompare(b.name));
+        setProducts(list);
+      } catch (err) {
+        console.error('Failed to load products for CRM outreach suggestions', err);
+      }
+    })();
+  }, []);
+
+  const productById = useMemo(() => {
+    const map = new Map<string, ProductSummary>();
+    products.forEach((product) => map.set(product.id, product));
+    return map;
+  }, [products]);
 
   const changeStatus = async (user: any, status: string) => {
     try {
@@ -99,6 +139,17 @@ export default function AdminUsersPage() {
     } catch (err: any) {
       console.error(err);
       alert(err.message || 'Error updating discount');
+    }
+  };
+
+  const updateSuggestedProduct = async (user: AdminUser, productId: string) => {
+    const value = productId || null;
+    try {
+      await adminUpdateUser({ userId: user.id, updates: { suggestedProductId: value } });
+      setUsers(users.map(u => (u.id === user.id ? { ...u, suggestedProductId: value } : u)));
+    } catch (err: any) {
+      console.error(err);
+      alert(err.message || 'Error updating suggested product');
     }
   };
 
@@ -179,7 +230,7 @@ export default function AdminUsersPage() {
     );
   };
 
-  const renderTable = (list: AdminUser[]) => (
+  const renderTable = (list: AdminUser[], status: 'client' | 'prospect' | 'outreach') => (
     list.length === 0 ? (
       <p>No records.</p>
     ) : (
@@ -191,6 +242,7 @@ export default function AdminUsersPage() {
             <th className="p-2">Stage</th>
             <th className="p-2">Roles</th>
             <th className="p-2">Discount%</th>
+            <th className="p-2">Suggested Product</th>
             <th className="p-2">Actions</th>
           </tr>
         </thead>
@@ -221,6 +273,24 @@ export default function AdminUsersPage() {
                   onChange={(e) => updateDiscount(user, parseFloat(e.target.value) || 0)}
                 />
               </td>
+              <td className="p-2">
+                {status === 'outreach' ? (
+                  <select
+                    className="border p-1 text-sm"
+                    value={user.suggestedProductId || ''}
+                    onChange={(e) => updateSuggestedProduct(user, e.target.value)}
+                  >
+                    <option value="">No suggestion</option>
+                    {products.map((product) => (
+                      <option key={product.id} value={product.id}>
+                        {product.name}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <span>{productById.get(user.suggestedProductId || '')?.name || '-'}</span>
+                )}
+              </td>
               <td className="p-2 flex gap-2">
                 <Link className="btn-sm" href={`/admin/users/${user.id}`}>View</Link>
                 {user.email && (
@@ -241,12 +311,19 @@ export default function AdminUsersPage() {
   const clients = users.filter(u => (u.crmStatus || 'client') === 'client');
   const prospects = users.filter(u => u.crmStatus === 'prospect');
   const outreach = users.filter(u => u.crmStatus === 'outreach');
+  const filteredOutreach = outreachProductFilter
+    ? outreach.filter((u) => (u.suggestedProductId || '') === outreachProductFilter)
+    : outreach;
 
   const handleAddRecord = async (data: any) => {
     try {
       const id = crypto.randomUUID();
-      await adminUpdateUser({ userId: id, updates: { ...data, crmStatus: activeTab } });
-      setUsers([...users, { id, ...data, crmStatus: activeTab }]);
+      const payload: Record<string, any> = { ...data, crmStatus: activeTab };
+      if ('suggestedProductId' in payload && !payload.suggestedProductId) {
+        payload.suggestedProductId = null;
+      }
+      await adminUpdateUser({ userId: id, updates: payload });
+      setUsers([...users, { id, ...payload }]);
       setShowForm(false);
     } catch (err: any) {
       console.error(err);
@@ -272,12 +349,31 @@ export default function AdminUsersPage() {
       <div className="flex justify-end">
         <button className="btn" onClick={() => setShowForm(true)}>Add Record</button>
       </div>
-      {activeTab === 'client' && renderTable(clients)}
-      {activeTab === 'prospect' && renderTable(prospects)}
-      {activeTab === 'outreach' && renderTable(outreach)}
+      {activeTab === 'outreach' && (
+        <div className="flex items-center gap-2">
+          <label className="text-sm" htmlFor="outreach-product-filter">Filter by product:</label>
+          <select
+            id="outreach-product-filter"
+            className="border p-1 text-sm"
+            value={outreachProductFilter}
+            onChange={(e) => setOutreachProductFilter(e.target.value)}
+          >
+            <option value="">All products</option>
+            {products.map((product) => (
+              <option key={product.id} value={product.id}>
+                {product.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      {activeTab === 'client' && renderTable(clients, 'client')}
+      {activeTab === 'prospect' && renderTable(prospects, 'prospect')}
+      {activeTab === 'outreach' && renderTable(filteredOutreach, 'outreach')}
       {showForm && (
         <CRMRecordForm
           status={activeTab}
+          products={products}
           onSave={handleAddRecord}
           onClose={() => setShowForm(false)}
         />

--- a/apps/web/components/CRMRecordForm.tsx
+++ b/apps/web/components/CRMRecordForm.tsx
@@ -1,17 +1,25 @@
 "use client";
 import { useState } from 'react';
 
+interface ProductOption {
+  id: string;
+  name: string;
+}
+
 interface Props {
   status: 'client' | 'prospect' | 'outreach';
   onSave: (data: any) => void;
   onClose: () => void;
+  products?: ProductOption[];
 }
 
-export default function CRMRecordForm({ status, onSave, onClose }: Props) {
+export default function CRMRecordForm({ status, onSave, onClose, products = [] }: Props) {
   const [tab, setTab] = useState<'organisation' | 'contact' | 'branding' | 'log' | 'projects'>('organisation');
   const [form, setForm] = useState<any>({});
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
@@ -200,6 +208,27 @@ export default function CRMRecordForm({ status, onSave, onClose }: Props) {
           </div>
 
           <div className={tab === 'projects' ? 'grid gap-2' : 'hidden'}>
+            {status === 'outreach' && (
+              <div className="grid gap-1">
+                <label className="text-sm font-medium" htmlFor="suggestedProductId">
+                  Suggested Product
+                </label>
+                <select
+                  id="suggestedProductId"
+                  name="suggestedProductId"
+                  className="border p-2"
+                  value={form.suggestedProductId || ''}
+                  onChange={handleChange}
+                >
+                  <option value="">Select a product</option>
+                  {products.map((product) => (
+                    <option key={product.id} value={product.id}>
+                      {product.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
             <textarea
               name="projects"
               placeholder="Project details"

--- a/apps/web/components/ProductDetail.tsx
+++ b/apps/web/components/ProductDetail.tsx
@@ -235,7 +235,7 @@ export default function ProductDetail({
         </section>
       )}
 
-      {(product.requirements || product.deliveryTime ||
+      {(product.requirements || product.deliveryTime || product.operationsInfo ||
         (product.deliverables && product.deliverables.length > 0)) && (
         <section>
           <h2 className="text-xl font-semibold mb-2">Project Details</h2>
@@ -245,9 +245,15 @@ export default function ProductDetail({
                 <p className="whitespace-pre-line">{product.requirements}</p>
               </ProductFeatureCard>
             )}
-            {product.deliveryTime && (
+            {(product.deliveryTime || product.operationsInfo) && (
               <ProductFeatureCard title="Delivery Time" icon={FiClock}>
-                <p>{product.deliveryTime}</p>
+                {product.deliveryTime && <p>{product.deliveryTime}</p>}
+                {product.operationsInfo && (
+                  <div className={`grid gap-1${product.deliveryTime ? " mt-3" : ""}`}>
+                    <p className="font-semibold text-gray-900">Our Operations</p>
+                    <p className="whitespace-pre-line">{product.operationsInfo}</p>
+                  </div>
+                )}
               </ProductFeatureCard>
             )}
             {product.deliverables && product.deliverables.length > 0 && (

--- a/apps/web/components/ProductDetail.tsx
+++ b/apps/web/components/ProductDetail.tsx
@@ -300,6 +300,119 @@ export default function ProductDetail({
 
   const venueName = venue?.name || product.venue || "";
 
+  const variationNameById = useMemo(() => {
+    if (!Array.isArray(product.variations)) {
+      return new Map<string, string>();
+    }
+    return new Map(
+      product.variations.map((entry, index) => [
+        entry.id,
+        entry.name?.trim() || `Package ${index + 1}`,
+      ])
+    );
+  }, [product.variations]);
+
+  const deliverableDisplay = useMemo(() => {
+    const entries = Array.isArray(product.deliverables)
+      ? product.deliverables.filter(
+          (item): item is Product["deliverables"][number] =>
+            !!item && typeof item === "object"
+        )
+      : [];
+
+    const availableVariationIds = Array.isArray(product.variations)
+      ? product.variations
+          .map((v) => v.id)
+          .filter((id): id is string => typeof id === "string" && id.length > 0)
+      : [];
+
+    const selectedId =
+      variation && availableVariationIds.includes(variation) ? variation : null;
+
+    let hasRestricted = false;
+
+    const visible = entries.filter((deliverable) => {
+      const scopedIds = Array.isArray(deliverable.variationIds)
+        ? deliverable.variationIds.filter(
+            (id): id is string => typeof id === "string" && id.trim().length > 0
+          )
+        : [];
+      if (scopedIds.length > 0) {
+        hasRestricted = true;
+        if (!selectedId) {
+          return false;
+        }
+        return scopedIds.includes(selectedId);
+      }
+      return true;
+    });
+
+    return {
+      visible,
+      hasRestricted,
+      selectedId,
+      total: entries.length,
+    } as const;
+  }, [product.deliverables, product.variations, variation]);
+
+  const deliverableItems = useMemo(() => {
+    return deliverableDisplay.visible
+      .map((deliverable, index) => {
+        const title =
+          typeof deliverable.title === "string"
+            ? deliverable.title.trim()
+            : "";
+        const description =
+          typeof deliverable.description === "string"
+            ? deliverable.description.trim()
+            : "";
+        const thumb =
+          typeof deliverable.thumbnailUrl === "string"
+            ? deliverable.thumbnailUrl.trim()
+            : "";
+        if (!title && !description && !thumb) return null;
+        const Icon =
+          (deliverable.type && deliverableIcons[deliverable.type]) || FiCheck;
+        const scopeLabels = Array.isArray(deliverable.variationIds)
+          ? deliverable.variationIds
+              .filter(
+                (id): id is string => typeof id === "string" && id.trim().length > 0
+              )
+              .map((id) => variationNameById.get(id) || id)
+          : [];
+
+        return (
+          <li
+            key={`${index}-${title || "deliverable"}`}
+            className="flex items-start gap-2"
+          >
+            <Icon className="mt-1 text-orange shrink-0" />
+            <div>
+              {title && <p className="font-medium">{title}</p>}
+              {description && (
+                <p className="text-gray-700 text-sm">{description}</p>
+              )}
+              {thumb && (
+                <Image
+                  src={thumb}
+                  alt={title || `Deliverable ${index + 1}`}
+                  width={64}
+                  height={64}
+                  className="w-16 h-16 object-cover rounded mt-1"
+                />
+              )}
+              {scopeLabels.length > 0 && (
+                <p className="mt-1 text-xs text-gray-500">
+                  Included with: {scopeLabels.join(", ")}
+                </p>
+              )}
+            </div>
+          </li>
+        );
+      })
+      .filter((item): item is JSX.Element => item !== null);
+  }, [deliverableDisplay.visible, variationNameById]);
+
   return (
     <div className="space-y-12">
       <div className="grid md:grid-cols-2 gap-8">
@@ -477,36 +590,30 @@ export default function ProductDetail({
             )}
             {product.deliverables && product.deliverables.length > 0 && (
               <ProductFeatureCard title="Deliverables" icon={FiGift}>
-                <ul className="space-y-2">
-                  {product.deliverables.map((d, i) => {
-                    const title = d.title?.trim();
-                    const description = d.description?.trim();
-                    const thumb = d.thumbnailUrl?.trim();
-                    if (!title && !description && !thumb) return null;
-                    const Icon =
-                      (d.type && deliverableIcons[d.type]) || FiCheck;
-                    return (
-                      <li key={i} className="flex items-start gap-2">
-                        <Icon className="mt-1 text-orange shrink-0" />
-                        <div>
-                          {title && <p className="font-medium">{title}</p>}
-                          {description && (
-                            <p className="text-gray-700 text-sm">{description}</p>
-                          )}
-                          {thumb && (
-                            <Image
-                              src={thumb}
-                              alt={title || `Deliverable ${i + 1}`}
-                              width={64}
-                              height={64}
-                              className="w-16 h-16 object-cover rounded mt-1"
-                            />
-                          )}
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
+                {deliverableDisplay.hasRestricted &&
+                !deliverableDisplay.selectedId &&
+                deliverableItems.length === 0 ? (
+                  <p className="text-sm text-gray-600">
+                    Select a package to see the deliverables included.
+                  </p>
+                ) : deliverableItems.length > 0 ? (
+                  <>
+                    <ul className="space-y-2">{deliverableItems}</ul>
+                    {deliverableDisplay.hasRestricted &&
+                      !deliverableDisplay.selectedId && (
+                        <p className="mt-3 text-xs text-gray-500">
+                          Some deliverables vary by package. Choose one to see
+                          everything that’s included.
+                        </p>
+                      )}
+                  </>
+                ) : (
+                  <p className="text-sm text-gray-600">
+                    {deliverableDisplay.selectedId
+                      ? "No deliverables are assigned to this package yet."
+                      : "Deliverables will be confirmed during scoping."}
+                  </p>
+                )}
               </ProductFeatureCard>
             )}
           </div>

--- a/apps/web/components/ProductDetail.tsx
+++ b/apps/web/components/ProductDetail.tsx
@@ -2,11 +2,12 @@
 
 import { Product, DeliverableType } from "@/lib/products";
 import type { Venue } from "@/lib/venues";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import ProductFeatureCard from "./ProductFeatureCard";
 import type { IconType } from "react-icons";
+import clsx from "clsx";
 import {
   FiClipboard,
   FiClock,
@@ -32,6 +33,139 @@ const deliverableIcons: Record<DeliverableType, IconType> = {
   "audio-licence": FiMusic,
   document: FiFileText,
 };
+
+type VideoPlayback =
+  | { kind: "iframe"; src: string }
+  | { kind: "file"; src: string }
+  | { kind: "external"; src: string };
+
+interface NormalizedVideo {
+  url: string;
+  title: string;
+  playback: VideoPlayback;
+}
+
+type GalleryItem =
+  | { id: string; type: "video"; label: string; video: NormalizedVideo }
+  | { id: string; type: "image"; label: string; src: string }
+  | { id: string; type: "placeholder"; label: string };
+
+function resolveVideoPlayback(input: string): VideoPlayback | null {
+  try {
+    const url = new URL(input);
+    const host = url.hostname.replace(/^www\./, "");
+
+    const ytIdFromSearch = () => url.searchParams.get("v") || "";
+    if (host === "youtu.be") {
+      const id = url.pathname.split("/").filter(Boolean)[0] || "";
+      if (id) {
+        return {
+          kind: "iframe",
+          src: `https://www.youtube-nocookie.com/embed/${id}?rel=0`,
+        };
+      }
+    }
+    if (host.endsWith("youtube.com")) {
+      let id = "";
+      if (ytIdFromSearch()) {
+        id = ytIdFromSearch();
+      } else if (url.pathname.startsWith("/shorts/")) {
+        id = url.pathname.replace("/shorts/", "").split("/")[0] || "";
+      } else if (url.pathname.startsWith("/embed/")) {
+        id = url.pathname.replace("/embed/", "").split("/")[0] || "";
+      }
+      if (id) {
+        return {
+          kind: "iframe",
+          src: `https://www.youtube-nocookie.com/embed/${id}?rel=0`,
+        };
+      }
+    }
+
+    if (host.endsWith("vimeo.com")) {
+      let id = "";
+      const parts = url.pathname.split("/").filter(Boolean);
+      if (host === "player.vimeo.com") {
+        const videoIndex = parts.findIndex((segment) => segment === "video");
+        if (videoIndex !== -1 && parts[videoIndex + 1]) {
+          id = parts[videoIndex + 1];
+        }
+      } else if (parts[0] && /^\d+$/.test(parts[0])) {
+        id = parts[0];
+      }
+      if (id) {
+        return { kind: "iframe", src: `https://player.vimeo.com/video/${id}` };
+      }
+    }
+
+    const pathname = url.pathname.toLowerCase();
+    if (/\.(mp4|webm|ogg|mov|m4v)$/i.test(pathname)) {
+      return { kind: "file", src: input };
+    }
+
+    return { kind: "external", src: input };
+  } catch {
+    return null;
+  }
+}
+
+function VideoPlayer({
+  video,
+  label,
+  showExternalLink,
+}: {
+  video: NormalizedVideo;
+  label: string;
+  showExternalLink?: boolean;
+}) {
+  if (video.playback.kind === "iframe") {
+    return (
+      <iframe
+        src={video.playback.src}
+        title={label}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        loading="lazy"
+        className="h-full w-full border-0"
+        referrerPolicy="no-referrer-when-downgrade"
+      />
+    );
+  }
+
+  if (video.playback.kind === "file") {
+    return (
+      <video
+        className="h-full w-full"
+        controls
+        controlsList="nodownload"
+        preload="metadata"
+        playsInline
+      >
+        <source src={video.playback.src} />
+        Your browser does not support embedded videos.
+        <a href={video.url} className="ml-1">Watch the video in a new tab.</a>
+      </video>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-gradient-to-br from-slate-900 via-gray-800 to-slate-700 p-6 text-center text-sm text-white/90">
+      <FiPlay className="h-8 w-8" />
+      <p>Preview not available. Open the link below to watch.</p>
+      {showExternalLink && (
+        <a
+          href={video.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 rounded bg-white/10 px-3 py-1 text-xs font-medium text-white transition hover:bg-white/20"
+        >
+          <FiExternalLink className="h-3 w-3" aria-hidden />
+          Watch in new tab
+        </a>
+      )}
+    </div>
+  );
+}
 import AddToCartWizard from "./AddToCartWizard";
 import ProductModifierSummary from "./ProductModifierSummary";
 import VenueMap from "./VenueMap";
@@ -47,61 +181,108 @@ export default function ProductDetail({
   const [variation, setVariation] = useState("");
   const [wizardOpen, setWizardOpen] = useState(false);
 
-  const exampleVideos = useMemo(() => {
+  const exampleVideos = useMemo<NormalizedVideo[]>(() => {
     const rawVideos = Array.isArray(product.exampleVideos)
       ? product.exampleVideos
       : [];
-    const normalised = rawVideos
-      .map((video: any) => {
-        if (typeof video === "string") {
-          const url = video.trim();
-          if (!url) return null;
-          return { url, title: "" };
-        }
-        if (video && typeof video.url === "string") {
-          const url = video.url.trim();
-          if (!url) return null;
-          const title =
-            typeof video.title === "string" ? video.title.trim() : "";
-          return { url, title };
-        }
-        return null;
-      })
-      .filter((entry): entry is { url: string; title: string } => !!entry);
-    if (normalised.length === 0) {
+    const entries: NormalizedVideo[] = [];
+
+    rawVideos.forEach((video: any) => {
+      let url = "";
+      let title = "";
+      if (typeof video === "string") {
+        url = video.trim();
+      } else if (video && typeof video.url === "string") {
+        url = video.url.trim();
+        title = typeof video.title === "string" ? video.title.trim() : "";
+      }
+      if (!url) return;
+      const playback = resolveVideoPlayback(url);
+      if (!playback) return;
+      entries.push({ url, title, playback });
+    });
+
+    if (entries.length === 0) {
       const fallback =
         typeof product.exampleWorkUrl === "string"
           ? product.exampleWorkUrl.trim()
           : "";
       if (fallback) {
-        normalised.push({ url: fallback, title: "" });
-      }
-    }
-    return normalised;
-  }, [product.exampleVideos, product.exampleWorkUrl]);
-
-  const resolveYouTubeEmbed = (input: string) => {
-    try {
-      const url = new URL(input);
-      const host = url.hostname.replace(/^www\./, "");
-      let id = "";
-      if (host === "youtu.be") {
-        id = url.pathname.split("/").filter(Boolean)[0] || "";
-      } else if (host.endsWith("youtube.com")) {
-        if (url.searchParams.get("v")) {
-          id = url.searchParams.get("v") || "";
-        } else if (url.pathname.startsWith("/shorts/")) {
-          id = url.pathname.replace("/shorts/", "").split("/")[0] || "";
-        } else if (url.pathname.startsWith("/embed/")) {
-          id = url.pathname.replace("/embed/", "").split("/")[0] || "";
+        const playback = resolveVideoPlayback(fallback);
+        if (playback) {
+          entries.push({ url: fallback, title: "", playback });
         }
       }
-      if (!id) return null;
-      return `https://www.youtube-nocookie.com/embed/${id}?rel=0`;
-    } catch {
-      return null;
     }
-  };
+
+    return entries;
+  }, [product.exampleVideos, product.exampleWorkUrl]);
+
+  const galleryMedia = useMemo<GalleryItem[]>(() => {
+    const items: GalleryItem[] = [];
+
+    exampleVideos.forEach((video, index) => {
+      const label = video.title || `Example video ${index + 1}`;
+      items.push({
+        id: `video-${index}-${video.url}`,
+        type: "video",
+        label,
+        video,
+      });
+    });
+
+    const coverImage =
+      typeof product.imageUrl === "string" ? product.imageUrl.trim() : "";
+    if (coverImage) {
+      items.push({
+        id: "image-cover",
+        type: "image",
+        label: product.name ? `${product.name} cover` : "Product image",
+        src: coverImage,
+      });
+    }
+
+    if (Array.isArray(product.storyboardImages)) {
+      product.storyboardImages.forEach((imageUrl, index) => {
+        if (typeof imageUrl !== "string") return;
+        const trimmed = imageUrl.trim();
+        if (!trimmed) return;
+        items.push({
+          id: `storyboard-${index}-${trimmed}`,
+          type: "image",
+          label: `Storyboard ${index + 1}`,
+          src: trimmed,
+        });
+      });
+    }
+
+    if (items.length === 0) {
+      items.push({
+        id: "placeholder",
+        type: "placeholder",
+        label: product.name || "Product preview",
+      });
+    }
+
+    return items;
+  }, [exampleVideos, product.imageUrl, product.storyboardImages, product.name]);
+
+  const [activeMediaId, setActiveMediaId] = useState<string | null>(
+    galleryMedia[0]?.id ?? null
+  );
+
+  useEffect(() => {
+    setActiveMediaId(galleryMedia[0]?.id ?? null);
+  }, [galleryMedia]);
+
+  const activeMedia = useMemo(() => {
+    return galleryMedia.find((item) => item.id === activeMediaId) ?? galleryMedia[0];
+  }, [galleryMedia, activeMediaId]);
+
+  const selectableMedia = useMemo(
+    () => galleryMedia.filter((item) => item.type !== "placeholder"),
+    [galleryMedia]
+  );
 
   const handleVariation = (id: string) => {
     const v = product.variations?.find((va) => va.id === id);
@@ -123,30 +304,68 @@ export default function ProductDetail({
     <div className="space-y-12">
       <div className="grid md:grid-cols-2 gap-8">
         <div className="space-y-4">
-          {product.imageUrl ? (
-            <Image
-              src={product.imageUrl}
-              alt={product.name}
-              width={800}
-              height={600}
-              priority
-              className="w-full h-80 object-cover rounded"
-            />
-          ) : (
-            <div className="w-full h-80 bg-gray-200 rounded" />
-          )}
-          {product.storyboardImages && product.storyboardImages.length > 0 && (
-            <div className="grid grid-cols-3 gap-2">
-              {product.storyboardImages.map((url, i) => (
-                <Image
-                  key={i}
-                  src={url}
-                  alt={`Storyboard ${i + 1}`}
-                  width={300}
-                  height={200}
-                  className="w-full h-24 object-cover rounded"
+          <div className="relative aspect-video w-full overflow-hidden rounded-lg bg-gray-200">
+            {activeMedia?.type === "image" && (
+              <Image
+                src={activeMedia.src}
+                alt={activeMedia.label || product.name || "Product image"}
+                fill
+                priority
+                sizes="(min-width: 768px) 50vw, 100vw"
+                className="object-cover"
+              />
+            )}
+            {activeMedia?.type === "video" && (
+              <div className="absolute inset-0">
+                <VideoPlayer
+                  video={activeMedia.video}
+                  label={activeMedia.label}
+                  showExternalLink
                 />
-              ))}
+              </div>
+            )}
+            {activeMedia?.type === "placeholder" && (
+              <div className="flex h-full w-full items-center justify-center bg-gray-200 text-sm text-gray-500">
+                No preview available
+              </div>
+            )}
+          </div>
+          {selectableMedia.length > 1 && (
+            <div className="grid grid-cols-4 gap-2 sm:grid-cols-6">
+              {selectableMedia.map((item) => {
+                const isActive = activeMedia?.id === item.id;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => setActiveMediaId(item.id)}
+                    aria-pressed={isActive}
+                    aria-label={`Show ${item.label}`}
+                    className={clsx(
+                      "relative h-20 overflow-hidden rounded-lg border transition focus:outline-none focus-visible:ring-2 focus-visible:ring-orange focus-visible:ring-offset-2 focus-visible:ring-offset-white",
+                      isActive
+                        ? "border-orange ring-2 ring-orange"
+                        : "border-gray-200 hover:border-orange/70"
+                    )}
+                  >
+                    {item.type === "image" ? (
+                      <div className="relative h-full w-full">
+                        <Image
+                          src={item.src}
+                          alt={item.label}
+                          fill
+                          sizes="100px"
+                          className="object-cover"
+                        />
+                      </div>
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center bg-slate-900/80 text-white">
+                        <FiPlay className="h-6 w-6" aria-hidden />
+                      </div>
+                    )}
+                  </button>
+                );
+              })}
             </div>
           )}
         </div>
@@ -299,30 +518,14 @@ export default function ProductDetail({
           <h2 className="text-xl font-semibold mb-2">Example Videos</h2>
           <div className="grid gap-6 md:grid-cols-2">
             {exampleVideos.map((video, index) => {
-              const embedUrl = resolveYouTubeEmbed(video.url);
               const label = video.title || `Example video ${index + 1}`;
               return (
                 <div
                   key={`${video.url}-${index}`}
                   className="space-y-3 rounded-lg border bg-white p-3 shadow-sm"
                 >
-                  <div className="aspect-video w-full overflow-hidden rounded-md bg-black">
-                    {embedUrl ? (
-                      <iframe
-                        src={embedUrl}
-                        title={label}
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowFullScreen
-                        loading="lazy"
-                        className="h-full w-full border-0"
-                        referrerPolicy="no-referrer-when-downgrade"
-                      />
-                    ) : (
-                      <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-gradient-to-br from-slate-900 via-gray-800 to-slate-700 p-6 text-center text-sm text-white/90">
-                        <FiPlay className="h-8 w-8" />
-                        <p>Preview not available. Open the link below to watch.</p>
-                      </div>
-                    )}
+                  <div className="relative aspect-video w-full overflow-hidden rounded-md bg-black">
+                    <VideoPlayer video={video} label={label} />
                   </div>
                   <div className="space-y-1">
                     <p className="font-medium text-gray-900">{label}</p>

--- a/apps/web/components/ProductDetail.tsx
+++ b/apps/web/components/ProductDetail.tsx
@@ -118,11 +118,6 @@ export default function ProductDetail({
   };
 
   const venueName = venue?.name || product.venue || "";
-  const hasMileage =
-    venue?.mileageFromWellingborough !== undefined &&
-    venue?.mileageFromWellingborough !== null;
-  const hasParkingRate =
-    venue?.parkingRate !== undefined && venue?.parkingRate !== null;
 
   return (
     <div className="space-y-12">
@@ -233,38 +228,6 @@ export default function ProductDetail({
             {venue.address && (
               <p>
                 <span className="font-medium">Address:</span> {venue.address}
-              </p>
-            )}
-            {hasMileage && (
-              <p>
-                <span className="font-medium">Distance from Wellingborough:</span>{" "}
-                {venue.mileageFromWellingborough} miles
-              </p>
-            )}
-            {hasParkingRate && (
-              <p>
-                <span className="font-medium">Fixed Parking Rate:</span> £
-                {Number(venue.parkingRate).toFixed(2)}
-              </p>
-            )}
-            {venue.parkingTips && (
-              <p className="whitespace-pre-line">
-                <span className="font-medium">Parking Tips:</span> {venue.parkingTips}
-              </p>
-            )}
-            {venue.accessInfo && (
-              <p className="whitespace-pre-line">
-                <span className="font-medium">Access Information:</span> {venue.accessInfo}
-              </p>
-            )}
-            {venue.internetInfo && (
-              <p className="whitespace-pre-line">
-                <span className="font-medium">Internet Details:</span> {venue.internetInfo}
-              </p>
-            )}
-            {venue.notes && (
-              <p className="whitespace-pre-line">
-                <span className="font-medium">Notes:</span> {venue.notes}
               </p>
             )}
             <VenueMap venue={venue} className="mt-2" />

--- a/apps/web/components/productListingUtils.ts
+++ b/apps/web/components/productListingUtils.ts
@@ -1,4 +1,8 @@
-import type { Product, DeliverableType } from "@/lib/products";
+import type {
+  Product,
+  DeliverableType,
+  ProductDeliverable,
+} from "@/lib/products";
 import type { IconType } from "react-icons";
 import {
   FiVideo,
@@ -56,8 +60,10 @@ type DeliverableBadge = {
 };
 
 function normaliseDeliverables(
-  rawDeliverables: unknown
+  rawDeliverables: unknown,
+  options: { variationId?: string | null } = {}
 ): { title: string; type?: DeliverableType }[] {
+  const variationFilter = options.variationId ?? null;
   if (!rawDeliverables) return [];
 
   const entries = Array.isArray(rawDeliverables)
@@ -79,11 +85,10 @@ function normaliseDeliverables(
     }
 
     if (typeof entry === "object") {
-      const candidate = entry as Partial<{
-        title?: unknown;
-        name?: unknown;
-        type?: unknown;
-      }>;
+      const candidate = entry as Partial<ProductDeliverable> &
+        Partial<{
+          name?: unknown;
+        }>;
       const rawTitle =
         typeof candidate.title === "string"
           ? candidate.title
@@ -96,6 +101,19 @@ function normaliseDeliverables(
         typeof candidate.type === "string"
           ? (candidate.type as DeliverableType)
           : undefined;
+      const restrictedIds = Array.isArray(candidate.variationIds)
+        ? candidate.variationIds.filter(
+            (id): id is string => typeof id === "string" && id.trim().length > 0
+          )
+        : [];
+      if (restrictedIds.length > 0) {
+        if (!variationFilter) {
+          return [];
+        }
+        if (!restrictedIds.includes(variationFilter)) {
+          return [];
+        }
+      }
       return [
         {
           title,

--- a/apps/web/lib/products.ts
+++ b/apps/web/lib/products.ts
@@ -200,6 +200,8 @@ export interface Product {
   imageUrl?: string;
   requirements?: string;
   deliveryTime?: string;
+  /** Details about on-site operations shared with the customer. */
+  operationsInfo?: string;
   deliverables?: ProductDeliverable[];
   modifiers?: ProductModifierSelection[];
   /** Modifier group IDs enabled for this product. */

--- a/apps/web/lib/products.ts
+++ b/apps/web/lib/products.ts
@@ -93,6 +93,8 @@ export interface ProductDeliverable {
   description?: string;
   /** Optional thumbnail image for visual deliverable previews. */
   thumbnailUrl?: string;
+  /** If provided, limits the deliverable to the matching variation IDs. */
+  variationIds?: string[];
 }
 
 export interface ProductBudgetOverride {


### PR DESCRIPTION
## Summary
- remove internal-only venue details from the product page
- retain the venue heading, address, and map for customers

## Testing
- npm --prefix apps/web run lint

------
https://chatgpt.com/codex/tasks/task_e_68d42137e26c8323bc200cba68951c82