### PR TITLE
feat: scaffold franchise management admin pages

### DIFF
--- a/apps/web/app/admin/ClientPage.tsx
+++ b/apps/web/app/admin/ClientPage.tsx
@@ -269,6 +269,7 @@ export default function AdminPage() {
                 { href: '/admin/users', label: 'CRM' },
                 { href: '/admin/team', label: 'Manage Team' },
                 { href: '/admin/join-team-steps', label: 'Join Team Form' },
+                { href: '/admin/franchises', label: 'Franchise Network' },
               ],
             },
             {

--- a/apps/web/app/admin/franchises/ClientPage.tsx
+++ b/apps/web/app/admin/franchises/ClientPage.tsx
@@ -19,8 +19,10 @@ import {
   type FranchiseMemberRole,
   type FranchiseStatus,
   type FranchiseTerritory,
+  type FranchiseRoyaltyConfig,
   canActivateFranchise,
   defaultFranchiseOnboarding,
+  defaultFranchiseRoyaltyConfig,
   parseFranchise,
   parseMember,
   parseTerritory,
@@ -79,6 +81,110 @@ function createOnboardingState() {
 
 type OnboardingState = ReturnType<typeof createOnboardingState>;
 
+type RoyaltyTierState = {
+  id: string;
+  minOrder: string;
+  maxOrder: string;
+  percentage: string;
+};
+
+type RoyaltyState = {
+  hqTiers: RoyaltyTierState[];
+  franchisePercentage: string;
+};
+
+const ordinal = (value: number) => {
+  const remainder = value % 10;
+  const isTeen = value % 100 >= 11 && value % 100 <= 13;
+  if (isTeen) return `${value}th`;
+  if (remainder === 1) return `${value}st`;
+  if (remainder === 2) return `${value}nd`;
+  if (remainder === 3) return `${value}rd`;
+  return `${value}th`;
+};
+
+const createRoyaltyState = (config?: FranchiseRoyaltyConfig | null): RoyaltyState => {
+  const base = config && config.hqTiers?.length > 0 ? config : defaultFranchiseRoyaltyConfig();
+  const tiers = (base.hqTiers?.length ? base.hqTiers : defaultFranchiseRoyaltyConfig().hqTiers).map(
+    (tier, index) => ({
+      id: `${tier.minOrder}-${tier.maxOrder ?? 'open'}-${index}`,
+      minOrder: String(tier.minOrder),
+      maxOrder: tier.maxOrder == null ? "" : String(tier.maxOrder),
+      percentage: String(tier.percentage),
+    })
+  );
+  return {
+    hqTiers: tiers,
+    franchisePercentage: String(base.franchiseSourcedPercentage ?? defaultFranchiseRoyaltyConfig().franchiseSourcedPercentage),
+  };
+};
+
+const serializeRoyaltyState = (state: RoyaltyState): FranchiseRoyaltyConfig => {
+  const defaults = defaultFranchiseRoyaltyConfig();
+  const tiers = state.hqTiers
+    .map((tier) => {
+      const min = Number.parseInt(tier.minOrder, 10);
+      const percentage = Number.parseFloat(tier.percentage);
+      if (!Number.isFinite(min) || min <= 0 || !Number.isFinite(percentage)) {
+        return null;
+      }
+      const cleanMin = Math.max(1, Math.floor(min));
+      const max = tier.maxOrder.trim().length === 0 ? null : Number.parseInt(tier.maxOrder, 10);
+      const cleanedMax =
+        max == null || !Number.isFinite(max)
+          ? null
+          : Math.max(cleanMin, Math.floor(max));
+      return {
+        minOrder: cleanMin,
+        maxOrder: cleanedMax,
+        percentage,
+      };
+    })
+    .filter((value): value is { minOrder: number; maxOrder: number | null; percentage: number } => value !== null)
+    .sort((a, b) => a.minOrder - b.minOrder);
+  const franchisePct = Number.parseFloat(state.franchisePercentage);
+  const franchisePercentage = Number.isFinite(franchisePct) && franchisePct >= 0
+    ? franchisePct
+    : defaults.franchiseSourcedPercentage;
+  return {
+    hqTiers: tiers.length > 0 ? tiers : defaults.hqTiers,
+    franchiseSourcedPercentage: franchisePercentage,
+  };
+};
+
+const appendRoyaltyTier = (state: RoyaltyState): RoyaltyState => {
+  const nextTiers = state.hqTiers.slice();
+  const last = nextTiers[nextTiers.length - 1];
+  const fallbackMin = last ? Number.parseInt(last.minOrder, 10) || 0 : 0;
+  const lastMax = last ? Number.parseInt(last.maxOrder, 10) : NaN;
+  const nextMin = Number.isFinite(lastMax) ? lastMax + 1 : fallbackMin + 1;
+  nextTiers.push({
+    id: `tier-${Date.now()}`,
+    minOrder: String(Math.max(1, nextMin)),
+    maxOrder: "",
+    percentage: last ? last.percentage : String(defaultFranchiseRoyaltyConfig().hqTiers[0].percentage),
+  });
+  return { ...state, hqTiers: nextTiers };
+};
+
+const removeRoyaltyTier = (state: RoyaltyState, index: number): RoyaltyState => {
+  if (state.hqTiers.length <= 1) {
+    return state;
+  }
+  const tiers = state.hqTiers.filter((_, idx) => idx !== index);
+  return { ...state, hqTiers: tiers };
+};
+
+const describeRoyaltyTier = (tier: { minOrder: number; maxOrder: number | null; percentage: number }) => {
+  if (tier.maxOrder == null) {
+    return `${tier.percentage}% ${ordinal(tier.minOrder)}+`;
+  }
+  if (tier.minOrder === tier.maxOrder) {
+    return `${tier.percentage}% ${ordinal(tier.minOrder)}`;
+  }
+  return `${tier.percentage}% ${ordinal(tier.minOrder)}–${ordinal(tier.maxOrder)}`;
+};
+
 export default function AdminFranchisesPage() {
   const { allowed, loading: guardLoading } = useRoleGate("admin");
   const [loading, setLoading] = useState(true);
@@ -99,6 +205,7 @@ export default function AdminFranchisesPage() {
     platformFee: "",
     notes: "",
     onboarding: createOnboardingState(),
+    royalty: createRoyaltyState(),
   });
   const [editingFranchiseId, setEditingFranchiseId] = useState<string | null>(null);
   const [editingFranchise, setEditingFranchise] = useState({
@@ -111,6 +218,7 @@ export default function AdminFranchisesPage() {
     platformFee: "",
     notes: "",
     onboarding: createOnboardingState(),
+    royalty: createRoyaltyState(),
   });
 
   const [showCreateTerritory, setShowCreateTerritory] = useState(false);
@@ -281,6 +389,7 @@ export default function AdminFranchisesPage() {
       platformFee: "",
       notes: "",
       onboarding: createOnboardingState(),
+      royalty: createRoyaltyState(),
     });
   };
 
@@ -294,6 +403,7 @@ export default function AdminFranchisesPage() {
         ...newFranchise.onboarding,
         notes: onboardingNotes.length > 0 ? onboardingNotes : null,
       };
+      const royaltyConfig = serializeRoyaltyState(newFranchise.royalty);
       const payload = {
         name: newFranchise.name.trim(),
         code: (newFranchise.code || newFranchise.name || "").trim().replace(/\s+/g, "-").toLowerCase(),
@@ -307,6 +417,7 @@ export default function AdminFranchisesPage() {
             : null,
         notes: newFranchise.notes.trim() || null,
         onboarding: onboardingPayload,
+        royalty: royaltyConfig,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       };
@@ -335,6 +446,7 @@ export default function AdminFranchisesPage() {
         ...createOnboardingState(),
         ...franchise.onboarding,
       },
+      royalty: createRoyaltyState(franchise.royalty),
     });
   };
 
@@ -350,6 +462,7 @@ export default function AdminFranchisesPage() {
       platformFee: "",
       notes: "",
       onboarding: createOnboardingState(),
+      royalty: createRoyaltyState(),
     });
   };
 
@@ -364,6 +477,7 @@ export default function AdminFranchisesPage() {
         ...editingFranchise.onboarding,
         notes: onboardingNotes.length > 0 ? onboardingNotes : null,
       };
+      const royaltyConfig = serializeRoyaltyState(editingFranchise.royalty);
       const activationReady = canActivateFranchise(onboardingPayload);
       if (editingFranchise.status === "active" && !activationReady) {
         alert(
@@ -384,6 +498,7 @@ export default function AdminFranchisesPage() {
             : null,
         notes: editingFranchise.notes.trim() || null,
         onboarding: onboardingPayload,
+        royalty: royaltyConfig,
         updatedAt: serverTimestamp(),
       };
       await updateDoc(doc(db, "franchises", editingFranchiseId), payload);
@@ -706,6 +821,133 @@ export default function AdminFranchisesPage() {
               </label>
             </div>
             <div className="grid gap-3 rounded border border-dashed border-gray-200 p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <div className="text-sm font-medium">Royalty configuration</div>
+                  <p className="text-xs text-gray-500">
+                    Define how royalties are split between HQ and the franchisee for HQ-sourced and franchise-sourced orders.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-xs"
+                  onClick={() =>
+                    setNewFranchise((prev) => ({
+                      ...prev,
+                      royalty: appendRoyaltyTier(prev.royalty),
+                    }))
+                  }
+                >
+                  Add HQ tier
+                </button>
+              </div>
+              <div className="grid gap-3">
+                {newFranchise.royalty.hqTiers.map((tier, index) => (
+                  <div key={tier.id} className="grid gap-2 rounded border border-gray-200 p-3 sm:grid-cols-4">
+                    <label className="grid gap-1 text-sm">
+                      <span className="font-medium">From order #</span>
+                      <input
+                        className="input"
+                        inputMode="numeric"
+                        value={tier.minOrder}
+                        onChange={(event) =>
+                          setNewFranchise((prev) => ({
+                            ...prev,
+                            royalty: {
+                              ...prev.royalty,
+                              hqTiers: prev.royalty.hqTiers.map((item, idx) =>
+                                idx === index ? { ...item, minOrder: event.target.value } : item
+                              ),
+                            },
+                          }))
+                        }
+                        required
+                      />
+                    </label>
+                    <label className="grid gap-1 text-sm">
+                      <span className="font-medium">Through order #</span>
+                      <input
+                        className="input"
+                        inputMode="numeric"
+                        value={tier.maxOrder}
+                        onChange={(event) =>
+                          setNewFranchise((prev) => ({
+                            ...prev,
+                            royalty: {
+                              ...prev.royalty,
+                              hqTiers: prev.royalty.hqTiers.map((item, idx) =>
+                                idx === index ? { ...item, maxOrder: event.target.value } : item
+                              ),
+                            },
+                          }))
+                        }
+                        placeholder="Leave blank for 6th+"
+                      />
+                    </label>
+                    <label className="grid gap-1 text-sm">
+                      <span className="font-medium">Royalty %</span>
+                      <input
+                        className="input"
+                        type="number"
+                        min="0"
+                        step="0.1"
+                        value={tier.percentage}
+                        onChange={(event) =>
+                          setNewFranchise((prev) => ({
+                            ...prev,
+                            royalty: {
+                              ...prev.royalty,
+                              hqTiers: prev.royalty.hqTiers.map((item, idx) =>
+                                idx === index ? { ...item, percentage: event.target.value } : item
+                              ),
+                            },
+                          }))
+                        }
+                        required
+                      />
+                    </label>
+                    <div className="flex items-end justify-end">
+                      <button
+                        type="button"
+                        className="btn btn-xs btn-outline"
+                        onClick={() =>
+                          setNewFranchise((prev) => ({
+                            ...prev,
+                            royalty: removeRoyaltyTier(prev.royalty, index),
+                          }))
+                        }
+                        disabled={newFranchise.royalty.hqTiers.length <= 1}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Franchise-sourced royalty (%)</span>
+                <input
+                  className="input"
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={newFranchise.royalty.franchisePercentage}
+                  onChange={(event) =>
+                    setNewFranchise((prev) => ({
+                      ...prev,
+                      royalty: {
+                        ...prev.royalty,
+                        franchisePercentage: event.target.value,
+                      },
+                    }))
+                  }
+                />
+                <span className="text-xs text-gray-500">
+                  Applied to deals sourced directly by the franchisee (e.g. referrals, local marketing).
+                </span>
+              </label>
+            </div>
+            <div className="grid gap-3 rounded border border-dashed border-gray-200 p-3">
               <div className="flex items-center justify-between">
                 <div>
                   <div className="text-sm font-medium">Onboarding checklist</div>
@@ -887,6 +1129,15 @@ export default function AdminFranchisesPage() {
                     franchise.onboarding.legalStatus === "completed" ? null : "Legal",
                     franchise.onboarding.chargesEnabled ? null : "Charges",
                   ].filter(Boolean) as string[];
+                  const royaltyConfig = franchise.royalty?.hqTiers?.length
+                    ? franchise.royalty
+                    : defaultFranchiseRoyaltyConfig();
+                  const hqScale = royaltyConfig.hqTiers
+                    .map((tier) => describeRoyaltyTier(tier))
+                    .join(" → ");
+                  const franchiseDirect = typeof royaltyConfig.franchiseSourcedPercentage === "number"
+                    ? royaltyConfig.franchiseSourcedPercentage
+                    : defaultFranchiseRoyaltyConfig().franchiseSourcedPercentage;
                   return (
                     <tr key={franchise.id} className="border-t align-top">
                       <td className="p-2 font-medium">
@@ -909,6 +1160,10 @@ export default function AdminFranchisesPage() {
                         {typeof franchise.platformFee === "number" && (
                           <div className="text-xs text-gray-500">Platform fee: {franchise.platformFee}%</div>
                         )}
+                        {hqScale && (
+                          <div className="text-xs text-gray-500">HQ: {hqScale}</div>
+                        )}
+                        <div className="text-xs text-gray-500">Franchise-sourced: {franchiseDirect}%</div>
                       </td>
                       <td className="p-2 text-xs">
                         <div>KYC: {onboardingStatusLabel(franchise.onboarding.kycStatus)}</div>
@@ -1045,6 +1300,123 @@ export default function AdminFranchisesPage() {
                                 }
                               />
                             </label>
+                            <div className="grid gap-2 rounded border border-dashed border-gray-200 p-2">
+                              <div className="flex flex-wrap items-center justify-between gap-2">
+                                <span className="text-[11px] font-semibold uppercase tracking-wide">Royalty configuration</span>
+                                <button
+                                  type="button"
+                                  className="btn btn-xs"
+                                  onClick={() =>
+                                    setEditingFranchise((prev) => ({
+                                      ...prev,
+                                      royalty: appendRoyaltyTier(prev.royalty),
+                                    }))
+                                  }
+                                >
+                                  Add HQ tier
+                                </button>
+                              </div>
+                              <div className="grid gap-2">
+                                {editingFranchise.royalty.hqTiers.map((tier, index) => (
+                                  <div key={tier.id} className="grid gap-2 rounded border border-gray-200 p-2 sm:grid-cols-4">
+                                    <label className="grid gap-1 text-xs">
+                                      <span className="font-medium">From order #</span>
+                                      <input
+                                        className="input"
+                                        inputMode="numeric"
+                                        value={tier.minOrder}
+                                        onChange={(event) =>
+                                          setEditingFranchise((prev) => ({
+                                            ...prev,
+                                            royalty: {
+                                              ...prev.royalty,
+                                              hqTiers: prev.royalty.hqTiers.map((item, idx) =>
+                                                idx === index ? { ...item, minOrder: event.target.value } : item
+                                              ),
+                                            },
+                                          }))
+                                        }
+                                      />
+                                    </label>
+                                    <label className="grid gap-1 text-xs">
+                                      <span className="font-medium">Through order #</span>
+                                      <input
+                                        className="input"
+                                        inputMode="numeric"
+                                        value={tier.maxOrder}
+                                        onChange={(event) =>
+                                          setEditingFranchise((prev) => ({
+                                            ...prev,
+                                            royalty: {
+                                              ...prev.royalty,
+                                              hqTiers: prev.royalty.hqTiers.map((item, idx) =>
+                                                idx === index ? { ...item, maxOrder: event.target.value } : item
+                                              ),
+                                            },
+                                          }))
+                                        }
+                                        placeholder="Leave blank for 6th+"
+                                      />
+                                    </label>
+                                    <label className="grid gap-1 text-xs">
+                                      <span className="font-medium">Royalty %</span>
+                                      <input
+                                        className="input"
+                                        type="number"
+                                        min="0"
+                                        step="0.1"
+                                        value={tier.percentage}
+                                        onChange={(event) =>
+                                          setEditingFranchise((prev) => ({
+                                            ...prev,
+                                            royalty: {
+                                              ...prev.royalty,
+                                              hqTiers: prev.royalty.hqTiers.map((item, idx) =>
+                                                idx === index ? { ...item, percentage: event.target.value } : item
+                                              ),
+                                            },
+                                          }))
+                                        }
+                                      />
+                                    </label>
+                                    <div className="flex items-end justify-end">
+                                      <button
+                                        type="button"
+                                        className="btn btn-xs btn-outline"
+                                        onClick={() =>
+                                          setEditingFranchise((prev) => ({
+                                            ...prev,
+                                            royalty: removeRoyaltyTier(prev.royalty, index),
+                                          }))
+                                        }
+                                        disabled={editingFranchise.royalty.hqTiers.length <= 1}
+                                      >
+                                        Remove
+                                      </button>
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                              <label className="grid gap-1 text-xs">
+                                <span className="font-medium">Franchise-sourced royalty (%)</span>
+                                <input
+                                  className="input"
+                                  type="number"
+                                  min="0"
+                                  step="0.1"
+                                  value={editingFranchise.royalty.franchisePercentage}
+                                  onChange={(event) =>
+                                    setEditingFranchise((prev) => ({
+                                      ...prev,
+                                      royalty: {
+                                        ...prev.royalty,
+                                        franchisePercentage: event.target.value,
+                                      },
+                                    }))
+                                  }
+                                />
+                              </label>
+                            </div>
                             <div className="grid gap-2 rounded border border-dashed border-gray-200 p-2">
                               <div className="flex items-center justify-between">
                                 <span className="text-[11px] font-semibold uppercase tracking-wide">Onboarding</span>

--- a/apps/web/app/admin/franchises/ClientPage.tsx
+++ b/apps/web/app/admin/franchises/ClientPage.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
+import TerritoryMap from "@/components/TerritoryMap";
 import {
   addDoc,
   collection,
@@ -36,6 +38,11 @@ interface UserSummary {
   contractor?: boolean;
   isStaff?: boolean;
   franchiseId?: string | null;
+}
+
+interface CategoryOption {
+  id: string;
+  name: string;
 }
 
 const FRANCHISE_STATUSES: { value: FranchiseStatus; label: string; description: string }[] = [
@@ -192,6 +199,7 @@ export default function AdminFranchisesPage() {
   const [territories, setTerritories] = useState<FranchiseTerritory[]>([]);
   const [members, setMembers] = useState<FranchiseMember[]>([]);
   const [users, setUsers] = useState<UserSummary[]>([]);
+  const [categoryOptions, setCategoryOptions] = useState<CategoryOption[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   const [showCreateFranchise, setShowCreateFranchise] = useState(false);
@@ -231,6 +239,8 @@ export default function AdminFranchisesPage() {
     radiusKm: "",
     centerLat: "",
     centerLng: "",
+    categories: [] as string[],
+    licenseFee: "",
     notes: "",
   });
   const [editingTerritoryId, setEditingTerritoryId] = useState<string | null>(null);
@@ -243,6 +253,8 @@ export default function AdminFranchisesPage() {
     radiusKm: "",
     centerLat: "",
     centerLng: "",
+    categories: [] as string[],
+    licenseFee: "",
     notes: "",
   });
 
@@ -263,11 +275,12 @@ export default function AdminFranchisesPage() {
   };
 
   const loadAll = useCallback(async (cancelRef?: { current: boolean }) => {
-    const [franchiseSnap, territorySnap, memberSnap, usersSnap] = await Promise.all([
+    const [franchiseSnap, territorySnap, memberSnap, usersSnap, categorySnap] = await Promise.all([
       getDocs(collection(db, "franchises")),
       getDocs(collection(db, "franchiseTerritories")),
       getDocs(collection(db, "franchiseMembers")),
       getDocs(collection(db, "users")),
+      getDocs(collection(db, "categories")),
     ]);
 
     if (cancelRef?.current) return;
@@ -301,10 +314,19 @@ export default function AdminFranchisesPage() {
 
     if (cancelRef?.current) return;
 
+    const categories = categorySnap.docs
+      .map((doc) => {
+        const data = doc.data() as Record<string, unknown>;
+        const name = typeof data.name === "string" && data.name.trim() ? data.name.trim() : doc.id;
+        return { id: doc.id, name } satisfies CategoryOption;
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+
     setFranchises(franchiseList);
     setTerritories(territoryList);
     setMembers(memberList);
     setUsers(userList.sort((a, b) => a.displayName.localeCompare(b.displayName)));
+    setCategoryOptions(categories);
   }, []);
 
   useEffect(() => {
@@ -349,6 +371,23 @@ export default function AdminFranchisesPage() {
     users.forEach((user) => map.set(user.id, user));
     return map;
   }, [users]);
+
+  const categoryMap = useMemo(() => {
+    const map = new Map<string, CategoryOption>();
+    categoryOptions.forEach((category) => map.set(category.id, category));
+    return map;
+  }, [categoryOptions]);
+
+  const gbpFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat("en-GB", {
+        style: "currency",
+        currency: "GBP",
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+      }),
+    []
+  );
 
   const territoryByFranchise = useMemo(() => {
     const map = new Map<string, FranchiseTerritory[]>();
@@ -520,6 +559,8 @@ export default function AdminFranchisesPage() {
       radiusKm: "",
       centerLat: "",
       centerLng: "",
+      categories: [],
+      licenseFee: "",
       notes: "",
     });
   };
@@ -534,6 +575,7 @@ export default function AdminFranchisesPage() {
       const parsedRadius = Number.parseFloat(newTerritory.radiusKm);
       const parsedLat = Number.parseFloat(newTerritory.centerLat);
       const parsedLng = Number.parseFloat(newTerritory.centerLng);
+      const parsedLicense = Number.parseFloat(newTerritory.licenseFee);
       const payload = {
         franchiseId: newTerritory.franchiseId,
         label: newTerritory.label.trim() || "Unnamed Territory",
@@ -551,6 +593,11 @@ export default function AdminFranchisesPage() {
         centerLng:
           newTerritory.type === "radius" && newTerritory.centerLng.trim() && Number.isFinite(parsedLng)
             ? parsedLng
+            : null,
+        categories: newTerritory.categories,
+        licenseFee:
+          newTerritory.licenseFee.trim() && Number.isFinite(parsedLicense) && parsedLicense >= 0
+            ? parsedLicense
             : null,
         notes: newTerritory.notes.trim() || null,
         createdAt: serverTimestamp(),
@@ -577,6 +624,8 @@ export default function AdminFranchisesPage() {
       radiusKm: territory.radiusKm ? String(territory.radiusKm) : "",
       centerLat: territory.centerLat ? String(territory.centerLat) : "",
       centerLng: territory.centerLng ? String(territory.centerLng) : "",
+      categories: territory.categories || [],
+      licenseFee: territory.licenseFee != null ? String(territory.licenseFee) : "",
       notes: territory.notes || "",
     });
   };
@@ -592,6 +641,8 @@ export default function AdminFranchisesPage() {
       radiusKm: "",
       centerLat: "",
       centerLng: "",
+      categories: [],
+      licenseFee: "",
       notes: "",
     });
   };
@@ -607,6 +658,7 @@ export default function AdminFranchisesPage() {
       const parsedRadius = Number.parseFloat(editingTerritory.radiusKm);
       const parsedLat = Number.parseFloat(editingTerritory.centerLat);
       const parsedLng = Number.parseFloat(editingTerritory.centerLng);
+      const parsedLicense = Number.parseFloat(editingTerritory.licenseFee);
       const payload = {
         franchiseId: editingTerritory.franchiseId,
         label: editingTerritory.label.trim() || "Unnamed Territory",
@@ -624,6 +676,11 @@ export default function AdminFranchisesPage() {
         centerLng:
           editingTerritory.type === "radius" && editingTerritory.centerLng.trim() && Number.isFinite(parsedLng)
             ? parsedLng
+            : null,
+        categories: editingTerritory.categories,
+        licenseFee:
+          editingTerritory.licenseFee.trim() && Number.isFinite(parsedLicense) && parsedLicense >= 0
+            ? parsedLicense
             : null,
         notes: editingTerritory.notes.trim() || null,
         updatedAt: serverTimestamp(),
@@ -724,6 +781,104 @@ export default function AdminFranchisesPage() {
         </p>
         {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
       </div>
+
+      <section className="grid gap-4">
+        <div>
+          <h2 className="text-lg font-semibold">Territory manager</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            Visualise every territory, see included services, and review monthly licensing at a glance.
+          </p>
+        </div>
+        <div className="grid gap-4">
+          {franchises.length === 0 ? (
+            <p className="text-sm text-gray-500">No franchise records yet.</p>
+          ) : (
+            franchises.map((franchise) => {
+              const assignedTerritories = territoryByFranchise.get(franchise.id) ?? [];
+              return (
+                <div key={franchise.id} className="rounded border p-4">
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h3 className="text-base font-semibold">{franchise.name}</h3>
+                      <p className="text-xs uppercase tracking-wide text-gray-500">{franchise.status}</p>
+                    </div>
+                    {franchise.contactEmail && (
+                      <a
+                        className="text-sm text-blue-600 hover:underline"
+                        href={`mailto:${franchise.contactEmail}`}
+                      >
+                        {franchise.contactEmail}
+                      </a>
+                    )}
+                  </div>
+                  {assignedTerritories.length === 0 ? (
+                    <p className="mt-3 text-sm text-gray-500">No territories assigned.</p>
+                  ) : (
+                    <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                      {assignedTerritories.map((territory) => {
+                        const categories = territory.categories.map((categoryId) => ({
+                          id: categoryId,
+                          name: categoryMap.get(categoryId)?.name || categoryId,
+                        }));
+                        const licenceLabel =
+                          typeof territory.licenseFee === "number"
+                            ? gbpFormatter.format(territory.licenseFee)
+                            : null;
+                        return (
+                          <div key={territory.id} className="grid gap-2 rounded border border-dashed p-3">
+                            <div className="flex items-center justify-between gap-2">
+                              <div>
+                                <div className="font-medium text-sm">{territory.label}</div>
+                                <div className="text-xs text-gray-500">{territorySummary(territory)}</div>
+                              </div>
+                              <span
+                                className={clsx(
+                                  "rounded px-2 py-0.5 text-[11px] uppercase",
+                                  territory.exclusive
+                                    ? "bg-emerald-100 text-emerald-800"
+                                    : "bg-gray-100 text-gray-600"
+                                )}
+                              >
+                                {territory.exclusive ? "Exclusive" : "Shared"}
+                              </span>
+                            </div>
+                            {categories.length > 0 && (
+                              <div>
+                                <span className="text-[11px] font-semibold uppercase text-gray-500">
+                                  Categories
+                                </span>
+                                <div className="mt-1 flex flex-wrap gap-1">
+                                  {categories.map((category) => (
+                                    <span
+                                      key={`${territory.id}-card-${category.id}`}
+                                      className="rounded bg-gray-100 px-2 py-0.5 text-[11px] text-gray-700"
+                                    >
+                                      {category.name}
+                                    </span>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+                            <div>
+                              <span className="text-[11px] font-semibold uppercase text-gray-500">
+                                License fee
+                              </span>
+                              <div className="mt-0.5 text-xs text-gray-700">
+                                {licenceLabel ? `${licenceLabel} / month` : "Free territory"}
+                              </div>
+                            </div>
+                            <TerritoryMap territory={territory} />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+      </section>
 
       <section className="grid gap-4">
         <div className="flex items-center justify-between">
@@ -1684,6 +1839,48 @@ export default function AdminFranchisesPage() {
               Exclusive lock for this territory
             </label>
             <label className="grid gap-1 text-sm">
+              <span className="font-medium">Service categories</span>
+              <select
+                multiple
+                className="input min-h-[120px]"
+                value={newTerritory.categories}
+                onChange={(event) =>
+                  setNewTerritory({
+                    ...newTerritory,
+                    categories: Array.from(event.target.selectedOptions).map((option) => option.value),
+                  })
+                }
+              >
+                {categoryOptions.length === 0 ? (
+                  <option value="" disabled>
+                    No categories available
+                  </option>
+                ) : (
+                  categoryOptions.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))
+                )}
+              </select>
+              <span className="text-xs text-gray-500">
+                Hold Ctrl/Command to select multiple categories. Leave empty if unrestricted.
+              </span>
+            </label>
+            <label className="grid gap-1 text-sm">
+              <span className="font-medium">Monthly license fee (£/mo)</span>
+              <input
+                className="input"
+                type="number"
+                min="0"
+                step="0.01"
+                value={newTerritory.licenseFee}
+                onChange={(event) => setNewTerritory({ ...newTerritory, licenseFee: event.target.value })}
+                placeholder="0"
+              />
+              <span className="text-xs text-gray-500">Leave blank to keep the territory free.</span>
+            </label>
+            <label className="grid gap-1 text-sm">
               <span className="font-medium">Notes</span>
               <textarea
                 className="input"
@@ -1732,12 +1929,51 @@ export default function AdminFranchisesPage() {
                 territories.map((territory) => {
                   const franchise = franchiseMap.get(territory.franchiseId);
                   const editing = editingTerritoryId === territory.id;
+                  const territoryCategories = territory.categories.map((categoryId) => ({
+                    id: categoryId,
+                    name: categoryMap.get(categoryId)?.name || categoryId,
+                  }));
+                  const formattedLicense =
+                    typeof territory.licenseFee === "number"
+                      ? gbpFormatter.format(territory.licenseFee)
+                      : null;
+
                   return (
                     <tr key={territory.id} className="border-t align-top">
                       <td className="p-2 font-medium">{territory.label}</td>
                       <td className="p-2">{franchise ? franchise.name : territory.franchiseId}</td>
                       <td className="p-2">{territory.exclusive ? "Yes" : "No"}</td>
-                      <td className="p-2 text-xs text-gray-600">{territorySummary(territory)}</td>
+                      <td className="p-2 text-xs text-gray-600">
+                        <div className="grid gap-2">
+                          <div>{territorySummary(territory)}</div>
+                          {territoryCategories.length > 0 && (
+                            <div>
+                              <span className="text-[11px] font-semibold uppercase text-gray-500">
+                                Categories
+                              </span>
+                              <div className="mt-1 flex flex-wrap gap-1">
+                                {territoryCategories.map((category) => (
+                                  <span
+                                    key={`${territory.id}-${category.id}`}
+                                    className="rounded bg-gray-100 px-2 py-0.5 text-[11px] text-gray-700"
+                                  >
+                                    {category.name}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          <div>
+                            <span className="text-[11px] font-semibold uppercase text-gray-500">
+                              License fee
+                            </span>
+                            <div className="mt-0.5 text-gray-700">
+                              {formattedLicense ? `${formattedLicense} / month` : "Free territory"}
+                            </div>
+                          </div>
+                          <TerritoryMap territory={territory} className="mt-1" height={160} />
+                        </div>
+                      </td>
                       <td className="p-2">
                         <div className="flex flex-wrap gap-2">
                           <button
@@ -1880,6 +2116,49 @@ export default function AdminFranchisesPage() {
                                 }
                               />
                               Exclusive lock
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Service categories</span>
+                              <select
+                                multiple
+                                className="input min-h-[120px]"
+                                value={editingTerritory.categories}
+                                onChange={(event) =>
+                                  setEditingTerritory({
+                                    ...editingTerritory,
+                                    categories: Array.from(event.target.selectedOptions).map((option) => option.value),
+                                  })
+                                }
+                              >
+                                {categoryOptions.length === 0 ? (
+                                  <option value="" disabled>
+                                    No categories available
+                                  </option>
+                                ) : (
+                                  categoryOptions.map((category) => (
+                                    <option key={category.id} value={category.id}>
+                                      {category.name}
+                                    </option>
+                                  ))
+                                )}
+                              </select>
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Monthly license fee (£/mo)</span>
+                              <input
+                                className="input"
+                                type="number"
+                                min="0"
+                                step="0.01"
+                                value={editingTerritory.licenseFee}
+                                onChange={(event) =>
+                                  setEditingTerritory({
+                                    ...editingTerritory,
+                                    licenseFee: event.target.value,
+                                  })
+                                }
+                                placeholder="0"
+                              />
                             </label>
                             <label className="grid gap-1 text-xs">
                               <span className="font-medium">Notes</span>

--- a/apps/web/app/admin/franchises/ClientPage.tsx
+++ b/apps/web/app/admin/franchises/ClientPage.tsx
@@ -1,0 +1,1340 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  serverTimestamp,
+  updateDoc,
+} from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { useRoleGate } from "@/hooks/useRoleGate";
+import {
+  type Franchise,
+  type FranchiseMember,
+  type FranchiseMemberRole,
+  type FranchiseStatus,
+  type FranchiseTerritory,
+  parseFranchise,
+  parseMember,
+  parseTerritory,
+  territorySummary,
+} from "@/lib/franchises";
+
+interface UserSummary {
+  id: string;
+  email: string;
+  displayName: string;
+  contractor?: boolean;
+  isStaff?: boolean;
+  franchiseId?: string | null;
+}
+
+const FRANCHISE_STATUSES: { value: FranchiseStatus; label: string; description: string }[] = [
+  { value: "prospect", label: "Prospect", description: "Exploring the opportunity and not yet launched." },
+  { value: "active", label: "Active", description: "Currently onboarding or servicing clients." },
+  { value: "paused", label: "Paused", description: "Temporarily on hold (seasonal or admin reasons)." },
+  { value: "suspended", label: "Suspended", description: "Access revoked pending resolution." },
+];
+
+const MEMBER_ROLES: { value: FranchiseMemberRole; label: string; description: string }[] = [
+  { value: "owner", label: "Owner", description: "Primary point of contact and legal licensee." },
+  { value: "franchisee", label: "Franchisee", description: "Day-to-day operator for the territory." },
+  { value: "contractor", label: "Contractor", description: "Operates under the franchise banner for specific jobs." },
+  { value: "hq", label: "HQ Liaison", description: "HQ team member supporting the franchise." },
+];
+
+const TERRITORY_TYPES = [
+  { value: "postal" as const, label: "Postcode collection" },
+  { value: "radius" as const, label: "Radius from coordinate" },
+];
+
+export default function AdminFranchisesPage() {
+  const { allowed, loading: guardLoading } = useRoleGate("admin");
+  const [loading, setLoading] = useState(true);
+  const [franchises, setFranchises] = useState<Franchise[]>([]);
+  const [territories, setTerritories] = useState<FranchiseTerritory[]>([]);
+  const [members, setMembers] = useState<FranchiseMember[]>([]);
+  const [users, setUsers] = useState<UserSummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showCreateFranchise, setShowCreateFranchise] = useState(false);
+  const [newFranchise, setNewFranchise] = useState({
+    name: "",
+    code: "",
+    status: "prospect" as FranchiseStatus,
+    contactEmail: "",
+    contactPhone: "",
+    stripeAccountId: "",
+    platformFee: "",
+    notes: "",
+  });
+  const [editingFranchiseId, setEditingFranchiseId] = useState<string | null>(null);
+  const [editingFranchise, setEditingFranchise] = useState({
+    name: "",
+    code: "",
+    status: "prospect" as FranchiseStatus,
+    contactEmail: "",
+    contactPhone: "",
+    stripeAccountId: "",
+    platformFee: "",
+    notes: "",
+  });
+
+  const [showCreateTerritory, setShowCreateTerritory] = useState(false);
+  const [newTerritory, setNewTerritory] = useState({
+    franchiseId: "",
+    label: "",
+    type: "postal" as "postal" | "radius",
+    postalCodes: "",
+    exclusive: true,
+    radiusKm: "",
+    centerLat: "",
+    centerLng: "",
+    notes: "",
+  });
+  const [editingTerritoryId, setEditingTerritoryId] = useState<string | null>(null);
+  const [editingTerritory, setEditingTerritory] = useState({
+    franchiseId: "",
+    label: "",
+    type: "postal" as "postal" | "radius",
+    postalCodes: "",
+    exclusive: true,
+    radiusKm: "",
+    centerLat: "",
+    centerLng: "",
+    notes: "",
+  });
+
+  const [showCreateMember, setShowCreateMember] = useState(false);
+  const [newMember, setNewMember] = useState({
+    franchiseId: "",
+    userId: "",
+    role: "franchisee" as FranchiseMemberRole,
+    primary: false,
+  });
+
+  const loadAll = useCallback(async (cancelRef?: { current: boolean }) => {
+    const [franchiseSnap, territorySnap, memberSnap, usersSnap] = await Promise.all([
+      getDocs(collection(db, "franchises")),
+      getDocs(collection(db, "franchiseTerritories")),
+      getDocs(collection(db, "franchiseMembers")),
+      getDocs(collection(db, "users")),
+    ]);
+
+    if (cancelRef?.current) return;
+
+    const franchiseList = franchiseSnap.docs.map((doc) => parseFranchise(doc)).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+    const territoryList = territorySnap.docs.map((doc) => parseTerritory(doc));
+    const memberList = memberSnap.docs.map((doc) => parseMember(doc));
+    const userList = usersSnap.docs.map((doc) => {
+      const data = doc.data() as Record<string, any>;
+      const displayName =
+        (typeof data.fullName === "string" && data.fullName.trim()) ||
+        (typeof data.displayName === "string" && data.displayName.trim()) ||
+        (typeof data.contractorInfo?.name === "string" && data.contractorInfo.name.trim()) ||
+        "";
+      return {
+        id: doc.id,
+        email: (typeof data.email === "string" && data.email.trim()) || doc.id,
+        displayName: displayName || ((typeof data.email === "string" && data.email.trim()) || doc.id),
+        contractor: data.contractor === true,
+        isStaff: data.isStaff === true,
+        franchiseId:
+          typeof data.franchiseId === "string"
+            ? data.franchiseId
+            : typeof data.primaryFranchiseId === "string"
+            ? data.primaryFranchiseId
+            : null,
+      } satisfies UserSummary;
+    });
+
+    if (cancelRef?.current) return;
+
+    setFranchises(franchiseList);
+    setTerritories(territoryList);
+    setMembers(memberList);
+    setUsers(userList.sort((a, b) => a.displayName.localeCompare(b.displayName)));
+  }, []);
+
+  useEffect(() => {
+    if (guardLoading) return;
+    if (!allowed) {
+      setLoading(false);
+      return;
+    }
+
+    const cancelRef = { current: false };
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        await loadAll(cancelRef);
+      } catch (err: any) {
+        console.error("Failed to load franchise data", err);
+        if (!cancelRef.current) {
+          setError(err?.message || "Unable to load franchise records.");
+        }
+      } finally {
+        if (!cancelRef.current) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelRef.current = true;
+    };
+  }, [allowed, guardLoading, loadAll]);
+
+  const franchiseMap = useMemo(() => {
+    const map = new Map<string, Franchise>();
+    franchises.forEach((franchise) => map.set(franchise.id, franchise));
+    return map;
+  }, [franchises]);
+
+  const userMap = useMemo(() => {
+    const map = new Map<string, UserSummary>();
+    users.forEach((user) => map.set(user.id, user));
+    return map;
+  }, [users]);
+
+  const territoryByFranchise = useMemo(() => {
+    const map = new Map<string, FranchiseTerritory[]>();
+    territories.forEach((territory) => {
+      const list = map.get(territory.franchiseId) || [];
+      list.push(territory);
+      map.set(territory.franchiseId, list);
+    });
+    return map;
+  }, [territories]);
+
+  const membersByFranchise = useMemo(() => {
+    const map = new Map<string, FranchiseMember[]>();
+    members.forEach((member) => {
+      const list = map.get(member.franchiseId) || [];
+      list.push(member);
+      map.set(member.franchiseId, list);
+    });
+    return map;
+  }, [members]);
+
+  if (guardLoading || loading) {
+    return <p>Loading…</p>;
+  }
+
+  if (!allowed) {
+    return <p>You do not have permission to manage franchise records.</p>;
+  }
+
+  const resetFranchiseForm = () => {
+    setNewFranchise({
+      name: "",
+      code: "",
+      status: "prospect",
+      contactEmail: "",
+      contactPhone: "",
+      stripeAccountId: "",
+      platformFee: "",
+      notes: "",
+    });
+  };
+
+  const handleCreateFranchise = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const parsedPlatformFee = Number.parseFloat(newFranchise.platformFee);
+      const payload = {
+        name: newFranchise.name.trim(),
+        code: (newFranchise.code || newFranchise.name || "").trim().replace(/\s+/g, "-").toLowerCase(),
+        status: newFranchise.status,
+        contactEmail: newFranchise.contactEmail.trim() || null,
+        contactPhone: newFranchise.contactPhone.trim() || null,
+        stripeAccountId: newFranchise.stripeAccountId.trim() || null,
+        platformFee:
+          newFranchise.platformFee.trim().length > 0 && Number.isFinite(parsedPlatformFee)
+            ? parsedPlatformFee
+            : null,
+        notes: newFranchise.notes.trim() || null,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      };
+      await addDoc(collection(db, "franchises"), payload);
+      resetFranchiseForm();
+      setShowCreateFranchise(false);
+      await refreshData();
+    } catch (err) {
+      console.error("Failed to create franchise", err);
+      alert("Unable to create franchise. Please try again.");
+    }
+  };
+
+  const startEditFranchise = (franchise: Franchise) => {
+    setEditingFranchiseId(franchise.id);
+    setEditingFranchise({
+      name: franchise.name,
+      code: franchise.code,
+      status: franchise.status,
+      contactEmail: franchise.contactEmail || "",
+      contactPhone: franchise.contactPhone || "",
+      stripeAccountId: franchise.stripeAccountId || "",
+      platformFee: typeof franchise.platformFee === "number" ? String(franchise.platformFee) : "",
+      notes: franchise.notes || "",
+    });
+  };
+
+  const cancelEditFranchise = () => {
+    setEditingFranchiseId(null);
+    setEditingFranchise({
+      name: "",
+      code: "",
+      status: "prospect",
+      contactEmail: "",
+      contactPhone: "",
+      stripeAccountId: "",
+      platformFee: "",
+      notes: "",
+    });
+  };
+
+  const handleUpdateFranchise = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingFranchiseId) return;
+    try {
+      const parsedPlatformFee = Number.parseFloat(editingFranchise.platformFee);
+      const payload = {
+        name: editingFranchise.name.trim() || "Untitled Franchise",
+        code: editingFranchise.code.trim() || editingFranchiseId,
+        status: editingFranchise.status,
+        contactEmail: editingFranchise.contactEmail.trim() || null,
+        contactPhone: editingFranchise.contactPhone.trim() || null,
+        stripeAccountId: editingFranchise.stripeAccountId.trim() || null,
+        platformFee:
+          editingFranchise.platformFee.trim().length > 0 && Number.isFinite(parsedPlatformFee)
+            ? parsedPlatformFee
+            : null,
+        notes: editingFranchise.notes.trim() || null,
+        updatedAt: serverTimestamp(),
+      };
+      await updateDoc(doc(db, "franchises", editingFranchiseId), payload);
+      cancelEditFranchise();
+      await refreshData();
+    } catch (err) {
+      console.error("Failed to update franchise", err);
+      alert("Unable to update franchise. Please try again.");
+    }
+  };
+
+  const resetTerritoryForm = () => {
+    setNewTerritory({
+      franchiseId: "",
+      label: "",
+      type: "postal",
+      postalCodes: "",
+      exclusive: true,
+      radiusKm: "",
+      centerLat: "",
+      centerLng: "",
+      notes: "",
+    });
+  };
+
+  const handleCreateTerritory = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const postalCodes = newTerritory.postalCodes
+        .split(/\s|,|;|\n/g)
+        .map((code) => code.trim())
+        .filter(Boolean);
+      const parsedRadius = Number.parseFloat(newTerritory.radiusKm);
+      const parsedLat = Number.parseFloat(newTerritory.centerLat);
+      const parsedLng = Number.parseFloat(newTerritory.centerLng);
+      const payload = {
+        franchiseId: newTerritory.franchiseId,
+        label: newTerritory.label.trim() || "Unnamed Territory",
+        type: newTerritory.type,
+        postalCodes,
+        exclusive: newTerritory.exclusive,
+        radiusKm:
+          newTerritory.type === "radius" && newTerritory.radiusKm.trim() && Number.isFinite(parsedRadius)
+            ? parsedRadius
+            : null,
+        centerLat:
+          newTerritory.type === "radius" && newTerritory.centerLat.trim() && Number.isFinite(parsedLat)
+            ? parsedLat
+            : null,
+        centerLng:
+          newTerritory.type === "radius" && newTerritory.centerLng.trim() && Number.isFinite(parsedLng)
+            ? parsedLng
+            : null,
+        notes: newTerritory.notes.trim() || null,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      };
+      await addDoc(collection(db, "franchiseTerritories"), payload);
+      resetTerritoryForm();
+      setShowCreateTerritory(false);
+      await refreshData();
+    } catch (err) {
+      console.error("Failed to create territory", err);
+      alert("Unable to create territory. Please try again.");
+    }
+  };
+
+  const startEditTerritory = (territory: FranchiseTerritory) => {
+    setEditingTerritoryId(territory.id);
+    setEditingTerritory({
+      franchiseId: territory.franchiseId,
+      label: territory.label,
+      type: territory.type,
+      postalCodes: territory.postalCodes.join("\n"),
+      exclusive: territory.exclusive,
+      radiusKm: territory.radiusKm ? String(territory.radiusKm) : "",
+      centerLat: territory.centerLat ? String(territory.centerLat) : "",
+      centerLng: territory.centerLng ? String(territory.centerLng) : "",
+      notes: territory.notes || "",
+    });
+  };
+
+  const cancelEditTerritory = () => {
+    setEditingTerritoryId(null);
+    setEditingTerritory({
+      franchiseId: "",
+      label: "",
+      type: "postal",
+      postalCodes: "",
+      exclusive: true,
+      radiusKm: "",
+      centerLat: "",
+      centerLng: "",
+      notes: "",
+    });
+  };
+
+  const handleUpdateTerritory = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingTerritoryId) return;
+    try {
+      const postalCodes = editingTerritory.postalCodes
+        .split(/\s|,|;|\n/g)
+        .map((code) => code.trim())
+        .filter(Boolean);
+      const parsedRadius = Number.parseFloat(editingTerritory.radiusKm);
+      const parsedLat = Number.parseFloat(editingTerritory.centerLat);
+      const parsedLng = Number.parseFloat(editingTerritory.centerLng);
+      const payload = {
+        franchiseId: editingTerritory.franchiseId,
+        label: editingTerritory.label.trim() || "Unnamed Territory",
+        type: editingTerritory.type,
+        postalCodes,
+        exclusive: editingTerritory.exclusive,
+        radiusKm:
+          editingTerritory.type === "radius" && editingTerritory.radiusKm.trim() && Number.isFinite(parsedRadius)
+            ? parsedRadius
+            : null,
+        centerLat:
+          editingTerritory.type === "radius" && editingTerritory.centerLat.trim() && Number.isFinite(parsedLat)
+            ? parsedLat
+            : null,
+        centerLng:
+          editingTerritory.type === "radius" && editingTerritory.centerLng.trim() && Number.isFinite(parsedLng)
+            ? parsedLng
+            : null,
+        notes: editingTerritory.notes.trim() || null,
+        updatedAt: serverTimestamp(),
+      };
+      await updateDoc(doc(db, "franchiseTerritories", editingTerritoryId), payload);
+      cancelEditTerritory();
+      await refreshData();
+    } catch (err) {
+      console.error("Failed to update territory", err);
+      alert("Unable to update territory. Please try again.");
+    }
+  };
+
+  const removeTerritory = async (territory: FranchiseTerritory) => {
+    if (!confirm(`Remove territory "${territory.label}"?`)) return;
+    try {
+      await deleteDoc(doc(db, "franchiseTerritories", territory.id));
+      await refreshData();
+    } catch (err) {
+      console.error("Failed to delete territory", err);
+      alert("Unable to delete territory. Please try again.");
+    }
+  };
+
+  const handleCreateMember = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newMember.franchiseId || !newMember.userId) {
+      alert("Select both a franchise and user.");
+      return;
+    }
+    try {
+      const payload = {
+        franchiseId: newMember.franchiseId,
+        userId: newMember.userId,
+        role: newMember.role,
+        primary: newMember.primary,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      };
+      await addDoc(collection(db, "franchiseMembers"), payload);
+      if (newMember.primary) {
+        await updateDoc(doc(db, "users", newMember.userId), {
+          franchiseId: newMember.franchiseId,
+          primaryFranchiseId: newMember.franchiseId,
+          updatedAt: serverTimestamp(),
+        }).catch((err) => {
+          console.warn("Unable to update user franchise assignment", err);
+        });
+      }
+      setShowCreateMember(false);
+      setNewMember({ franchiseId: "", userId: "", role: "franchisee", primary: false });
+      await refreshData();
+    } catch (err) {
+      console.error("Failed to create membership", err);
+      alert("Unable to assign member. Please try again.");
+    }
+  };
+
+  const removeMember = async (member: FranchiseMember) => {
+    const user = userMap.get(member.userId);
+    const franchise = franchiseMap.get(member.franchiseId);
+    const label = `${user?.displayName || user?.email || member.userId} → ${franchise?.name || member.franchiseId}`;
+    if (!confirm(`Remove ${label}?`)) return;
+    try {
+      await deleteDoc(doc(db, "franchiseMembers", member.id));
+      if (member.primary) {
+        await updateDoc(doc(db, "users", member.userId), {
+          franchiseId: null,
+          primaryFranchiseId: null,
+          updatedAt: serverTimestamp(),
+        }).catch((err) => {
+          console.warn("Unable to clear user franchise assignment", err);
+        });
+      }
+      await refreshData();
+    } catch (err) {
+      console.error("Failed to remove membership", err);
+      alert("Unable to remove membership. Please try again.");
+    }
+  };
+
+  async function refreshData() {
+    try {
+      await loadAll();
+    } catch (err) {
+      console.error("Failed to refresh franchise data", err);
+      alert("Unable to refresh franchise data. Try again.");
+    }
+  }
+
+
+  return (
+    <div className="grid gap-8">
+      <div>
+        <h1 className="text-xl font-semibold">Franchise Network</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Configure franchise territories, assign operators, and prepare Stripe Connect mappings for revenue sharing.
+        </p>
+        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      </div>
+
+      <section className="grid gap-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Franchises</h2>
+          <button
+            type="button"
+            className="btn btn-sm"
+            onClick={() => setShowCreateFranchise((value) => !value)}
+          >
+            {showCreateFranchise ? "Close" : "New franchise"}
+          </button>
+        </div>
+        {showCreateFranchise && (
+          <form className="grid gap-3 rounded border p-4" onSubmit={handleCreateFranchise}>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Franchise name</span>
+                <input
+                  className="input"
+                  value={newFranchise.name}
+                  onChange={(event) => setNewFranchise({ ...newFranchise, name: event.target.value })}
+                  placeholder="e.g. Pineapple Tapped – Manchester"
+                  required
+                />
+              </label>
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Code</span>
+                <input
+                  className="input"
+                  value={newFranchise.code}
+                  onChange={(event) => setNewFranchise({ ...newFranchise, code: event.target.value })}
+                  placeholder="manchester"
+                />
+              </label>
+            </div>
+            <label className="grid gap-1 text-sm">
+              <span className="font-medium">Status</span>
+              <select
+                className="input"
+                value={newFranchise.status}
+                onChange={(event) => setNewFranchise({ ...newFranchise, status: event.target.value as FranchiseStatus })}
+              >
+                {FRANCHISE_STATUSES.map((status) => (
+                  <option key={status.value} value={status.value}>
+                    {status.label}
+                  </option>
+                ))}
+              </select>
+              <span className="text-xs text-gray-500">
+                {FRANCHISE_STATUSES.find((status) => status.value === newFranchise.status)?.description}
+              </span>
+            </label>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Contact email</span>
+                <input
+                  className="input"
+                  type="email"
+                  value={newFranchise.contactEmail}
+                  onChange={(event) => setNewFranchise({ ...newFranchise, contactEmail: event.target.value })}
+                  placeholder="franchise@pineappletapped.com"
+                />
+              </label>
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Contact phone</span>
+                <input
+                  className="input"
+                  value={newFranchise.contactPhone}
+                  onChange={(event) => setNewFranchise({ ...newFranchise, contactPhone: event.target.value })}
+                  placeholder="+44 1234 567890"
+                />
+              </label>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Stripe account ID</span>
+                <input
+                  className="input"
+                  value={newFranchise.stripeAccountId}
+                  onChange={(event) => setNewFranchise({ ...newFranchise, stripeAccountId: event.target.value })}
+                  placeholder="acct_123..."
+                />
+              </label>
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Platform fee (%)</span>
+                <input
+                  className="input"
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={newFranchise.platformFee}
+                  onChange={(event) => setNewFranchise({ ...newFranchise, platformFee: event.target.value })}
+                  placeholder="6"
+                />
+              </label>
+            </div>
+            <label className="grid gap-1 text-sm">
+              <span className="font-medium">Notes</span>
+              <textarea
+                className="input"
+                rows={3}
+                value={newFranchise.notes}
+                onChange={(event) => setNewFranchise({ ...newFranchise, notes: event.target.value })}
+                placeholder="Launch plan, onboarding checklist, marketing commitments…"
+              />
+            </label>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="btn btn-sm btn-outline"
+                onClick={() => {
+                  resetFranchiseForm();
+                  setShowCreateFranchise(false);
+                }}
+              >
+                Cancel
+              </button>
+              <button type="submit" className="btn btn-sm">
+                Save franchise
+              </button>
+            </div>
+          </form>
+        )}
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-sm border">
+            <thead>
+              <tr className="bg-gray-100 text-left">
+                <th className="p-2">Franchise</th>
+                <th className="p-2">Status</th>
+                <th className="p-2">Contact</th>
+                <th className="p-2">Stripe</th>
+                <th className="p-2">Territories</th>
+                <th className="p-2">Members</th>
+                <th className="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {franchises.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="p-4 text-center text-gray-500">
+                    No franchises created yet.
+                  </td>
+                </tr>
+              ) : (
+                franchises.map((franchise) => {
+                  const territoryCount = territoryByFranchise.get(franchise.id)?.length ?? 0;
+                  const memberCount = membersByFranchise.get(franchise.id)?.length ?? 0;
+                  const editing = editingFranchiseId === franchise.id;
+                  return (
+                    <tr key={franchise.id} className="border-t align-top">
+                      <td className="p-2 font-medium">
+                        <div>{franchise.name}</div>
+                        <div className="text-xs text-gray-500">Code: {franchise.code}</div>
+                      </td>
+                      <td className="p-2 capitalize">{franchise.status}</td>
+                      <td className="p-2 text-sm">
+                        {franchise.contactEmail && <div>{franchise.contactEmail}</div>}
+                        {franchise.contactPhone && <div>{franchise.contactPhone}</div>}
+                      </td>
+                      <td className="p-2 text-xs">
+                        {franchise.stripeAccountId ? (
+                          <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">
+                            {franchise.stripeAccountId}
+                          </code>
+                        ) : (
+                          <span className="text-gray-500">Pending</span>
+                        )}
+                        {typeof franchise.platformFee === "number" && (
+                          <div className="text-xs text-gray-500">Platform fee: {franchise.platformFee}%</div>
+                        )}
+                      </td>
+                      <td className="p-2">{territoryCount}</td>
+                      <td className="p-2">{memberCount}</td>
+                      <td className="p-2">
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            className="btn btn-xs"
+                            onClick={() => startEditFranchise(franchise)}
+                          >
+                            Edit
+                          </button>
+                        </div>
+                        {editing && (
+                          <form className="mt-3 grid gap-2 rounded border p-2" onSubmit={handleUpdateFranchise}>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Name</span>
+                              <input
+                                className="input"
+                                value={editingFranchise.name}
+                                onChange={(event) =>
+                                  setEditingFranchise({ ...editingFranchise, name: event.target.value })
+                                }
+                                required
+                              />
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Code</span>
+                              <input
+                                className="input"
+                                value={editingFranchise.code}
+                                onChange={(event) =>
+                                  setEditingFranchise({ ...editingFranchise, code: event.target.value })
+                                }
+                                required
+                              />
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Status</span>
+                              <select
+                                className="input"
+                                value={editingFranchise.status}
+                                onChange={(event) =>
+                                  setEditingFranchise({
+                                    ...editingFranchise,
+                                    status: event.target.value as FranchiseStatus,
+                                  })
+                                }
+                              >
+                                {FRANCHISE_STATUSES.map((status) => (
+                                  <option key={status.value} value={status.value}>
+                                    {status.label}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Contact email</span>
+                              <input
+                                className="input"
+                                value={editingFranchise.contactEmail}
+                                onChange={(event) =>
+                                  setEditingFranchise({
+                                    ...editingFranchise,
+                                    contactEmail: event.target.value,
+                                  })
+                                }
+                              />
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Contact phone</span>
+                              <input
+                                className="input"
+                                value={editingFranchise.contactPhone}
+                                onChange={(event) =>
+                                  setEditingFranchise({
+                                    ...editingFranchise,
+                                    contactPhone: event.target.value,
+                                  })
+                                }
+                              />
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Stripe account</span>
+                              <input
+                                className="input"
+                                value={editingFranchise.stripeAccountId}
+                                onChange={(event) =>
+                                  setEditingFranchise({
+                                    ...editingFranchise,
+                                    stripeAccountId: event.target.value,
+                                  })
+                                }
+                              />
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Platform fee (%)</span>
+                              <input
+                                className="input"
+                                type="number"
+                                min="0"
+                                step="0.1"
+                                value={editingFranchise.platformFee}
+                                onChange={(event) =>
+                                  setEditingFranchise({
+                                    ...editingFranchise,
+                                    platformFee: event.target.value,
+                                  })
+                                }
+                              />
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Notes</span>
+                              <textarea
+                                className="input"
+                                rows={2}
+                                value={editingFranchise.notes}
+                                onChange={(event) =>
+                                  setEditingFranchise({ ...editingFranchise, notes: event.target.value })
+                                }
+                              />
+                            </label>
+                            <div className="flex justify-end gap-2">
+                              <button type="button" className="btn btn-xs btn-outline" onClick={cancelEditFranchise}>
+                                Close
+                              </button>
+                              <button type="submit" className="btn btn-xs">
+                                Save
+                              </button>
+                            </div>
+                          </form>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="grid gap-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Territories</h2>
+          <button
+            type="button"
+            className="btn btn-sm"
+            onClick={() => setShowCreateTerritory((value) => !value)}
+          >
+            {showCreateTerritory ? "Close" : "New territory"}
+          </button>
+        </div>
+        {showCreateTerritory && (
+          <form className="grid gap-3 rounded border p-4" onSubmit={handleCreateTerritory}>
+            <label className="grid gap-1 text-sm">
+              <span className="font-medium">Franchise</span>
+              <select
+                className="input"
+                value={newTerritory.franchiseId}
+                onChange={(event) => setNewTerritory({ ...newTerritory, franchiseId: event.target.value })}
+                required
+              >
+                <option value="">Select franchise…</option>
+                {franchises.map((franchise) => (
+                  <option key={franchise.id} value={franchise.id}>
+                    {franchise.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Label</span>
+                <input
+                  className="input"
+                  value={newTerritory.label}
+                  onChange={(event) => setNewTerritory({ ...newTerritory, label: event.target.value })}
+                  placeholder="Manchester city core"
+                  required
+                />
+              </label>
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Type</span>
+                <select
+                  className="input"
+                  value={newTerritory.type}
+                  onChange={(event) => setNewTerritory({ ...newTerritory, type: event.target.value as "postal" | "radius" })}
+                >
+                  {TERRITORY_TYPES.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            {newTerritory.type === "postal" ? (
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Postcodes (one per line)</span>
+                <textarea
+                  className="input"
+                  rows={4}
+                  value={newTerritory.postalCodes}
+                  onChange={(event) => setNewTerritory({ ...newTerritory, postalCodes: event.target.value })}
+                  placeholder="M1\nM2\nM3"
+                  required
+                />
+              </label>
+            ) : (
+              <div className="grid gap-3 sm:grid-cols-3">
+                <label className="grid gap-1 text-sm">
+                  <span className="font-medium">Latitude</span>
+                  <input
+                    className="input"
+                    value={newTerritory.centerLat}
+                    onChange={(event) => setNewTerritory({ ...newTerritory, centerLat: event.target.value })}
+                    placeholder="53.4808"
+                    required
+                  />
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="font-medium">Longitude</span>
+                  <input
+                    className="input"
+                    value={newTerritory.centerLng}
+                    onChange={(event) => setNewTerritory({ ...newTerritory, centerLng: event.target.value })}
+                    placeholder="-2.2426"
+                    required
+                  />
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="font-medium">Radius (km)</span>
+                  <input
+                    className="input"
+                    type="number"
+                    min="1"
+                    step="0.5"
+                    value={newTerritory.radiusKm}
+                    onChange={(event) => setNewTerritory({ ...newTerritory, radiusKm: event.target.value })}
+                    placeholder="25"
+                    required
+                  />
+                </label>
+              </div>
+            )}
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={newTerritory.exclusive}
+                onChange={(event) => setNewTerritory({ ...newTerritory, exclusive: event.target.checked })}
+              />
+              Exclusive lock for this territory
+            </label>
+            <label className="grid gap-1 text-sm">
+              <span className="font-medium">Notes</span>
+              <textarea
+                className="input"
+                rows={2}
+                value={newTerritory.notes}
+                onChange={(event) => setNewTerritory({ ...newTerritory, notes: event.target.value })}
+                placeholder="Paid ads radius, special restrictions, partner agreements…"
+              />
+            </label>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="btn btn-sm btn-outline"
+                onClick={() => {
+                  resetTerritoryForm();
+                  setShowCreateTerritory(false);
+                }}
+              >
+                Cancel
+              </button>
+              <button type="submit" className="btn btn-sm">
+                Save territory
+              </button>
+            </div>
+          </form>
+        )}
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-sm border">
+            <thead>
+              <tr className="bg-gray-100 text-left">
+                <th className="p-2">Territory</th>
+                <th className="p-2">Franchise</th>
+                <th className="p-2">Exclusive</th>
+                <th className="p-2">Summary</th>
+                <th className="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {territories.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="p-4 text-center text-gray-500">
+                    No territories configured.
+                  </td>
+                </tr>
+              ) : (
+                territories.map((territory) => {
+                  const franchise = franchiseMap.get(territory.franchiseId);
+                  const editing = editingTerritoryId === territory.id;
+                  return (
+                    <tr key={territory.id} className="border-t align-top">
+                      <td className="p-2 font-medium">{territory.label}</td>
+                      <td className="p-2">{franchise ? franchise.name : territory.franchiseId}</td>
+                      <td className="p-2">{territory.exclusive ? "Yes" : "No"}</td>
+                      <td className="p-2 text-xs text-gray-600">{territorySummary(territory)}</td>
+                      <td className="p-2">
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            className="btn btn-xs"
+                            onClick={() => startEditTerritory(territory)}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            className="btn btn-xs btn-outline"
+                            onClick={() => removeTerritory(territory)}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                        {editing && (
+                          <form className="mt-3 grid gap-2 rounded border p-2" onSubmit={handleUpdateTerritory}>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Label</span>
+                              <input
+                                className="input"
+                                value={editingTerritory.label}
+                                onChange={(event) =>
+                                  setEditingTerritory({ ...editingTerritory, label: event.target.value })
+                                }
+                                required
+                              />
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Franchise</span>
+                              <select
+                                className="input"
+                                value={editingTerritory.franchiseId}
+                                onChange={(event) =>
+                                  setEditingTerritory({ ...editingTerritory, franchiseId: event.target.value })
+                                }
+                              >
+                                {franchises.map((franchiseOption) => (
+                                  <option key={franchiseOption.id} value={franchiseOption.id}>
+                                    {franchiseOption.name}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Type</span>
+                              <select
+                                className="input"
+                                value={editingTerritory.type}
+                                onChange={(event) =>
+                                  setEditingTerritory({
+                                    ...editingTerritory,
+                                    type: event.target.value as "postal" | "radius",
+                                  })
+                                }
+                              >
+                                {TERRITORY_TYPES.map((option) => (
+                                  <option key={option.value} value={option.value}>
+                                    {option.label}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            {editingTerritory.type === "postal" ? (
+                              <label className="grid gap-1 text-xs">
+                                <span className="font-medium">Postcodes (one per line)</span>
+                                <textarea
+                                  className="input"
+                                  rows={3}
+                                  value={editingTerritory.postalCodes}
+                                  onChange={(event) =>
+                                    setEditingTerritory({
+                                      ...editingTerritory,
+                                      postalCodes: event.target.value,
+                                    })
+                                  }
+                                  required
+                                />
+                              </label>
+                            ) : (
+                              <div className="grid gap-2 sm:grid-cols-3">
+                                <label className="grid gap-1 text-xs">
+                                  <span className="font-medium">Latitude</span>
+                                  <input
+                                    className="input"
+                                    value={editingTerritory.centerLat}
+                                    onChange={(event) =>
+                                      setEditingTerritory({
+                                        ...editingTerritory,
+                                        centerLat: event.target.value,
+                                      })
+                                    }
+                                    required
+                                  />
+                                </label>
+                                <label className="grid gap-1 text-xs">
+                                  <span className="font-medium">Longitude</span>
+                                  <input
+                                    className="input"
+                                    value={editingTerritory.centerLng}
+                                    onChange={(event) =>
+                                      setEditingTerritory({
+                                        ...editingTerritory,
+                                        centerLng: event.target.value,
+                                      })
+                                    }
+                                    required
+                                  />
+                                </label>
+                                <label className="grid gap-1 text-xs">
+                                  <span className="font-medium">Radius (km)</span>
+                                  <input
+                                    className="input"
+                                    type="number"
+                                    min="1"
+                                    step="0.5"
+                                    value={editingTerritory.radiusKm}
+                                    onChange={(event) =>
+                                      setEditingTerritory({
+                                        ...editingTerritory,
+                                        radiusKm: event.target.value,
+                                      })
+                                    }
+                                    required
+                                  />
+                                </label>
+                              </div>
+                            )}
+                            <label className="flex items-center gap-2 text-xs">
+                              <input
+                                type="checkbox"
+                                checked={editingTerritory.exclusive}
+                                onChange={(event) =>
+                                  setEditingTerritory({
+                                    ...editingTerritory,
+                                    exclusive: event.target.checked,
+                                  })
+                                }
+                              />
+                              Exclusive lock
+                            </label>
+                            <label className="grid gap-1 text-xs">
+                              <span className="font-medium">Notes</span>
+                              <textarea
+                                className="input"
+                                rows={2}
+                                value={editingTerritory.notes}
+                                onChange={(event) =>
+                                  setEditingTerritory({ ...editingTerritory, notes: event.target.value })
+                                }
+                              />
+                            </label>
+                            <div className="flex justify-end gap-2">
+                              <button type="button" className="btn btn-xs btn-outline" onClick={cancelEditTerritory}>
+                                Close
+                              </button>
+                              <button type="submit" className="btn btn-xs">
+                                Save
+                              </button>
+                            </div>
+                          </form>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="grid gap-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Members & assignments</h2>
+          <button
+            type="button"
+            className="btn btn-sm"
+            onClick={() => setShowCreateMember((value) => !value)}
+          >
+            {showCreateMember ? "Close" : "New assignment"}
+          </button>
+        </div>
+        {showCreateMember && (
+          <form className="grid gap-3 rounded border p-4" onSubmit={handleCreateMember}>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Franchise</span>
+                <select
+                  className="input"
+                  value={newMember.franchiseId}
+                  onChange={(event) => setNewMember({ ...newMember, franchiseId: event.target.value })}
+                  required
+                >
+                  <option value="">Select franchise…</option>
+                  {franchises.map((franchise) => (
+                    <option key={franchise.id} value={franchise.id}>
+                      {franchise.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">User</span>
+                <select
+                  className="input"
+                  value={newMember.userId}
+                  onChange={(event) => setNewMember({ ...newMember, userId: event.target.value })}
+                  required
+                >
+                  <option value="">Select user…</option>
+                  {users.map((user) => (
+                    <option key={user.id} value={user.id}>
+                      {user.displayName} ({user.email})
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <label className="grid gap-1 text-sm">
+              <span className="font-medium">Role</span>
+              <select
+                className="input"
+                value={newMember.role}
+                onChange={(event) => setNewMember({ ...newMember, role: event.target.value as FranchiseMemberRole })}
+              >
+                {MEMBER_ROLES.map((role) => (
+                  <option key={role.value} value={role.value}>
+                    {role.label}
+                  </option>
+                ))}
+              </select>
+              <span className="text-xs text-gray-500">
+                {MEMBER_ROLES.find((role) => role.value === newMember.role)?.description}
+              </span>
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={newMember.primary}
+                onChange={(event) => setNewMember({ ...newMember, primary: event.target.checked })}
+              />
+              Primary assignment (updates the user profile to use this franchise by default)
+            </label>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="btn btn-sm btn-outline"
+                onClick={() => {
+                  setShowCreateMember(false);
+                  setNewMember({ franchiseId: "", userId: "", role: "franchisee", primary: false });
+                }}
+              >
+                Cancel
+              </button>
+              <button type="submit" className="btn btn-sm">
+                Save assignment
+              </button>
+            </div>
+          </form>
+        )}
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-sm border">
+            <thead>
+              <tr className="bg-gray-100 text-left">
+                <th className="p-2">User</th>
+                <th className="p-2">Franchise</th>
+                <th className="p-2">Role</th>
+                <th className="p-2">Primary</th>
+                <th className="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="p-4 text-center text-gray-500">
+                    No member assignments yet.
+                  </td>
+                </tr>
+              ) : (
+                members.map((member) => {
+                  const user = userMap.get(member.userId);
+                  const franchise = franchiseMap.get(member.franchiseId);
+                  return (
+                    <tr key={member.id} className="border-t">
+                      <td className="p-2">
+                        <div className="font-medium">{user?.displayName || user?.email || member.userId}</div>
+                        <div className="text-xs text-gray-500">{user?.email}</div>
+                      </td>
+                      <td className="p-2">{franchise ? franchise.name : member.franchiseId}</td>
+                      <td className="p-2 capitalize">{member.role}</td>
+                      <td className="p-2">{member.primary ? "Yes" : "No"}</td>
+                      <td className="p-2">
+                        <button
+                          type="button"
+                          className="btn btn-xs btn-outline"
+                          onClick={() => removeMember(member)}
+                        >
+                          Remove
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/admin/franchises/ClientPage.tsx
+++ b/apps/web/app/admin/franchises/ClientPage.tsx
@@ -14,10 +14,13 @@ import { db } from "@/lib/firebase";
 import { useRoleGate } from "@/hooks/useRoleGate";
 import {
   type Franchise,
+  type FranchiseOnboardingStatus,
   type FranchiseMember,
   type FranchiseMemberRole,
   type FranchiseStatus,
   type FranchiseTerritory,
+  canActivateFranchise,
+  defaultFranchiseOnboarding,
   parseFranchise,
   parseMember,
   parseTerritory,
@@ -52,6 +55,30 @@ const TERRITORY_TYPES = [
   { value: "radius" as const, label: "Radius from coordinate" },
 ];
 
+const ONBOARDING_STATUS_OPTIONS: {
+  value: FranchiseOnboardingStatus;
+  label: string;
+  description: string;
+}[] = [
+  { value: "not_started", label: "Not started", description: "No information submitted yet." },
+  { value: "in_progress", label: "In progress", description: "Franchisee is working through the step." },
+  {
+    value: "needs_attention",
+    label: "Needs attention",
+    description: "Information provided but requires follow-up or correction.",
+  },
+  { value: "completed", label: "Completed", description: "Step verified and approved by HQ." },
+];
+
+const onboardingStatusLabel = (value: FranchiseOnboardingStatus) =>
+  ONBOARDING_STATUS_OPTIONS.find((option) => option.value === value)?.label || "Not started";
+
+function createOnboardingState() {
+  return { ...defaultFranchiseOnboarding() };
+}
+
+type OnboardingState = ReturnType<typeof createOnboardingState>;
+
 export default function AdminFranchisesPage() {
   const { allowed, loading: guardLoading } = useRoleGate("admin");
   const [loading, setLoading] = useState(true);
@@ -71,6 +98,7 @@ export default function AdminFranchisesPage() {
     stripeAccountId: "",
     platformFee: "",
     notes: "",
+    onboarding: createOnboardingState(),
   });
   const [editingFranchiseId, setEditingFranchiseId] = useState<string | null>(null);
   const [editingFranchise, setEditingFranchise] = useState({
@@ -82,6 +110,7 @@ export default function AdminFranchisesPage() {
     stripeAccountId: "",
     platformFee: "",
     notes: "",
+    onboarding: createOnboardingState(),
   });
 
   const [showCreateTerritory, setShowCreateTerritory] = useState(false);
@@ -116,6 +145,14 @@ export default function AdminFranchisesPage() {
     role: "franchisee" as FranchiseMemberRole,
     primary: false,
   });
+
+  const updateNewOnboarding = (updates: Partial<OnboardingState>) => {
+    setNewFranchise((prev) => ({ ...prev, onboarding: { ...prev.onboarding, ...updates } }));
+  };
+
+  const updateEditingOnboarding = (updates: Partial<OnboardingState>) => {
+    setEditingFranchise((prev) => ({ ...prev, onboarding: { ...prev.onboarding, ...updates } }));
+  };
 
   const loadAll = useCallback(async (cancelRef?: { current: boolean }) => {
     const [franchiseSnap, territorySnap, memberSnap, usersSnap] = await Promise.all([
@@ -243,6 +280,7 @@ export default function AdminFranchisesPage() {
       stripeAccountId: "",
       platformFee: "",
       notes: "",
+      onboarding: createOnboardingState(),
     });
   };
 
@@ -250,6 +288,12 @@ export default function AdminFranchisesPage() {
     event.preventDefault();
     try {
       const parsedPlatformFee = Number.parseFloat(newFranchise.platformFee);
+      const onboardingNotes =
+        typeof newFranchise.onboarding.notes === "string" ? newFranchise.onboarding.notes.trim() : "";
+      const onboardingPayload = {
+        ...newFranchise.onboarding,
+        notes: onboardingNotes.length > 0 ? onboardingNotes : null,
+      };
       const payload = {
         name: newFranchise.name.trim(),
         code: (newFranchise.code || newFranchise.name || "").trim().replace(/\s+/g, "-").toLowerCase(),
@@ -262,6 +306,7 @@ export default function AdminFranchisesPage() {
             ? parsedPlatformFee
             : null,
         notes: newFranchise.notes.trim() || null,
+        onboarding: onboardingPayload,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       };
@@ -286,6 +331,10 @@ export default function AdminFranchisesPage() {
       stripeAccountId: franchise.stripeAccountId || "",
       platformFee: typeof franchise.platformFee === "number" ? String(franchise.platformFee) : "",
       notes: franchise.notes || "",
+      onboarding: {
+        ...createOnboardingState(),
+        ...franchise.onboarding,
+      },
     });
   };
 
@@ -300,6 +349,7 @@ export default function AdminFranchisesPage() {
       stripeAccountId: "",
       platformFee: "",
       notes: "",
+      onboarding: createOnboardingState(),
     });
   };
 
@@ -308,6 +358,19 @@ export default function AdminFranchisesPage() {
     if (!editingFranchiseId) return;
     try {
       const parsedPlatformFee = Number.parseFloat(editingFranchise.platformFee);
+      const onboardingNotes =
+        typeof editingFranchise.onboarding.notes === "string" ? editingFranchise.onboarding.notes.trim() : "";
+      const onboardingPayload = {
+        ...editingFranchise.onboarding,
+        notes: onboardingNotes.length > 0 ? onboardingNotes : null,
+      };
+      const activationReady = canActivateFranchise(onboardingPayload);
+      if (editingFranchise.status === "active" && !activationReady) {
+        alert(
+          "Franchises can only be marked Active once KYC and Stripe Connect onboarding are completed and charges are enabled."
+        );
+        return;
+      }
       const payload = {
         name: editingFranchise.name.trim() || "Untitled Franchise",
         code: editingFranchise.code.trim() || editingFranchiseId,
@@ -320,6 +383,7 @@ export default function AdminFranchisesPage() {
             ? parsedPlatformFee
             : null,
         notes: editingFranchise.notes.trim() || null,
+        onboarding: onboardingPayload,
         updatedAt: serverTimestamp(),
       };
       await updateDoc(doc(db, "franchises", editingFranchiseId), payload);
@@ -641,6 +705,124 @@ export default function AdminFranchisesPage() {
                 />
               </label>
             </div>
+            <div className="grid gap-3 rounded border border-dashed border-gray-200 p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm font-medium">Onboarding checklist</div>
+                  <p className="text-xs text-gray-500">
+                    Track key milestones needed before a franchise can take live payments.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-xs"
+                  onClick={() =>
+                    alert(
+                      "Stripe Connect onboarding placeholder – integration will hand off to Stripe Hosted onboarding in a later iteration."
+                    )
+                  }
+                >
+                  Launch Stripe flow
+                </button>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <label className="grid gap-1 text-sm">
+                  <span className="font-medium">KYC verification</span>
+                  <select
+                    className="input"
+                    value={newFranchise.onboarding.kycStatus}
+                    onChange={(event) =>
+                      updateNewOnboarding({ kycStatus: event.target.value as FranchiseOnboardingStatus })
+                    }
+                  >
+                    {ONBOARDING_STATUS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="text-xs text-gray-500">
+                    {ONBOARDING_STATUS_OPTIONS.find((option) => option.value === newFranchise.onboarding.kycStatus)?.description}
+                  </span>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="font-medium">Stripe Connect onboarding</span>
+                  <select
+                    className="input"
+                    value={newFranchise.onboarding.stripeAccountStatus}
+                    onChange={(event) =>
+                      updateNewOnboarding({
+                        stripeAccountStatus: event.target.value as FranchiseOnboardingStatus,
+                      })
+                    }
+                  >
+                    {ONBOARDING_STATUS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="text-xs text-gray-500">
+                    Mark as completed once Stripe confirms the account is onboarded.
+                  </span>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="font-medium">Bank details</span>
+                  <select
+                    className="input"
+                    value={newFranchise.onboarding.bankStatus}
+                    onChange={(event) =>
+                      updateNewOnboarding({ bankStatus: event.target.value as FranchiseOnboardingStatus })
+                    }
+                  >
+                    {ONBOARDING_STATUS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="font-medium">Legal documents</span>
+                  <select
+                    className="input"
+                    value={newFranchise.onboarding.legalStatus}
+                    onChange={(event) =>
+                      updateNewOnboarding({ legalStatus: event.target.value as FranchiseOnboardingStatus })
+                    }
+                  >
+                    {ONBOARDING_STATUS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={newFranchise.onboarding.chargesEnabled}
+                  onChange={(event) => updateNewOnboarding({ chargesEnabled: event.target.checked })}
+                />
+                <span>Stripe indicates charges are enabled for this account.</span>
+              </label>
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Onboarding notes</span>
+                <textarea
+                  className="input"
+                  rows={2}
+                  value={typeof newFranchise.onboarding.notes === "string" ? newFranchise.onboarding.notes : ""}
+                  onChange={(event) => updateNewOnboarding({ notes: event.target.value })}
+                  placeholder="KYC checklist, outstanding documents, etc."
+                />
+              </label>
+              <p className="text-xs text-amber-600">
+                A franchise should only move to <span className="font-medium">Active</span> once KYC and Stripe onboarding
+                are complete and charges are enabled.
+              </p>
+            </div>
             <label className="grid gap-1 text-sm">
               <span className="font-medium">Notes</span>
               <textarea
@@ -669,13 +851,14 @@ export default function AdminFranchisesPage() {
           </form>
         )}
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] text-sm border">
+          <table className="w-full min-w-[720px] text-sm border">
             <thead>
               <tr className="bg-gray-100 text-left">
                 <th className="p-2">Franchise</th>
                 <th className="p-2">Status</th>
                 <th className="p-2">Contact</th>
                 <th className="p-2">Stripe</th>
+                <th className="p-2">Onboarding</th>
                 <th className="p-2">Territories</th>
                 <th className="p-2">Members</th>
                 <th className="p-2">Actions</th>
@@ -684,7 +867,7 @@ export default function AdminFranchisesPage() {
             <tbody>
               {franchises.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="p-4 text-center text-gray-500">
+                  <td colSpan={8} className="p-4 text-center text-gray-500">
                     No franchises created yet.
                   </td>
                 </tr>
@@ -693,6 +876,17 @@ export default function AdminFranchisesPage() {
                   const territoryCount = territoryByFranchise.get(franchise.id)?.length ?? 0;
                   const memberCount = membersByFranchise.get(franchise.id)?.length ?? 0;
                   const editing = editingFranchiseId === franchise.id;
+                  const activationReady = canActivateFranchise(franchise.onboarding);
+                  const editingActivationReady = editing
+                    ? canActivateFranchise(editingFranchise.onboarding)
+                    : false;
+                  const pendingSteps = [
+                    franchise.onboarding.kycStatus === "completed" ? null : "KYC",
+                    franchise.onboarding.stripeAccountStatus === "completed" ? null : "Stripe",
+                    franchise.onboarding.bankStatus === "completed" ? null : "Bank",
+                    franchise.onboarding.legalStatus === "completed" ? null : "Legal",
+                    franchise.onboarding.chargesEnabled ? null : "Charges",
+                  ].filter(Boolean) as string[];
                   return (
                     <tr key={franchise.id} className="border-t align-top">
                       <td className="p-2 font-medium">
@@ -714,6 +908,31 @@ export default function AdminFranchisesPage() {
                         )}
                         {typeof franchise.platformFee === "number" && (
                           <div className="text-xs text-gray-500">Platform fee: {franchise.platformFee}%</div>
+                        )}
+                      </td>
+                      <td className="p-2 text-xs">
+                        <div>KYC: {onboardingStatusLabel(franchise.onboarding.kycStatus)}</div>
+                        <div>Stripe: {onboardingStatusLabel(franchise.onboarding.stripeAccountStatus)}</div>
+                        <div>Bank: {onboardingStatusLabel(franchise.onboarding.bankStatus)}</div>
+                        <div>Legal: {onboardingStatusLabel(franchise.onboarding.legalStatus)}</div>
+                        <div>Charges: {franchise.onboarding.chargesEnabled ? "Enabled" : "Pending"}</div>
+                        {activationReady ? (
+                          <div className="mt-1 text-[10px] font-medium uppercase tracking-wide text-emerald-600">
+                            Ready to activate
+                          </div>
+                        ) : (
+                          <>
+                            {pendingSteps.length > 0 && (
+                              <div className="mt-1 text-[10px] tracking-wide text-amber-600">
+                                Awaiting: {pendingSteps.join(", ")}
+                              </div>
+                            )}
+                            {franchise.status === "active" && (
+                              <div className="mt-1 text-[10px] font-medium uppercase tracking-wide text-red-600">
+                                Review onboarding blockers
+                              </div>
+                            )}
+                          </>
                         )}
                       </td>
                       <td className="p-2">{territoryCount}</td>
@@ -826,6 +1045,129 @@ export default function AdminFranchisesPage() {
                                 }
                               />
                             </label>
+                            <div className="grid gap-2 rounded border border-dashed border-gray-200 p-2">
+                              <div className="flex items-center justify-between">
+                                <span className="text-[11px] font-semibold uppercase tracking-wide">Onboarding</span>
+                                <button
+                                  type="button"
+                                  className="btn btn-xs"
+                                  onClick={() =>
+                                    alert(
+                                      "Stripe Connect onboarding placeholder – integration will hand off to Stripe Hosted onboarding in a later iteration."
+                                    )
+                                  }
+                                >
+                                  Launch Stripe flow
+                                </button>
+                              </div>
+                              <div className="grid gap-2">
+                                <label className="grid gap-1 text-xs">
+                                  <span className="font-medium">KYC verification</span>
+                                  <select
+                                    className="input"
+                                    value={editingFranchise.onboarding.kycStatus}
+                                    onChange={(event) =>
+                                      updateEditingOnboarding({
+                                        kycStatus: event.target.value as FranchiseOnboardingStatus,
+                                      })
+                                    }
+                                  >
+                                    {ONBOARDING_STATUS_OPTIONS.map((option) => (
+                                      <option key={option.value} value={option.value}>
+                                        {option.label}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </label>
+                                <label className="grid gap-1 text-xs">
+                                  <span className="font-medium">Stripe Connect</span>
+                                  <select
+                                    className="input"
+                                    value={editingFranchise.onboarding.stripeAccountStatus}
+                                    onChange={(event) =>
+                                      updateEditingOnboarding({
+                                        stripeAccountStatus: event.target.value as FranchiseOnboardingStatus,
+                                      })
+                                    }
+                                  >
+                                    {ONBOARDING_STATUS_OPTIONS.map((option) => (
+                                      <option key={option.value} value={option.value}>
+                                        {option.label}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </label>
+                                <label className="grid gap-1 text-xs">
+                                  <span className="font-medium">Bank details</span>
+                                  <select
+                                    className="input"
+                                    value={editingFranchise.onboarding.bankStatus}
+                                    onChange={(event) =>
+                                      updateEditingOnboarding({
+                                        bankStatus: event.target.value as FranchiseOnboardingStatus,
+                                      })
+                                    }
+                                  >
+                                    {ONBOARDING_STATUS_OPTIONS.map((option) => (
+                                      <option key={option.value} value={option.value}>
+                                        {option.label}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </label>
+                                <label className="grid gap-1 text-xs">
+                                  <span className="font-medium">Legal documents</span>
+                                  <select
+                                    className="input"
+                                    value={editingFranchise.onboarding.legalStatus}
+                                    onChange={(event) =>
+                                      updateEditingOnboarding({
+                                        legalStatus: event.target.value as FranchiseOnboardingStatus,
+                                      })
+                                    }
+                                  >
+                                    {ONBOARDING_STATUS_OPTIONS.map((option) => (
+                                      <option key={option.value} value={option.value}>
+                                        {option.label}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </label>
+                                <label className="flex items-center gap-2 text-xs">
+                                  <input
+                                    type="checkbox"
+                                    className="h-3.5 w-3.5"
+                                    checked={editingFranchise.onboarding.chargesEnabled}
+                                    onChange={(event) => updateEditingOnboarding({ chargesEnabled: event.target.checked })}
+                                  />
+                                  <span>Charges enabled</span>
+                                </label>
+                                <label className="grid gap-1 text-xs">
+                                  <span className="font-medium">Onboarding notes</span>
+                                  <textarea
+                                    className="input"
+                                    rows={2}
+                                    value={
+                                      typeof editingFranchise.onboarding.notes === "string"
+                                        ? editingFranchise.onboarding.notes
+                                        : ""
+                                    }
+                                    onChange={(event) => updateEditingOnboarding({ notes: event.target.value })}
+                                  />
+                                </label>
+                                <div className="rounded bg-gray-100 p-2 text-[11px] text-gray-600">
+                                  <div>
+                                    Activation readiness: {editingActivationReady ? "✅ Ready" : "🚧 Incomplete"}
+                                  </div>
+                                  {!editingActivationReady && (
+                                    <div className="mt-1">
+                                      Ensure KYC + Stripe Connect are approved and charges are enabled before setting the
+                                      status to Active.
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
+                            </div>
                             <label className="grid gap-1 text-xs">
                               <span className="font-medium">Notes</span>
                               <textarea

--- a/apps/web/app/admin/franchises/page.tsx
+++ b/apps/web/app/admin/franchises/page.tsx
@@ -1,0 +1,7 @@
+import ClientPage from './ClientPage';
+
+export const metadata = { title: 'Franchise Management | Pineapple Tapped' };
+
+export default function Page() {
+  return <ClientPage />;
+}

--- a/apps/web/app/admin/orders/ClientPage.tsx
+++ b/apps/web/app/admin/orders/ClientPage.tsx
@@ -284,6 +284,28 @@ export default function AdminOrdersPage() {
                 assignment?.inputPostalCode ||
                 assignment?.normalizedPostalCode ||
                 null;
+              const royalty = (o.royalty as any) || null;
+              const royaltySource =
+                (royalty?.source as string | undefined) ||
+                (o.royaltySource as string | undefined) ||
+                (o.leadSource as string | undefined) ||
+                'hq';
+              const royaltyLabel = royaltySource === 'franchisee' ? 'Franchise-sourced' : 'HQ-sourced';
+              const royaltyPercentage =
+                typeof royalty?.percentage === 'number'
+                  ? royalty.percentage
+                  : typeof o.royaltyPercentage === 'number'
+                    ? o.royaltyPercentage
+                    : null;
+              const royaltyOrderIndex =
+                typeof royalty?.orderIndex === 'number'
+                  ? royalty.orderIndex
+                  : typeof o.clientRoyaltyOrderIndex === 'number'
+                    ? o.clientRoyaltyOrderIndex
+                    : null;
+              const royaltyTier = royalty?.tier as
+                | { minOrder?: number | null; maxOrder?: number | null }
+                | undefined;
               return (
                 <tr key={o.id} className="border-t">
                   <td className="p-2">{o.id}</td>
@@ -346,6 +368,17 @@ export default function AdminOrdersPage() {
                       <div className="text-[10px] uppercase text-gray-400">
                         {assignmentStatus}
                         {assignmentMatchType ? ` · ${assignmentMatchType}` : ""}
+                      </div>
+                    )}
+                    {(royaltyPercentage !== null || royaltyOrderIndex !== null) && (
+                      <div className="mt-2 text-xs text-gray-500">
+                        Royalty: {royaltyPercentage !== null ? `${royaltyPercentage}%` : '—'} · {royaltyLabel}
+                        {royaltyOrderIndex ? ` · order #${royaltyOrderIndex}` : ''}
+                        {royaltyTier?.minOrder
+                          ? royaltyTier.maxOrder != null
+                            ? ` · tier ${royaltyTier.minOrder}-${royaltyTier.maxOrder}`
+                            : ` · tier ${royaltyTier.minOrder}+`
+                          : ''}
                       </div>
                     )}
                   </td>

--- a/apps/web/app/admin/orders/ClientPage.tsx
+++ b/apps/web/app/admin/orders/ClientPage.tsx
@@ -19,6 +19,9 @@ import { useRoleGate } from "@/hooks/useRoleGate";
 export default function AdminOrdersPage() {
   const { allowed, loading: guardLoading } = useRoleGate(["admin", "operations"]);
   const [orders, setOrders] = useState<any[]>([]);
+  const [franchiseMap, setFranchiseMap] = useState<
+    Record<string, { name?: string | null; code?: string | null }>
+  >({});
   const [statusFilter, setStatusFilter] = useState("all");
   const [emailFilter, setEmailFilter] = useState("");
   const [startDate, setStartDate] = useState("");
@@ -87,20 +90,66 @@ export default function AdminOrdersPage() {
       return;
     }
     (async () => {
-      const orderSnap = await getDocs(
-        query(collection(db, "orders"), orderBy("createdAt", "desc"))
-      );
-      const raw = orderSnap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
-      const ids = Array.from(new Set(raw.map((o) => o.userId).filter(Boolean)));
-      const userMap: Record<string, any> = {};
-      await Promise.all(
-        ids.map(async (uid) => {
-          const uSnap = await getDoc(doc(db, "users", uid));
-          if (uSnap.exists()) userMap[uid] = uSnap.data();
-        })
-      );
-      setOrders(raw.map((o) => ({ ...o, user: userMap[o.userId] })));
-      setLoading(false);
+      try {
+        const orderSnap = await getDocs(
+          query(collection(db, "orders"), orderBy("createdAt", "desc"))
+        );
+        const raw = orderSnap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
+        const ids = Array.from(
+          new Set(raw.map((o) => o.userId).filter((value): value is string => Boolean(value)))
+        );
+        const userMap: Record<string, any> = {};
+        await Promise.all(
+          ids.map(async (uid) => {
+            try {
+              const uSnap = await getDoc(doc(db, "users", uid));
+              if (uSnap.exists()) userMap[uid] = uSnap.data();
+            } catch (err) {
+              console.warn("Failed to load user", uid, err);
+            }
+          })
+        );
+
+        const franchiseIds = new Set<string>();
+        raw.forEach((order) => {
+          if (order.franchiseId) franchiseIds.add(order.franchiseId as string);
+          const assignmentFranchiseId = (order.franchiseAssignment as any)?.franchiseId;
+          if (assignmentFranchiseId) {
+            franchiseIds.add(String(assignmentFranchiseId));
+          }
+        });
+
+        const franchiseData: Record<string, { name?: string | null; code?: string | null }> = {};
+        if (franchiseIds.size > 0) {
+          await Promise.all(
+            Array.from(franchiseIds).map(async (franchiseId) => {
+              try {
+                const snap = await getDoc(doc(db, "franchises", franchiseId));
+                if (snap.exists()) {
+                  const data = snap.data() as any;
+                  franchiseData[franchiseId] = {
+                    name: (data?.name as string) || null,
+                    code: (data?.code as string) || null,
+                  };
+                }
+              } catch (franchiseErr) {
+                console.warn(
+                  "Failed to load franchise details",
+                  franchiseId,
+                  franchiseErr
+                );
+              }
+            })
+          );
+        }
+
+        setFranchiseMap(franchiseData);
+        setOrders(raw.map((o) => ({ ...o, user: userMap[o.userId] })));
+      } catch (err) {
+        console.error("Failed to load orders", err);
+      } finally {
+        setLoading(false);
+      }
     })();
   }, [allowed, guardLoading]);
 
@@ -185,6 +234,7 @@ export default function AdminOrdersPage() {
               <th className="p-2">ID</th>
               <th className="p-2">Customer</th>
               <th className="p-2">Status</th>
+              <th className="p-2">Franchise Routing</th>
               <th className="p-2">Created</th>
               <th className="p-2">Project</th>
               <th className="p-2">Actions</th>
@@ -198,6 +248,42 @@ export default function AdminOrdersPage() {
                 o.user?.email ||
                 "-";
               const company = o.companyName || o.user?.companyName;
+              const assignment = o.franchiseAssignment as
+                | {
+                    status?: string;
+                    matchType?: string;
+                    franchiseId?: string;
+                    territoryLabel?: string;
+                    territoryPostalCode?: string;
+                    normalizedPostalCode?: string;
+                    inputPostalCode?: string;
+                  }
+                | null;
+              const assignmentStatus = assignment?.status || null;
+              const assignmentMatchType = assignment?.matchType || null;
+              const franchiseId =
+                (o.franchiseId as string | undefined) ||
+                (assignment?.franchiseId as string | undefined) ||
+                null;
+              const franchiseDetails = franchiseId
+                ? franchiseMap[franchiseId]
+                : undefined;
+              const franchiseName =
+                franchiseDetails?.name ||
+                franchiseDetails?.code ||
+                franchiseId ||
+                null;
+              const territoryLabel =
+                assignment?.territoryLabel || assignment?.territoryPostalCode || null;
+              const assignedOperator =
+                (o.franchiseAssignedUser?.displayName as string | undefined) ||
+                (o.franchiseAssignedUser?.email as string | undefined) ||
+                null;
+              const inputPostalCode =
+                (o.clientPostalCode as string | undefined) ||
+                assignment?.inputPostalCode ||
+                assignment?.normalizedPostalCode ||
+                null;
               return (
                 <tr key={o.id} className="border-t">
                   <td className="p-2">{o.id}</td>
@@ -217,40 +303,74 @@ export default function AdminOrdersPage() {
                     )}
                   </td>
                   <td className="p-2">
-                  <select
-                    className="input capitalize"
-                    value={o.status || "pending"}
-                    onChange={(e) => handleStatusChange(o, e.target.value)}
-                  >
-                    {statusOptions.map((s) => (
-                      <option key={s} value={s}>
-                        {s}
-                      </option>
-                    ))}
-                  </select>
-                </td>
-                <td className="p-2">
-                  {o.createdAt?.toDate
-                    ? o.createdAt.toDate().toLocaleDateString()
-                    : "-"}
-                </td>
-                <td className="p-2">
-                  {o.projectId ? (
-                    <Link
-                      href={`/projects/${o.projectId}`}
-                      className="text-orange underline"
+                    <select
+                      className="input capitalize"
+                      value={o.status || "pending"}
+                      onChange={(e) => handleStatusChange(o, e.target.value)}
                     >
-                      View
+                      {statusOptions.map((s) => (
+                        <option key={s} value={s}>
+                          {s}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className="p-2 align-top">
+                    {franchiseName ? (
+                      <div>
+                        <div className="font-medium">{franchiseName}</div>
+                        {territoryLabel && (
+                          <div className="text-xs text-gray-500">
+                            Territory: {territoryLabel}
+                          </div>
+                        )}
+                        {assignedOperator && (
+                          <div className="text-xs text-gray-500">
+                            Operator: {assignedOperator}
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="text-xs text-gray-500">
+                        {assignmentStatus === "unmatched"
+                          ? "No territory match"
+                          : "Not routed"}
+                      </div>
+                    )}
+                    {inputPostalCode && (
+                      <div className="text-[10px] uppercase text-gray-400 mt-1">
+                        Postcode: {inputPostalCode}
+                      </div>
+                    )}
+                    {assignmentStatus && (
+                      <div className="text-[10px] uppercase text-gray-400">
+                        {assignmentStatus}
+                        {assignmentMatchType ? ` · ${assignmentMatchType}` : ""}
+                      </div>
+                    )}
+                  </td>
+                  <td className="p-2">
+                    {o.createdAt?.toDate
+                      ? o.createdAt.toDate().toLocaleDateString()
+                      : "-"}
+                  </td>
+                  <td className="p-2">
+                    {o.projectId ? (
+                      <Link
+                        href={`/projects/${o.projectId}`}
+                        className="text-orange underline"
+                      >
+                        View
+                      </Link>
+                    ) : (
+                      "-"
+                    )}
+                  </td>
+                  <td className="p-2">
+                    <Link href={`/orders/${o.id}`} className="btn-sm">
+                      Open
                     </Link>
-                  ) : (
-                    "-"
-                  )}
-                </td>
-                <td className="p-2">
-                  <Link href={`/orders/${o.id}`} className="btn-sm">
-                    Open
-                  </Link>
-                </td>
+                  </td>
                 </tr>
               );
             })}

--- a/apps/web/app/admin/projects/ClientPage.tsx
+++ b/apps/web/app/admin/projects/ClientPage.tsx
@@ -14,6 +14,12 @@ interface StaffOption {
   email?: string | null;
 }
 
+interface FranchiseOption {
+  id: string;
+  name: string;
+  code?: string | null;
+}
+
 type ProjectPriority = 'low' | 'medium' | 'high' | '';
 
 interface ProjectRecord {
@@ -28,6 +34,23 @@ interface ProjectRecord {
   kickoffDate?: Timestamp | Date | null;
   dueDate?: Timestamp | Date | null;
   priority?: ProjectPriority | string | null;
+  franchiseId?: string | null;
+  franchiseTerritoryId?: string | null;
+  franchiseAssignment?: {
+    territoryLabel?: string | null;
+    territoryPostalCode?: string | null;
+    [key: string]: any;
+  } | null;
+  franchiseAssignedUserId?: string | null;
+  franchiseAssignedMemberId?: string | null;
+  franchiseAssignedRole?: string | null;
+  franchiseAssignedIsPrimary?: boolean | null;
+  franchiseAssignedUser?: {
+    displayName?: string | null;
+    email?: string | null;
+    [key: string]: any;
+  } | null;
+  clientPostalCode?: string | null;
   [key: string]: any;
 }
 
@@ -84,11 +107,13 @@ export default function AdminProjectsPage() {
   const { allowed, loading: guardLoading } = useRoleGate(['admin', 'projects']);
   const [projects, setProjects] = useState<ProjectRecord[]>([]);
   const [staff, setStaff] = useState<StaffOption[]>([]);
+  const [franchises, setFranchises] = useState<FranchiseOption[]>([]);
   const [view, setView] = useState<'kanban' | 'list'>('kanban');
   const [filter, setFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [ownerFilter, setOwnerFilter] = useState('');
   const [dueFilter, setDueFilter] = useState<'all' | 'overdue' | 'week' | 'month' | 'none'>('all');
+  const [franchiseFilter, setFranchiseFilter] = useState<'all' | '__unassigned' | string>('all');
   const [groupBy, setGroupBy] = useState<'status' | 'owner' | 'due'>('status');
 
   useEffect(() => {
@@ -163,9 +188,48 @@ export default function AdminProjectsPage() {
     };
   }, []);
 
+  useEffect(() => {
+    let active = true;
+
+    (async () => {
+      if (guardLoading || !allowed) return;
+      try {
+        const { db } = await ensureFirebase();
+        if (!db) {
+          throw new Error('Firestore is unavailable');
+        }
+        const snap = await getDocs(collection(db, 'franchises'));
+        if (!active) return;
+        const items = snap.docs
+          .map((doc) => {
+            const data = doc.data() as Record<string, any>;
+            const rawName = typeof data.name === 'string' ? data.name.trim() : '';
+            const rawCode = typeof data.code === 'string' ? data.code.trim() : '';
+            return {
+              id: doc.id,
+              name: rawName || rawCode || doc.id,
+              code: rawCode || null,
+            } satisfies FranchiseOption;
+          })
+          .sort((a, b) => a.name.localeCompare(b.name));
+        setFranchises(items);
+      } catch (err) {
+        console.error('Failed to load franchises', err);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [allowed, guardLoading]);
+
   const staffMap = useMemo(() => {
     return new Map(staff.map((member) => [member.uid, member] as const));
   }, [staff]);
+
+  const franchiseMap = useMemo(() => {
+    return new Map(franchises.map((franchise) => [franchise.id, franchise] as const));
+  }, [franchises]);
 
   const resolveDb = useCallback(async () => {
     const { db } = await ensureFirebase();
@@ -236,6 +300,28 @@ export default function AdminProjectsPage() {
     [updateProject]
   );
 
+  const resolveFranchiseContext = useCallback(
+    (project: ProjectRecord) => {
+      const franchise = project.franchiseId ? franchiseMap.get(project.franchiseId) : undefined;
+      const assignment = project.franchiseAssignment || null;
+      const territoryLabel =
+        assignment && typeof assignment === 'object'
+          ? (assignment.territoryLabel as string | undefined) ||
+            (assignment.territoryPostalCode as string | undefined) ||
+            null
+          : null;
+      const operator =
+        (project.franchiseAssignedUser && typeof project.franchiseAssignedUser === 'object'
+          ? (project.franchiseAssignedUser.displayName as string | undefined) ||
+            (project.franchiseAssignedUser.email as string | undefined)
+          : null) ||
+        (typeof project.franchiseAssignedUserId === 'string' ? project.franchiseAssignedUserId : null);
+      const franchiseLabel = franchise?.name || (project.franchiseId ? String(project.franchiseId) : null);
+      return { franchise, franchiseLabel, territoryLabel, operator };
+    },
+    [franchiseMap]
+  );
+
   const resolveDueBucket = useCallback((project: ProjectRecord) => {
     const due = coerceDate(project.dueDate);
     const today = new Date();
@@ -284,9 +370,15 @@ export default function AdminProjectsPage() {
           matchesDue = bucket === 'week' || bucket === 'month';
         }
       }
-      return matchesText && matchesStatus && matchesOwner && matchesDue;
+      const matchesFranchise =
+        franchiseFilter === 'all'
+          ? true
+          : franchiseFilter === '__unassigned'
+            ? !project.franchiseId
+            : project.franchiseId === franchiseFilter;
+      return matchesText && matchesStatus && matchesOwner && matchesDue && matchesFranchise;
     });
-  }, [projects, filter, statusFilter, ownerFilter, dueFilter, resolveDueBucket]);
+  }, [projects, filter, statusFilter, ownerFilter, dueFilter, resolveDueBucket, franchiseFilter]);
 
   const groupedColumns = useMemo(() => {
     if (groupBy === 'owner') {
@@ -384,6 +476,19 @@ export default function AdminProjectsPage() {
           ))}
         </select>
         <select
+          value={franchiseFilter}
+          onChange={(e) => setFranchiseFilter(e.target.value)}
+          className="input max-w-xs"
+        >
+          <option value="all">All franchises</option>
+          <option value="__unassigned">Unassigned</option>
+          {franchises.map((franchise) => (
+            <option key={franchise.id} value={franchise.id}>
+              {franchise.name}
+            </option>
+          ))}
+        </select>
+        <select
           value={dueFilter}
           onChange={(e) => setDueFilter(e.target.value as typeof dueFilter)}
           className="input max-w-xs"
@@ -419,6 +524,7 @@ export default function AdminProjectsPage() {
               <tr className="bg-gray-100 text-left">
                 <th className="p-2">Title</th>
                 <th className="p-2">Client</th>
+                <th className="p-2">Franchise</th>
                 <th className="p-2">Assignee</th>
                 <th className="p-2">Kickoff</th>
                 <th className="p-2">Due</th>
@@ -433,6 +539,25 @@ export default function AdminProjectsPage() {
                 <tr key={p.id} className="border-t">
                   <td className="p-2 align-top">{p.title || 'Untitled'}</td>
                   <td className="p-2 align-top">{p.userEmail || '-'}</td>
+                  <td className="p-2 align-top">
+                    {(() => {
+                      const { franchiseLabel, territoryLabel, operator } = resolveFranchiseContext(p);
+                      if (!franchiseLabel) {
+                        return <span className="text-xs text-gray-500">Unassigned</span>;
+                      }
+                      return (
+                        <div className="grid gap-1">
+                          <span className="font-medium text-sm">{franchiseLabel}</span>
+                          {territoryLabel && (
+                            <span className="text-xs text-gray-500">Territory: {territoryLabel}</span>
+                          )}
+                          {operator && (
+                            <span className="text-xs text-gray-500">Operator: {operator}</span>
+                          )}
+                        </div>
+                      );
+                    })()}
+                  </td>
                   <td className="p-2 align-top">
                     <select
                       value={p.ownerUid || ''}
@@ -550,6 +675,18 @@ export default function AdminProjectsPage() {
                           {formatDateDisplay(project.dueDate)}
                         </span>
                       </div>
+                      {(() => {
+                        const { franchiseLabel, territoryLabel, operator } = resolveFranchiseContext(project);
+                        return (
+                          <div className="grid gap-1 text-xs text-gray-600">
+                            <span className={franchiseLabel ? 'font-medium text-gray-700' : 'text-gray-400'}>
+                              Franchise: {franchiseLabel || 'Unassigned'}
+                            </span>
+                            {territoryLabel && <span>Territory: {territoryLabel}</span>}
+                            {operator && <span>Operator: {operator}</span>}
+                          </div>
+                        );
+                      })()}
                       <div className="flex flex-wrap gap-2 text-xs text-gray-600">
                         {project.ownerUid && staffMap.get(project.ownerUid)?.label && (
                           <span className="rounded-full bg-gray-100 px-2 py-1">

--- a/apps/web/app/checkout/page.tsx
+++ b/apps/web/app/checkout/page.tsx
@@ -74,6 +74,7 @@ export default function CheckoutPage() {
       postalCode: postalCode || null,
       projectName: projectName || null,
       voucher: voucher || null,
+      leadSource: "hq" as const,
     };
   }, [
     items,

--- a/apps/web/app/checkout/page.tsx
+++ b/apps/web/app/checkout/page.tsx
@@ -42,6 +42,7 @@ export default function CheckoutPage() {
   const [name, setName] = useState("");
   const [company, setCompany] = useState("");
   const [location, setLocation] = useState("");
+  const [postalCode, setPostalCode] = useState("");
   const [projectName, setProjectName] = useState("");
   const [voucher, setVoucher] = useState("");
   const [currentUser, setCurrentUser] = useState<User | null>(null);
@@ -70,6 +71,7 @@ export default function CheckoutPage() {
       customerName: name,
       companyName: company || null,
       location: location || null,
+      postalCode: postalCode || null,
       projectName: projectName || null,
       voucher: voucher || null,
     };
@@ -81,6 +83,7 @@ export default function CheckoutPage() {
     name,
     company,
     location,
+    postalCode,
     projectName,
     voucher,
   ]);
@@ -228,6 +231,10 @@ export default function CheckoutPage() {
     }
     if (!orderInput.customerName) {
       setPaymentError("Please enter your name before continuing.");
+      return false;
+    }
+    if (!orderInput.postalCode) {
+      setPaymentError("Please provide a postcode for the shoot location.");
       return false;
     }
     if (!stripePromise) {
@@ -379,6 +386,13 @@ export default function CheckoutPage() {
             placeholder="Shooting Location"
             value={location}
             onChange={(e) => setLocation(e.target.value)}
+          />
+          <input
+            className="input input-bordered w-full"
+            placeholder="Postcode"
+            value={postalCode}
+            onChange={(e) => setPostalCode(e.target.value.toUpperCase())}
+            required
           />
           <input
             className="input input-bordered w-full"

--- a/apps/web/app/projects/[id]/tasks/page.tsx
+++ b/apps/web/app/projects/[id]/tasks/page.tsx
@@ -1,10 +1,62 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { auth, db } from '@/lib/firebase';
+import { auth, db, ensureFirebase, functions, httpsCallable } from '@/lib/firebase';
 import { collection, getDoc, doc, getDocs, addDoc, updateDoc, serverTimestamp, query, where, orderBy } from 'firebase/firestore';
 import { extractUserRoles, hasRole } from '@/lib/roles';
+
+type PaymentMode = 'deposit_balance' | 'balance_on_completion';
+
+interface OfferFormState {
+  role: string;
+  targetType: 'hq' | 'franchise';
+  targetFranchiseId: string;
+  targetUserId: string;
+  totalAmount: string;
+  depositAmount: string;
+  paymentMode: PaymentMode;
+  currency: string;
+  notes: string;
+}
+
+interface CounterFormState {
+  taskId: string | null;
+  totalAmount: string;
+  depositAmount: string;
+  paymentMode: PaymentMode;
+  currency: string;
+  notes: string;
+}
+
+interface UserContextState {
+  uid: string | null;
+  franchiseIds: string[];
+  canManage: boolean;
+  canOutsource: boolean;
+  isHq: boolean;
+}
+
+const OFFER_FORM_DEFAULTS: OfferFormState = {
+  role: '',
+  targetType: 'hq',
+  targetFranchiseId: '',
+  targetUserId: '',
+  totalAmount: '',
+  depositAmount: '',
+  paymentMode: 'deposit_balance',
+  currency: 'GBP',
+  notes: '',
+};
+
+const COUNTER_FORM_DEFAULTS: CounterFormState = {
+  taskId: null,
+  totalAmount: '',
+  depositAmount: '',
+  paymentMode: 'deposit_balance',
+  currency: 'GBP',
+  notes: '',
+};
 
 /**
  * Project Tasks Board
@@ -25,55 +77,206 @@ export default function ProjectTasksPage() {
   const [assignedTo, setAssignedTo] = useState('');
   const [members, setMembers] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [franchises, setFranchises] = useState<any[]>([]);
+  const [userContext, setUserContext] = useState<UserContextState>({
+    uid: null,
+    franchiseIds: [],
+    canManage: false,
+    canOutsource: false,
+    isHq: false,
+  });
+  const [activeOfferTaskId, setActiveOfferTaskId] = useState<string | null>(null);
+  const [offerForm, setOfferForm] = useState<OfferFormState>({ ...OFFER_FORM_DEFAULTS });
+  const [offerSubmitting, setOfferSubmitting] = useState(false);
+  const [actionState, setActionState] = useState<string | null>(null);
+  const [counterState, setCounterState] = useState<CounterFormState>({ ...COUNTER_FORM_DEFAULTS });
+
+  const franchiseMap = useMemo(() => {
+    const map = new Map<string, any>();
+    franchises.forEach((item) => {
+      if (item?.id) {
+        map.set(item.id, item);
+      }
+    });
+    return map;
+  }, [franchises]);
+
+  const formatCurrency = useCallback((value: unknown, currency?: string | null) => {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(numeric)) {
+      return '';
+    }
+    const safeCurrency = currency && typeof currency === 'string' ? currency : 'GBP';
+    try {
+      return new Intl.NumberFormat(undefined, { style: 'currency', currency: safeCurrency }).format(numeric);
+    } catch (err) {
+      console.warn('Unable to format currency', err);
+      return `${safeCurrency} ${numeric.toFixed(2)}`;
+    }
+  }, []);
+
+  const formatMoney = useCallback(
+    (amount: unknown, currency?: string | null) => {
+      const formatted = formatCurrency(amount, currency);
+      if (formatted) {
+        return formatted;
+      }
+      if (typeof amount === 'number' && Number.isFinite(amount)) {
+        return `${currency || 'GBP'} ${amount.toFixed(2)}`;
+      }
+      if (typeof amount === 'string' && amount.trim()) {
+        return `${currency || 'GBP'} ${amount.trim()}`;
+      }
+      return '';
+    },
+    [formatCurrency]
+  );
+
+  const reloadTasks = useCallback(async () => {
+    if (!projectId) return;
+    const tSnap = await getDocs(
+      query(collection(db, 'projects', projectId, 'tasks'), orderBy('createdAt', 'desc'))
+    );
+    setTasks(tSnap.docs.map((d) => ({ id: d.id, ...d.data() })));
+  }, [projectId]);
+
+  const primaryActionClasses =
+    'rounded bg-emerald-600 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50';
+  const dangerActionClasses =
+    'rounded bg-rose-600 px-3 py-1 text-xs font-semibold text-white hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50';
+  const secondaryActionClasses =
+    'rounded border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50';
 
   // Load project and tasks
   useEffect(() => {
+    let active = true;
     (async () => {
       if (!projectId) return;
-      const pDoc = await getDoc(doc(db, 'projects', projectId));
-      if (!pDoc.exists()) { setProject(null); setLoading(false); return; }
-      const proj = pDoc.data() as any;
-      setProject(proj);
-      // Determine if user is staff or client_admin of the org
-      const user = auth.currentUser;
-      if (!user) { setIsStaffOrAdmin(false); } else {
-        const uSnap = await getDoc(doc(db, 'users', user.uid));
-        const me = uSnap.data() as any;
-        const roles = extractUserRoles(me);
-        let canEdit = hasRole(roles, ['admin', 'projects']);
-        // Check membership role
-        const memDoc = await getDoc(doc(db, 'memberships', proj.orgId + '_' + user.uid));
-        if (memDoc.exists()) {
-          const mem = memDoc.data() as any;
-          if (mem.role === 'client_admin') canEdit = true;
+      try {
+        const projectSnap = await getDoc(doc(db, 'projects', projectId));
+        if (!active) return;
+        if (!projectSnap.exists()) {
+          setProject(null);
+          setTasks([]);
+          setMembers([]);
+          setIsStaffOrAdmin(false);
+          setUserContext({ uid: null, franchiseIds: [], canManage: false, canOutsource: false, isHq: false });
+          setLoading(false);
+          return;
         }
-        setIsStaffOrAdmin(canEdit);
+
+        const proj = projectSnap.data() as any;
+        setProject(proj);
+
+        const user = auth.currentUser;
+        if (!user) {
+          setIsStaffOrAdmin(false);
+          setUserContext({ uid: null, franchiseIds: [], canManage: false, canOutsource: false, isHq: false });
+        } else {
+          const userSnap = await getDoc(doc(db, 'users', user.uid));
+          if (!active) return;
+          const me = userSnap.data() as any;
+          const roles = extractUserRoles(me);
+          let canEdit = hasRole(roles, ['admin', 'projects']);
+          if (proj?.orgId) {
+            const membershipSnap = await getDoc(doc(db, 'memberships', `${proj.orgId}_${user.uid}`));
+            if (!active) return;
+            if (membershipSnap.exists()) {
+              const membership = membershipSnap.data() as any;
+              if (membership?.role === 'client_admin') {
+                canEdit = true;
+              }
+            }
+          }
+          setIsStaffOrAdmin(canEdit);
+          const franchiseIds = new Set<string>();
+          if (typeof me?.primaryFranchiseId === 'string' && me.primaryFranchiseId.trim()) {
+            franchiseIds.add(me.primaryFranchiseId.trim());
+          }
+          if (typeof me?.franchiseId === 'string' && me.franchiseId.trim()) {
+            franchiseIds.add(me.franchiseId.trim());
+          }
+          if (Array.isArray(me?.franchiseIds)) {
+            me.franchiseIds.forEach((value: unknown) => {
+              if (typeof value === 'string' && value.trim()) {
+                franchiseIds.add(value.trim());
+              }
+            });
+          }
+          setUserContext({
+            uid: user.uid,
+            franchiseIds: Array.from(franchiseIds),
+            canManage: canEdit,
+            canOutsource: canEdit || franchiseIds.size > 0,
+            isHq: canEdit,
+          });
+        }
+
+        await reloadTasks();
+        if (!active) return;
+
+        if (proj?.orgId) {
+          const memSnap = await getDocs(query(collection(db, 'memberships'), where('orgId', '==', proj.orgId)));
+          if (!active) return;
+          const mems = memSnap.docs.map((d) => d.data() as any);
+          const userSnaps = await Promise.all(mems.map((m) => getDoc(doc(db, 'users', m.userId))));
+          if (!active) return;
+          setMembers(
+            mems.map((m, i) => {
+              const userSnap = userSnaps[i];
+              const data = userSnap.data() as any;
+              return {
+                uid: m.userId,
+                name: data?.displayName || data?.email || 'Unnamed',
+              };
+            })
+          );
+        } else {
+          setMembers([]);
+        }
+      } catch (err) {
+        console.error('Failed to load project tasks', err);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
       }
-      // Load tasks
-      const tSnap = await getDocs(
-        query(collection(db, 'projects', projectId, 'tasks'), orderBy('createdAt', 'desc'))
-      );
-      setTasks(tSnap.docs.map((d) => ({ id: d.id, ...d.data() })));
-      // Load members for assignment
-      const memSnap = await getDocs(query(collection(db, 'memberships'), where('orgId', '==', proj.orgId)));
-      const mems = memSnap.docs.map((d) => d.data() as any);
-      const userSnaps = await Promise.all(mems.map((m) => getDoc(doc(db, 'users', m.userId))));
-      setMembers(
-        mems.map((m, i) => {
-          const u = userSnaps[i];
-          const data = u.data() as any;
-          return {
-            uid: m.userId,
-            name: data?.displayName || data?.email || 'Unnamed',
-          };
-        })
-      );
-      setLoading(false);
     })();
-  }, [projectId]);
+
+    return () => {
+      active = false;
+    };
+  }, [projectId, reloadTasks]);
+
+  useEffect(() => {
+    if (!projectId || !userContext.canOutsource) return;
+    let active = true;
+    (async () => {
+      try {
+        const snap = await getDocs(collection(db, 'franchises'));
+        if (!active) return;
+        const items = snap.docs.map((docSnap) => {
+          const data = docSnap.data() as any;
+          return {
+            id: docSnap.id,
+            name: data?.name || docSnap.id,
+            code: data?.code || null,
+          };
+        });
+        setFranchises(items);
+      } catch (err) {
+        console.error('Failed to load franchises', err);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [projectId, userContext.canOutsource]);
 
   const addTask = async () => {
     if (!title.trim()) { alert('Task title is required'); return; }
+    if (!projectId) { alert('Project is unavailable.'); return; }
     try {
       // Create the task doc
       const taskRef = await addDoc(collection(db, 'projects', projectId, 'tasks'), {
@@ -96,11 +299,11 @@ export default function ProjectTasksPage() {
         uid: user ? user.uid : null,
         createdAt: serverTimestamp(),
       });
-      const snap = await getDocs(
-        query(collection(db, 'projects', projectId, 'tasks'), orderBy('createdAt', 'desc'))
-      );
-      setTasks(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
-      setTitle(''); setDescription(''); setDueDate(''); setAssignedTo('');
+      await reloadTasks();
+      setTitle('');
+      setDescription('');
+      setDueDate('');
+      setAssignedTo('');
     } catch (err: any) {
       console.error(err);
       alert(err.message || 'Error creating task');
@@ -108,6 +311,7 @@ export default function ProjectTasksPage() {
   };
 
   const updateTaskStatus = async (taskId: string, newStatus: string) => {
+    if (!projectId) { alert('Project is unavailable.'); return; }
     try {
       // Read current status to record history
       const current = tasks.find((t) => t.id === taskId);
@@ -124,7 +328,7 @@ export default function ProjectTasksPage() {
         uid: user ? user.uid : null,
         createdAt: serverTimestamp(),
       });
-      setTasks(tasks.map((t) => t.id === taskId ? { ...t, status: newStatus } : t));
+      await reloadTasks();
     } catch (err: any) {
       console.error(err);
       alert(err.message || 'Error updating task');
@@ -132,21 +336,157 @@ export default function ProjectTasksPage() {
   };
 
   const updateTaskAssignee = async (taskId: string, uid: string) => {
+    if (!projectId) { alert('Project is unavailable.'); return; }
     try {
       const member = members.find((m) => m.uid === uid);
       await updateDoc(doc(db, 'projects', projectId, 'tasks', taskId), {
         assignedTo: uid || null,
         assigneeName: member?.name || null,
       });
-      setTasks(
-        tasks.map((t) =>
-          t.id === taskId ? { ...t, assignedTo: uid || null, assigneeName: member?.name || null } : t
-        )
-      );
+      await reloadTasks();
     } catch (err: any) {
       console.error(err);
       alert(err.message || 'Error assigning task');
     }
+  };
+
+  const openOfferForm = (taskId: string) => {
+    setActiveOfferTaskId(taskId);
+    setOfferForm({ ...OFFER_FORM_DEFAULTS });
+  };
+
+  const closeOfferForm = () => {
+    setActiveOfferTaskId(null);
+    setOfferForm({ ...OFFER_FORM_DEFAULTS });
+  };
+
+  const submitOffer = async (taskId: string) => {
+    if (!projectId) { alert('Project is unavailable.'); return; }
+    if (!offerForm.totalAmount.trim()) {
+      alert('Enter a total amount for the outsourced work.');
+      return;
+    }
+    if (offerForm.targetType === 'franchise' && !offerForm.targetFranchiseId) {
+      alert('Select a franchise to send the offer to.');
+      return;
+    }
+    setOfferSubmitting(true);
+    try {
+      await ensureFirebase();
+      const callable = httpsCallable(functions, 'taskOffers_create');
+      await callable({
+        projectId,
+        taskId,
+        role: offerForm.role || null,
+        targetType: offerForm.targetType,
+        targetFranchiseId: offerForm.targetType === 'franchise' ? offerForm.targetFranchiseId : null,
+        targetUserId: offerForm.targetUserId || null,
+        totalAmount: offerForm.totalAmount,
+        depositAmount:
+          offerForm.paymentMode === 'deposit_balance' ? offerForm.depositAmount || '0' : '0',
+        paymentMode: offerForm.paymentMode,
+        currency: offerForm.currency || 'GBP',
+        notes: offerForm.notes || null,
+      });
+      await reloadTasks();
+      closeOfferForm();
+    } catch (err: any) {
+      console.error('Failed to submit outsourcing offer', err);
+      alert(err?.message || 'Unable to submit outsourcing offer.');
+    } finally {
+      setOfferSubmitting(false);
+    }
+  };
+
+  const respondToOffer = async (
+    taskId: string,
+    offerId: string,
+    action: 'accept' | 'reject' | 'withdraw' | 'counter',
+    payload: Record<string, unknown> = {}
+  ) => {
+    if (!projectId) { alert('Project is unavailable.'); return; }
+    setActionState(`${taskId}:${action}`);
+    try {
+      await ensureFirebase();
+      const callable = httpsCallable(functions, 'taskOffers_respond');
+      await callable({
+        projectId,
+        taskId,
+        offerId,
+        action,
+        ...payload,
+      });
+      await reloadTasks();
+      if (action === 'counter') {
+        setCounterState({ ...COUNTER_FORM_DEFAULTS });
+      }
+    } catch (err: any) {
+      console.error('Failed to update outsourcing offer', err);
+      alert(err?.message || 'Unable to update offer.');
+    } finally {
+      setActionState(null);
+    }
+  };
+
+  const openCounterForm = (taskId: string, proposal: any) => {
+    const baseCurrency =
+      typeof proposal?.counter?.currency === 'string' && proposal.counter.currency
+        ? proposal.counter.currency
+        : typeof proposal?.currency === 'string' && proposal.currency
+          ? proposal.currency
+          : 'GBP';
+    const defaultModeValue =
+      (proposal?.counter?.paymentMode ?? proposal?.paymentMode) === 'balance_on_completion'
+        ? 'balance_on_completion'
+        : 'deposit_balance';
+    const defaultTotal =
+      typeof proposal?.counter?.totalAmount === 'number'
+        ? String(proposal.counter.totalAmount)
+        : typeof proposal?.totalAmount === 'number'
+          ? String(proposal.totalAmount)
+          : '';
+    const defaultDeposit =
+      defaultModeValue === 'deposit_balance'
+        ? typeof (proposal?.counter?.depositAmount ?? proposal?.depositAmount) === 'number'
+          ? String(proposal?.counter?.depositAmount ?? proposal?.depositAmount)
+          : ''
+        : '';
+    setCounterState({
+      taskId,
+      totalAmount: defaultTotal,
+      depositAmount: defaultDeposit,
+      paymentMode: defaultModeValue as PaymentMode,
+      currency: baseCurrency,
+      notes: '',
+    });
+  };
+
+  const cancelCounterForm = () => {
+    setCounterState({ ...COUNTER_FORM_DEFAULTS });
+  };
+
+  const submitCounter = async () => {
+    if (!projectId) { alert('Project is unavailable.'); return; }
+    if (!counterState.taskId) { alert('No task selected for counter offer.'); return; }
+    if (!counterState.totalAmount.trim()) {
+      alert('Enter a counter total amount.');
+      return;
+    }
+    const task = tasks.find((t) => t.id === counterState.taskId);
+    const proposal = task?.outsourcingProposal as any;
+    const offerId = proposal?.offerId;
+    if (!offerId) {
+      alert('Unable to find the active offer to counter.');
+      return;
+    }
+    await respondToOffer(counterState.taskId, offerId, 'counter', {
+      totalAmount: counterState.totalAmount,
+      depositAmount:
+        counterState.paymentMode === 'deposit_balance' ? counterState.depositAmount || '0' : '0',
+      paymentMode: counterState.paymentMode,
+      currency: counterState.currency || proposal?.currency || 'GBP',
+      notes: counterState.notes || null,
+    });
   };
 
   if (loading) return <p>Loading…</p>;
@@ -177,30 +517,552 @@ export default function ProjectTasksPage() {
               <p className="text-sm text-gray-500">No tasks</p>
             ) : (
               <div className="flex flex-col gap-2">
-                {tasks.filter((t) => t.status === status).map((task) => (
-                  <div key={task.id} className="card p-2 grid gap-1">
-                    <p className="font-medium text-sm">{task.title}</p>
-                    {task.description && <p className="text-xs text-gray-600">{task.description}</p>}
-                    {task.dueDate && <p className="text-xs text-gray-500">Due: {task.dueDate}</p>}
-                    <p className="text-xs text-gray-600">Assigned: {task.assigneeName || 'Unassigned'}</p>
-                    {isStaffOrAdmin && (
-                      <>
-                        <select className="input mt-1" value={task.status} onChange={(e) => updateTaskStatus(task.id, e.target.value)}>
-                          <option value="todo">To Do</option>
-                          <option value="in_progress">In Progress</option>
-                          <option value="review">Review</option>
-                          <option value="done">Done</option>
-                        </select>
-                        <select className="input mt-1" value={task.assignedTo || ''} onChange={(e) => updateTaskAssignee(task.id, e.target.value)}>
-                          <option value="">Unassigned</option>
-                          {members.map((m) => (
-                            <option key={m.uid} value={m.uid}>{m.name}</option>
-                          ))}
-                        </select>
-                      </>
-                    )}
-                  </div>
-                ))}
+                {tasks
+                  .filter((t) => t.status === status)
+                  .map((task) => {
+                    const proposal = task.outsourcingProposal as any;
+                    const agreement = task.outsourcingAgreement as any;
+                    const offerId = typeof proposal?.offerId === 'string' ? proposal.offerId : null;
+                    const offerStatus = typeof proposal?.status === 'string' ? proposal.status : null;
+                    const hasOpenOffer = offerStatus === 'pending' || offerStatus === 'countered';
+                    const allowNewOffer =
+                      userContext.canOutsource &&
+                      (!proposal || offerStatus === 'rejected' || offerStatus === 'withdrawn') &&
+                      !agreement;
+                    const userFranchiseIds = userContext.franchiseIds || [];
+                    const userIsRequester = proposal?.proposedByUid === userContext.uid;
+                    const userIsTarget =
+                      proposal?.targetType === 'hq'
+                        ? userContext.isHq
+                        : proposal?.targetFranchiseId
+                          ? userFranchiseIds.includes(proposal.targetFranchiseId)
+                          : false;
+                    const awaitingTargetDecision = offerStatus === 'pending' && userIsTarget;
+                    const awaitingRequesterDecision = offerStatus === 'countered' && userIsRequester;
+                    const canWithdraw =
+                      userIsRequester &&
+                      offerId &&
+                      (offerStatus === 'pending' || offerStatus === 'countered');
+                    const showCounterForm =
+                      counterState.taskId === task.id &&
+                      (awaitingTargetDecision || awaitingRequesterDecision);
+                    const franchiseLabel =
+                      proposal?.targetType === 'franchise'
+                        ? franchiseMap.get(proposal.targetFranchiseId)?.name || proposal.targetFranchiseId
+                        : 'Head Office';
+                    const statusLabel = offerStatus ? offerStatus.replace(/_/g, ' ') : 'pending';
+
+                    return (
+                      <div key={task.id} className="card grid gap-2 p-3">
+                        <p className="font-medium text-sm">{task.title}</p>
+                        {task.description && (
+                          <p className="text-xs text-gray-600">{task.description}</p>
+                        )}
+                        {task.dueDate && (
+                          <p className="text-xs text-gray-500">Due: {task.dueDate}</p>
+                        )}
+                        <p className="text-xs text-gray-600">
+                          Assigned: {task.assigneeName || 'Unassigned'}
+                        </p>
+                        {isStaffOrAdmin && (
+                          <div className="grid gap-2">
+                            <select
+                              className="input mt-1"
+                              value={task.status}
+                              onChange={(event) => updateTaskStatus(task.id, event.target.value)}
+                            >
+                              <option value="todo">To Do</option>
+                              <option value="in_progress">In Progress</option>
+                              <option value="review">Review</option>
+                              <option value="done">Done</option>
+                            </select>
+                            <select
+                              className="input"
+                              value={task.assignedTo || ''}
+                              onChange={(event) => updateTaskAssignee(task.id, event.target.value)}
+                            >
+                              <option value="">Unassigned</option>
+                              {members.map((m) => (
+                                <option key={m.uid} value={m.uid}>
+                                  {m.name}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        )}
+
+                        {proposal && (
+                          <div className="mt-2 space-y-2 rounded border border-dashed border-gray-300 p-2 text-xs text-gray-600">
+                            <div className="flex items-center justify-between">
+                              <span className="font-semibold uppercase tracking-wide text-gray-500">
+                                Outsourcing offer
+                              </span>
+                              <span className="text-[11px] font-semibold uppercase text-gray-700">
+                                {statusLabel}
+                              </span>
+                            </div>
+                            <div className="space-y-1">
+                              <p>Target: {franchiseLabel}</p>
+                              {proposal.role && <p>Role: {proposal.role}</p>}
+                              <p>Fee: {formatMoney(proposal.totalAmount, proposal.currency) || '—'}</p>
+                              {proposal.paymentMode === 'deposit_balance' ? (
+                                <p>
+                                  Deposit: {formatMoney(proposal.depositAmount, proposal.currency) || '—'} ·
+                                  Balance: {formatMoney(proposal.balanceAmount, proposal.currency) || '—'}
+                                </p>
+                              ) : (
+                                <p>Payment: Balance on completion</p>
+                              )}
+                              {proposal.notes && (
+                                <p className="text-gray-500">Notes: {proposal.notes}</p>
+                              )}
+                            </div>
+                            {proposal.counter && offerStatus === 'countered' && (
+                              <div className="rounded bg-amber-50 p-2 text-amber-700">
+                                <p className="font-semibold">Counter offer pending review</p>
+                                <p>
+                                  Total:{' '}
+                                  {formatMoney(
+                                    proposal.counter.totalAmount,
+                                    proposal.counter.currency
+                                  ) || '—'}
+                                </p>
+                                {proposal.counter.paymentMode === 'deposit_balance' ? (
+                                  <p>
+                                    Deposit:{' '}
+                                    {formatMoney(
+                                      proposal.counter.depositAmount,
+                                      proposal.counter.currency
+                                    ) || '—'}
+                                    {' · '}Balance:{' '}
+                                    {formatMoney(
+                                      proposal.counter.balanceAmount,
+                                      proposal.counter.currency
+                                    ) || '—'}
+                                  </p>
+                                ) : (
+                                  <p>Payment: Balance on completion</p>
+                                )}
+                                {proposal.counter.notes && (
+                                  <p className="text-amber-800">Notes: {proposal.counter.notes}</p>
+                                )}
+                              </div>
+                            )}
+                            {agreement && (
+                              <div className="rounded bg-emerald-50 p-2 text-emerald-700">
+                                <p className="font-semibold">Accepted outsourcing agreement</p>
+                                <p>
+                                  Total: {formatMoney(agreement.totalAmount, agreement.currency) || '—'}
+                                </p>
+                                {agreement.paymentMode === 'deposit_balance' ? (
+                                  <p>
+                                    Deposit:{' '}
+                                    {formatMoney(agreement.depositAmount, agreement.currency) || '—'}
+                                    {' · '}Balance:{' '}
+                                    {formatMoney(agreement.balanceAmount, agreement.currency) || '—'}
+                                  </p>
+                                ) : (
+                                  <p>Payment: Balance on completion</p>
+                                )}
+                              </div>
+                            )}
+                            {(awaitingTargetDecision || awaitingRequesterDecision || canWithdraw) && offerId && (
+                              <div className="flex flex-wrap gap-2">
+                                {awaitingTargetDecision && (
+                                  <>
+                                    <button
+                                      className={primaryActionClasses}
+                                      onClick={() => respondToOffer(task.id, offerId, 'accept')}
+                                      disabled={actionState === `${task.id}:accept`}
+                                    >
+                                      {actionState === `${task.id}:accept` ? 'Accepting…' : 'Accept'}
+                                    </button>
+                                    <button
+                                      className={dangerActionClasses}
+                                      onClick={() => respondToOffer(task.id, offerId, 'reject')}
+                                      disabled={actionState === `${task.id}:reject`}
+                                    >
+                                      {actionState === `${task.id}:reject` ? 'Rejecting…' : 'Reject'}
+                                    </button>
+                                    <button
+                                      className={secondaryActionClasses}
+                                      onClick={() => openCounterForm(task.id, proposal)}
+                                      disabled={showCounterForm && actionState === `${task.id}:counter`}
+                                    >
+                                      Counter
+                                    </button>
+                                  </>
+                                )}
+                                {awaitingRequesterDecision && (
+                                  <>
+                                    <button
+                                      className={primaryActionClasses}
+                                      onClick={() => respondToOffer(task.id, offerId, 'accept')}
+                                      disabled={actionState === `${task.id}:accept`}
+                                    >
+                                      {actionState === `${task.id}:accept`
+                                        ? 'Accepting…'
+                                        : 'Accept counter'}
+                                    </button>
+                                    <button
+                                      className={dangerActionClasses}
+                                      onClick={() => respondToOffer(task.id, offerId, 'reject')}
+                                      disabled={actionState === `${task.id}:reject`}
+                                    >
+                                      {actionState === `${task.id}:reject`
+                                        ? 'Rejecting…'
+                                        : 'Decline counter'}
+                                    </button>
+                                    <button
+                                      className={secondaryActionClasses}
+                                      onClick={() =>
+                                        openCounterForm(task.id, proposal.counter ?? proposal)
+                                      }
+                                      disabled={showCounterForm && actionState === `${task.id}:counter`}
+                                    >
+                                      Counter again
+                                    </button>
+                                  </>
+                                )}
+                                {canWithdraw && (
+                                  <button
+                                    className={secondaryActionClasses}
+                                    onClick={() => respondToOffer(task.id, offerId, 'withdraw')}
+                                    disabled={actionState === `${task.id}:withdraw`}
+                                  >
+                                    {actionState === `${task.id}:withdraw`
+                                      ? 'Withdrawing…'
+                                      : 'Withdraw offer'}
+                                  </button>
+                                )}
+                              </div>
+                            )}
+                            {showCounterForm && (
+                              <div className="space-y-2 rounded border border-amber-200 bg-amber-50 p-3 text-amber-800">
+                                <div className="grid gap-2">
+                                  <div>
+                                    <label className="block text-[11px] font-semibold uppercase">
+                                      Counter total
+                                    </label>
+                                    <input
+                                      type="number"
+                                      step="0.01"
+                                      className="input mt-1"
+                                      value={counterState.totalAmount}
+                                      onChange={(event) =>
+                                        setCounterState((prev) => ({
+                                          ...prev,
+                                          totalAmount: event.target.value,
+                                        }))
+                                      }
+                                    />
+                                  </div>
+                                  <div className="grid grid-cols-2 gap-2">
+                                    <div>
+                                      <label className="block text-[11px] font-semibold uppercase">
+                                        Currency
+                                      </label>
+                                      <input
+                                        type="text"
+                                        className="input mt-1"
+                                        value={counterState.currency}
+                                        onChange={(event) =>
+                                          setCounterState((prev) => ({
+                                            ...prev,
+                                            currency: event.target.value,
+                                          }))
+                                        }
+                                      />
+                                    </div>
+                                    <div>
+                                      <label className="block text-[11px] font-semibold uppercase">
+                                        Payment schedule
+                                      </label>
+                                      <select
+                                        className="input mt-1"
+                                        value={counterState.paymentMode}
+                                        onChange={(event) => {
+                                          const mode = event.target.value as PaymentMode;
+                                          setCounterState((prev) => ({
+                                            ...prev,
+                                            paymentMode: mode,
+                                            depositAmount:
+                                              mode === 'deposit_balance' ? prev.depositAmount : '',
+                                          }));
+                                        }}
+                                      >
+                                        <option value="deposit_balance">Deposit + balance</option>
+                                        <option value="balance_on_completion">Balance on completion</option>
+                                      </select>
+                                    </div>
+                                  </div>
+                                  {counterState.paymentMode === 'deposit_balance' && (
+                                    <div>
+                                      <label className="block text-[11px] font-semibold uppercase">
+                                        Deposit amount
+                                      </label>
+                                      <input
+                                        type="number"
+                                        step="0.01"
+                                        className="input mt-1"
+                                        value={counterState.depositAmount}
+                                        onChange={(event) =>
+                                          setCounterState((prev) => ({
+                                            ...prev,
+                                            depositAmount: event.target.value,
+                                          }))
+                                        }
+                                      />
+                                    </div>
+                                  )}
+                                  <div>
+                                    <label className="block text-[11px] font-semibold uppercase">
+                                      Notes (optional)
+                                    </label>
+                                    <textarea
+                                      className="input mt-1"
+                                      rows={2}
+                                      value={counterState.notes}
+                                      onChange={(event) =>
+                                        setCounterState((prev) => ({
+                                          ...prev,
+                                          notes: event.target.value,
+                                        }))
+                                      }
+                                    />
+                                  </div>
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                  <button
+                                    className={primaryActionClasses}
+                                    onClick={submitCounter}
+                                    disabled={actionState === `${task.id}:counter`}
+                                  >
+                                    {actionState === `${task.id}:counter`
+                                      ? 'Sending…'
+                                      : 'Send counter'}
+                                  </button>
+                                  <button
+                                    className={secondaryActionClasses}
+                                    onClick={cancelCounterForm}
+                                    disabled={actionState === `${task.id}:counter`}
+                                  >
+                                    Cancel
+                                  </button>
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        {allowNewOffer && (
+                          activeOfferTaskId === task.id ? (
+                            <div className="mt-2 space-y-2 rounded border border-gray-200 bg-gray-50 p-3 text-xs text-gray-700">
+                              <div className="grid gap-2">
+                                <div>
+                                  <label className="block text-[11px] font-semibold uppercase">
+                                    Role / service
+                                  </label>
+                                  <input
+                                    type="text"
+                                    className="input mt-1"
+                                    value={offerForm.role}
+                                    onChange={(event) =>
+                                      setOfferForm((prev) => ({
+                                        ...prev,
+                                        role: event.target.value,
+                                      }))
+                                    }
+                                  />
+                                </div>
+                                <div>
+                                  <label className="block text-[11px] font-semibold uppercase">
+                                    Send to
+                                  </label>
+                                  <select
+                                    className="input mt-1"
+                                    value={offerForm.targetType}
+                                    onChange={(event) => {
+                                      const target = event.target.value as 'hq' | 'franchise';
+                                      setOfferForm((prev) => ({
+                                        ...prev,
+                                        targetType: target,
+                                        targetFranchiseId:
+                                          target === 'franchise' ? prev.targetFranchiseId : '',
+                                      }));
+                                    }}
+                                  >
+                                    <option value="hq">Head Office</option>
+                                    <option value="franchise">Franchise</option>
+                                  </select>
+                                </div>
+                                {offerForm.targetType === 'franchise' && (
+                                  <div>
+                                    <label className="block text-[11px] font-semibold uppercase">
+                                      Franchise
+                                    </label>
+                                    <select
+                                      className="input mt-1"
+                                      value={offerForm.targetFranchiseId}
+                                      onChange={(event) =>
+                                        setOfferForm((prev) => ({
+                                          ...prev,
+                                          targetFranchiseId: event.target.value,
+                                        }))
+                                      }
+                                    >
+                                      <option value="">Select franchise</option>
+                                      {franchises.map((franchise) => (
+                                        <option key={franchise.id} value={franchise.id}>
+                                          {franchise.name || franchise.id}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </div>
+                                )}
+                                <div>
+                                  <label className="block text-[11px] font-semibold uppercase">
+                                    Assignee user ID (optional)
+                                  </label>
+                                  <input
+                                    type="text"
+                                    className="input mt-1"
+                                    value={offerForm.targetUserId}
+                                    onChange={(event) =>
+                                      setOfferForm((prev) => ({
+                                        ...prev,
+                                        targetUserId: event.target.value,
+                                      }))
+                                    }
+                                  />
+                                </div>
+                                <div className="grid grid-cols-2 gap-2">
+                                  <div>
+                                    <label className="block text-[11px] font-semibold uppercase">
+                                      Total amount
+                                    </label>
+                                    <input
+                                      type="number"
+                                      step="0.01"
+                                      className="input mt-1"
+                                      value={offerForm.totalAmount}
+                                      onChange={(event) =>
+                                        setOfferForm((prev) => ({
+                                          ...prev,
+                                          totalAmount: event.target.value,
+                                        }))
+                                      }
+                                    />
+                                  </div>
+                                  <div>
+                                    <label className="block text-[11px] font-semibold uppercase">
+                                      Currency
+                                    </label>
+                                    <input
+                                      type="text"
+                                      className="input mt-1"
+                                      value={offerForm.currency}
+                                      onChange={(event) =>
+                                        setOfferForm((prev) => ({
+                                          ...prev,
+                                          currency: event.target.value,
+                                        }))
+                                      }
+                                    />
+                                  </div>
+                                </div>
+                                <div>
+                                  <label className="block text-[11px] font-semibold uppercase">
+                                    Payment schedule
+                                  </label>
+                                  <select
+                                    className="input mt-1"
+                                    value={offerForm.paymentMode}
+                                    onChange={(event) => {
+                                      const mode = event.target.value as PaymentMode;
+                                      setOfferForm((prev) => ({
+                                        ...prev,
+                                        paymentMode: mode,
+                                        depositAmount:
+                                          mode === 'deposit_balance' ? prev.depositAmount : '',
+                                      }));
+                                    }}
+                                  >
+                                    <option value="deposit_balance">Deposit + balance</option>
+                                    <option value="balance_on_completion">Balance on completion</option>
+                                  </select>
+                                </div>
+                                {offerForm.paymentMode === 'deposit_balance' && (
+                                  <div>
+                                    <label className="block text-[11px] font-semibold uppercase">
+                                      Deposit amount
+                                    </label>
+                                    <input
+                                      type="number"
+                                      step="0.01"
+                                      className="input mt-1"
+                                      value={offerForm.depositAmount}
+                                      onChange={(event) =>
+                                        setOfferForm((prev) => ({
+                                          ...prev,
+                                          depositAmount: event.target.value,
+                                        }))
+                                      }
+                                    />
+                                  </div>
+                                )}
+                                <div>
+                                  <label className="block text-[11px] font-semibold uppercase">
+                                    Notes (optional)
+                                  </label>
+                                  <textarea
+                                    className="input mt-1"
+                                    rows={2}
+                                    value={offerForm.notes}
+                                    onChange={(event) =>
+                                      setOfferForm((prev) => ({
+                                        ...prev,
+                                        notes: event.target.value,
+                                      }))
+                                    }
+                                  />
+                                </div>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                <button
+                                  className={primaryActionClasses}
+                                  onClick={() => submitOffer(task.id)}
+                                  disabled={offerSubmitting}
+                                >
+                                  {offerSubmitting ? 'Submitting…' : 'Send offer'}
+                                </button>
+                                <button
+                                  className={secondaryActionClasses}
+                                  onClick={closeOfferForm}
+                                  disabled={offerSubmitting}
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          ) : (
+                            <button
+                              className={secondaryActionClasses}
+                              onClick={() => openOfferForm(task.id)}
+                            >
+                              Propose outsourcing
+                            </button>
+                          )
+                        )}
+
+                        {userContext.canOutsource && hasOpenOffer && !showCounterForm && !awaitingTargetDecision && !awaitingRequesterDecision && offerStatus && (
+                          <p className="text-[11px] text-gray-500">
+                            Waiting on {proposal?.targetType === 'hq' ? 'HQ' : 'franchise'} response.
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
               </div>
             )}
           </div>

--- a/apps/web/components/Breadcrumbs.tsx
+++ b/apps/web/components/Breadcrumbs.tsx
@@ -8,6 +8,7 @@ const LABELS: Record<string, string> = {
   dashboard: 'Dashboard',
   equipment: 'Equipment',
   products: 'Products',
+  franchises: 'Franchises',
   proposals: 'Proposals',
   quotes: 'Quotes',
   crm: 'CRM',

--- a/apps/web/components/TerritoryMap.tsx
+++ b/apps/web/components/TerritoryMap.tsx
@@ -1,0 +1,52 @@
+import clsx from "clsx";
+import type { FranchiseTerritory } from "@/lib/franchises";
+
+interface TerritoryMapProps {
+  territory: FranchiseTerritory;
+  className?: string;
+  height?: number;
+}
+
+function buildQuery(territory: FranchiseTerritory): string | null {
+  if (territory.type === "radius") {
+    const lat = typeof territory.centerLat === "number" ? territory.centerLat : null;
+    const lng = typeof territory.centerLng === "number" ? territory.centerLng : null;
+    if (lat !== null && lng !== null) {
+      return `${lat},${lng}`;
+    }
+  }
+  const firstCode = territory.postalCodes.find((code) => code.trim().length > 0);
+  if (firstCode) {
+    return firstCode;
+  }
+  return territory.label.trim() ? territory.label : null;
+}
+
+export default function TerritoryMap({ territory, className, height = 220 }: TerritoryMapProps) {
+  const query = buildQuery(territory);
+  if (!query) return null;
+
+  const embedUrl = `https://www.google.com/maps?q=${encodeURIComponent(query)}&output=embed`;
+  const linkUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+
+  return (
+    <div className={clsx("grid gap-2", className)}>
+      <div className="w-full overflow-hidden rounded-md border">
+        <iframe
+          title={`${territory.label} map`}
+          src={embedUrl}
+          className="w-full"
+          style={{ minHeight: height }}
+          loading="lazy"
+          allowFullScreen
+          referrerPolicy="no-referrer-when-downgrade"
+        />
+      </div>
+      <div className="text-xs text-gray-600">
+        <a className="text-blue-600 hover:underline" href={linkUrl} target="_blank" rel="noreferrer">
+          Open in Maps
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/franchises.ts
+++ b/apps/web/lib/franchises.ts
@@ -1,0 +1,119 @@
+import type { Timestamp } from 'firebase/firestore';
+import type { DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
+
+export type FranchiseStatus = 'prospect' | 'active' | 'paused' | 'suspended';
+
+export interface Franchise {
+  id: string;
+  name: string;
+  code: string;
+  status: FranchiseStatus;
+  contactEmail?: string | null;
+  contactPhone?: string | null;
+  stripeAccountId?: string | null;
+  platformFee?: number | null;
+  notes?: string | null;
+  createdAt?: Timestamp | null;
+  updatedAt?: Timestamp | null;
+}
+
+export type TerritoryType = 'postal' | 'radius';
+
+export interface FranchiseTerritory {
+  id: string;
+  franchiseId: string;
+  label: string;
+  type: TerritoryType;
+  postalCodes: string[];
+  exclusive: boolean;
+  radiusKm?: number | null;
+  centerLat?: number | null;
+  centerLng?: number | null;
+  notes?: string | null;
+  createdAt?: Timestamp | null;
+  updatedAt?: Timestamp | null;
+}
+
+export type FranchiseMemberRole = 'owner' | 'franchisee' | 'contractor' | 'hq';
+
+export interface FranchiseMember {
+  id: string;
+  franchiseId: string;
+  userId: string;
+  role: FranchiseMemberRole;
+  primary?: boolean | null;
+  createdAt?: Timestamp | null;
+  updatedAt?: Timestamp | null;
+}
+
+type SnapshotWithId = QueryDocumentSnapshot<DocumentData>;
+
+export function parseFranchise(doc: SnapshotWithId): Franchise {
+  const data = doc.data() as Record<string, unknown>;
+  return {
+    id: doc.id,
+    name: (data.name as string) || 'Untitled Franchise',
+    code: (data.code as string) || doc.id,
+    status: ((data.status as FranchiseStatus) ?? 'prospect') as FranchiseStatus,
+    contactEmail: (data.contactEmail as string) ?? null,
+    contactPhone: (data.contactPhone as string) ?? null,
+    stripeAccountId: (data.stripeAccountId as string) ?? null,
+    platformFee: typeof data.platformFee === 'number' ? (data.platformFee as number) : null,
+    notes: (data.notes as string) ?? null,
+    createdAt: (data.createdAt as Timestamp) ?? null,
+    updatedAt: (data.updatedAt as Timestamp) ?? null,
+  };
+}
+
+export function parseTerritory(doc: SnapshotWithId): FranchiseTerritory {
+  const data = doc.data() as Record<string, unknown>;
+  const postalCodesRaw = Array.isArray(data.postalCodes)
+    ? (data.postalCodes as unknown[]).map((p) => String(p).trim()).filter(Boolean)
+    : typeof data.postalCodes === 'string'
+      ? (data.postalCodes as string)
+          .split(',')
+          .map((p) => p.trim())
+          .filter(Boolean)
+      : [];
+  return {
+    id: doc.id,
+    franchiseId: (data.franchiseId as string) || '',
+    label: (data.label as string) || 'Unnamed Territory',
+    type: ((data.type as TerritoryType) ?? 'postal') as TerritoryType,
+    postalCodes: postalCodesRaw,
+    exclusive: data.exclusive !== false,
+    radiusKm: typeof data.radiusKm === 'number' ? (data.radiusKm as number) : null,
+    centerLat: typeof data.centerLat === 'number' ? (data.centerLat as number) : null,
+    centerLng: typeof data.centerLng === 'number' ? (data.centerLng as number) : null,
+    notes: (data.notes as string) ?? null,
+    createdAt: (data.createdAt as Timestamp) ?? null,
+    updatedAt: (data.updatedAt as Timestamp) ?? null,
+  };
+}
+
+export function parseMember(doc: SnapshotWithId): FranchiseMember {
+  const data = doc.data() as Record<string, unknown>;
+  return {
+    id: doc.id,
+    franchiseId: (data.franchiseId as string) || '',
+    userId: (data.userId as string) || '',
+    role: ((data.role as FranchiseMemberRole) ?? 'franchisee') as FranchiseMemberRole,
+    primary: data.primary === true,
+    createdAt: (data.createdAt as Timestamp) ?? null,
+    updatedAt: (data.updatedAt as Timestamp) ?? null,
+  };
+}
+
+export function territorySummary(territory: FranchiseTerritory): string {
+  if (territory.type === 'radius') {
+    const center =
+      typeof territory.centerLat === 'number' && typeof territory.centerLng === 'number'
+        ? `${territory.centerLat.toFixed(4)}, ${territory.centerLng.toFixed(4)}`
+        : 'Unspecified centre';
+    const radius = typeof territory.radiusKm === 'number' ? `${territory.radiusKm} km radius` : 'Radius pending';
+    return `${territory.label} · ${radius} · ${center}`;
+  }
+  const codes = territory.postalCodes.slice(0, 6).join(', ');
+  const suffix = territory.postalCodes.length > 6 ? '…' : '';
+  return `${territory.label} · ${territory.postalCodes.length} codes · ${codes}${suffix}`;
+}

--- a/apps/web/lib/franchises.ts
+++ b/apps/web/lib/franchises.ts
@@ -3,6 +3,23 @@ import type { DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
 
 export type FranchiseStatus = 'prospect' | 'active' | 'paused' | 'suspended';
 
+export type FranchiseOnboardingStatus =
+  | 'not_started'
+  | 'in_progress'
+  | 'needs_attention'
+  | 'completed';
+
+export interface FranchiseOnboardingChecklist {
+  kycStatus: FranchiseOnboardingStatus;
+  stripeAccountStatus: FranchiseOnboardingStatus;
+  bankStatus: FranchiseOnboardingStatus;
+  legalStatus: FranchiseOnboardingStatus;
+  chargesEnabled: boolean;
+  notes?: string | null;
+  lastSyncedAt?: Timestamp | null;
+  activatedAt?: Timestamp | null;
+}
+
 export interface Franchise {
   id: string;
   name: string;
@@ -13,6 +30,7 @@ export interface Franchise {
   stripeAccountId?: string | null;
   platformFee?: number | null;
   notes?: string | null;
+  onboarding: FranchiseOnboardingChecklist;
   createdAt?: Timestamp | null;
   updatedAt?: Timestamp | null;
 }
@@ -48,8 +66,50 @@ export interface FranchiseMember {
 
 type SnapshotWithId = QueryDocumentSnapshot<DocumentData>;
 
+function parseOnboardingStatus(value: unknown): FranchiseOnboardingStatus {
+  switch (value) {
+    case 'in_progress':
+    case 'needs_attention':
+    case 'completed':
+      return value as FranchiseOnboardingStatus;
+    default:
+      return 'not_started';
+  }
+}
+
+function parseOnboardingChecklist(data: Record<string, unknown> | null | undefined): FranchiseOnboardingChecklist {
+  const notes = typeof data?.notes === 'string' ? data.notes : null;
+  return {
+    kycStatus: parseOnboardingStatus(data?.kycStatus),
+    stripeAccountStatus: parseOnboardingStatus(data?.stripeAccountStatus),
+    bankStatus: parseOnboardingStatus(data?.bankStatus),
+    legalStatus: parseOnboardingStatus(data?.legalStatus),
+    chargesEnabled: data?.chargesEnabled === true,
+    notes,
+    lastSyncedAt: (data?.lastSyncedAt as Timestamp) ?? null,
+    activatedAt: (data?.activatedAt as Timestamp) ?? null,
+  } satisfies FranchiseOnboardingChecklist;
+}
+
+export function defaultFranchiseOnboarding(): FranchiseOnboardingChecklist {
+  return {
+    kycStatus: 'not_started',
+    stripeAccountStatus: 'not_started',
+    bankStatus: 'not_started',
+    legalStatus: 'not_started',
+    chargesEnabled: false,
+    notes: null,
+    lastSyncedAt: null,
+    activatedAt: null,
+  };
+}
+
 export function parseFranchise(doc: SnapshotWithId): Franchise {
   const data = doc.data() as Record<string, unknown>;
+  const onboardingData =
+    data.onboarding && typeof data.onboarding === 'object'
+      ? (data.onboarding as Record<string, unknown>)
+      : null;
   return {
     id: doc.id,
     name: (data.name as string) || 'Untitled Franchise',
@@ -60,6 +120,7 @@ export function parseFranchise(doc: SnapshotWithId): Franchise {
     stripeAccountId: (data.stripeAccountId as string) ?? null,
     platformFee: typeof data.platformFee === 'number' ? (data.platformFee as number) : null,
     notes: (data.notes as string) ?? null,
+    onboarding: parseOnboardingChecklist(onboardingData),
     createdAt: (data.createdAt as Timestamp) ?? null,
     updatedAt: (data.updatedAt as Timestamp) ?? null,
   };
@@ -116,4 +177,12 @@ export function territorySummary(territory: FranchiseTerritory): string {
   const codes = territory.postalCodes.slice(0, 6).join(', ');
   const suffix = territory.postalCodes.length > 6 ? '…' : '';
   return `${territory.label} · ${territory.postalCodes.length} codes · ${codes}${suffix}`;
+}
+
+export function canActivateFranchise(onboarding: FranchiseOnboardingChecklist): boolean {
+  return (
+    onboarding.kycStatus === 'completed' &&
+    onboarding.stripeAccountStatus === 'completed' &&
+    onboarding.chargesEnabled === true
+  );
 }

--- a/apps/web/lib/franchises.ts
+++ b/apps/web/lib/franchises.ts
@@ -20,6 +20,19 @@ export interface FranchiseOnboardingChecklist {
   activatedAt?: Timestamp | null;
 }
 
+export type RoyaltySource = 'hq' | 'franchisee';
+
+export interface FranchiseRoyaltyTier {
+  minOrder: number;
+  maxOrder?: number | null;
+  percentage: number;
+}
+
+export interface FranchiseRoyaltyConfig {
+  hqTiers: FranchiseRoyaltyTier[];
+  franchiseSourcedPercentage: number;
+}
+
 export interface Franchise {
   id: string;
   name: string;
@@ -31,6 +44,7 @@ export interface Franchise {
   platformFee?: number | null;
   notes?: string | null;
   onboarding: FranchiseOnboardingChecklist;
+  royalty: FranchiseRoyaltyConfig;
   createdAt?: Timestamp | null;
   updatedAt?: Timestamp | null;
 }
@@ -91,6 +105,107 @@ function parseOnboardingChecklist(data: Record<string, unknown> | null | undefin
   } satisfies FranchiseOnboardingChecklist;
 }
 
+function parseRoyaltyTier(input: unknown): FranchiseRoyaltyTier | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+  const data = input as Record<string, unknown>;
+  const rawMin = data.minOrder ?? data.orderFrom ?? data.start ?? data.from;
+  const rawMax = data.maxOrder ?? data.orderThrough ?? data.end ?? data.to;
+  const rawPercentage = data.percentage ?? data.rate ?? data.percent ?? data.value;
+  const minOrder = Number(rawMin);
+  if (!Number.isFinite(minOrder) || minOrder <= 0) {
+    return null;
+  }
+  const maxOrder = rawMax == null || rawMax === '' ? null : Number(rawMax);
+  const percentage = Number(rawPercentage);
+  if (!Number.isFinite(percentage)) {
+    return null;
+  }
+  const tier: FranchiseRoyaltyTier = {
+    minOrder: Math.max(1, Math.floor(minOrder)),
+    percentage,
+  };
+  if (Number.isFinite(maxOrder)) {
+    tier.maxOrder = Math.max(Math.floor(Number(maxOrder)), tier.minOrder);
+  } else {
+    tier.maxOrder = null;
+  }
+  return tier;
+}
+
+function parseRoyaltyConfig(raw: unknown): FranchiseRoyaltyConfig {
+  const defaultConfig = defaultFranchiseRoyaltyConfig();
+  if (!raw || typeof raw !== 'object') {
+    return defaultConfig;
+  }
+  const data = raw as Record<string, unknown>;
+  const tierValues: unknown = data.hqTiers ?? data.hq ?? data.slidingScale;
+  const tiers: FranchiseRoyaltyTier[] = Array.isArray(tierValues)
+    ? tierValues
+        .map((item) => parseRoyaltyTier(item))
+        .filter((item): item is FranchiseRoyaltyTier => item !== null)
+    : [];
+  const franchiseValue = data.franchiseSourcedPercentage ?? data.franchise ?? data.local ?? data.direct;
+  const parsedFranchise = Number(franchiseValue);
+  const franchisePercentage = Number.isFinite(parsedFranchise)
+    ? parsedFranchise
+    : defaultConfig.franchiseSourcedPercentage;
+  if (tiers.length === 0) {
+    return { ...defaultConfig, franchiseSourcedPercentage: franchisePercentage };
+  }
+  const sortedTiers = tiers.sort((a, b) => a.minOrder - b.minOrder);
+  return {
+    hqTiers: sortedTiers,
+    franchiseSourcedPercentage: franchisePercentage,
+  } satisfies FranchiseRoyaltyConfig;
+}
+
+export function defaultFranchiseRoyaltyConfig(): FranchiseRoyaltyConfig {
+  return {
+    hqTiers: [
+      { minOrder: 1, maxOrder: 1, percentage: 20 },
+      { minOrder: 2, maxOrder: 2, percentage: 15 },
+      { minOrder: 3, maxOrder: 5, percentage: 10 },
+      { minOrder: 6, maxOrder: null, percentage: 6 },
+    ],
+    franchiseSourcedPercentage: 6,
+  };
+}
+
+export function resolveRoyaltyPercentage(
+  config: FranchiseRoyaltyConfig | null | undefined,
+  source: RoyaltySource,
+  orderIndex: number
+): { percentage: number; tier: FranchiseRoyaltyTier | null } {
+  const fallback = defaultFranchiseRoyaltyConfig();
+  const activeConfig = config ?? fallback;
+  if (source === 'franchisee') {
+    return {
+      percentage:
+        typeof activeConfig.franchiseSourcedPercentage === 'number'
+          ? activeConfig.franchiseSourcedPercentage
+          : fallback.franchiseSourcedPercentage,
+      tier: null,
+    };
+  }
+  const tiers = (activeConfig.hqTiers?.length ? activeConfig.hqTiers : fallback.hqTiers).slice();
+  tiers.sort((a, b) => a.minOrder - b.minOrder);
+  const index = Number(orderIndex);
+  if (!Number.isFinite(index) || index <= 0) {
+    return { percentage: tiers[0]?.percentage ?? fallback.hqTiers[0].percentage, tier: tiers[0] ?? fallback.hqTiers[0] };
+  }
+  for (const tier of tiers) {
+    const withinLower = index >= tier.minOrder;
+    const withinUpper = tier.maxOrder == null || index <= tier.maxOrder;
+    if (withinLower && withinUpper) {
+      return { percentage: tier.percentage, tier };
+    }
+  }
+  const lastTier = tiers[tiers.length - 1] ?? fallback.hqTiers[fallback.hqTiers.length - 1];
+  return { percentage: lastTier.percentage, tier: lastTier };
+}
+
 export function defaultFranchiseOnboarding(): FranchiseOnboardingChecklist {
   return {
     kycStatus: 'not_started',
@@ -121,6 +236,7 @@ export function parseFranchise(doc: SnapshotWithId): Franchise {
     platformFee: typeof data.platformFee === 'number' ? (data.platformFee as number) : null,
     notes: (data.notes as string) ?? null,
     onboarding: parseOnboardingChecklist(onboardingData),
+    royalty: parseRoyaltyConfig(data.royalty),
     createdAt: (data.createdAt as Timestamp) ?? null,
     updatedAt: (data.updatedAt as Timestamp) ?? null,
   };

--- a/apps/web/lib/franchises.ts
+++ b/apps/web/lib/franchises.ts
@@ -61,6 +61,8 @@ export interface FranchiseTerritory {
   radiusKm?: number | null;
   centerLat?: number | null;
   centerLng?: number | null;
+  categories: string[];
+  licenseFee?: number | null;
   notes?: string | null;
   createdAt?: Timestamp | null;
   updatedAt?: Timestamp | null;
@@ -262,6 +264,12 @@ export function parseTerritory(doc: SnapshotWithId): FranchiseTerritory {
     radiusKm: typeof data.radiusKm === 'number' ? (data.radiusKm as number) : null,
     centerLat: typeof data.centerLat === 'number' ? (data.centerLat as number) : null,
     centerLng: typeof data.centerLng === 'number' ? (data.centerLng as number) : null,
+    categories: Array.isArray(data.categories)
+      ? (data.categories as unknown[])
+          .map((value) => (typeof value === 'string' ? value.trim() : String(value ?? '')).trim())
+          .filter(Boolean)
+      : [],
+    licenseFee: typeof data.licenseFee === 'number' ? (data.licenseFee as number) : null,
     notes: (data.notes as string) ?? null,
     createdAt: (data.createdAt as Timestamp) ?? null,
     updatedAt: (data.updatedAt as Timestamp) ?? null,

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -32,6 +32,9 @@ admin.initializeApp({
 const db = admin.firestore();
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2024-06-20' });
 const VAT_RATE = 0.2;
+const DAY_IN_MS = 86_400_000;
+const DEFAULT_FILMING_SLA_DAYS = 7;
+const DEFAULT_EDITING_SLA_DAYS = 14;
 function defaultRoyaltyConfig() {
     return {
         hqTiers: [
@@ -481,9 +484,17 @@ export const onOrderCreated = functions.firestore
         createdAt: admin.firestore.FieldValue.serverTimestamp(),
     });
     await snap.ref.set({ projectId: projRef.id }, { merge: true });
-    const projectBudgetData = {};
+    const filmingDueDate = new Date(Date.now() + DEFAULT_FILMING_SLA_DAYS * DAY_IN_MS);
+    const editingDueDate = new Date(Date.now() + DEFAULT_EDITING_SLA_DAYS * DAY_IN_MS);
+    const filmingDueAt = admin.firestore.Timestamp.fromDate(filmingDueDate);
+    const editingDueAt = admin.firestore.Timestamp.fromDate(editingDueDate);
+    const projectUpdates = {
+        kickoffDate: admin.firestore.FieldValue.serverTimestamp(),
+        dueDate: editingDueAt,
+        filmingDueDate: filmingDueAt,
+    };
     if (order.budgetTotals)
-        projectBudgetData.budgetTotals = order.budgetTotals;
+        projectUpdates.budgetTotals = order.budgetTotals;
     const budgetItems = (order.items || []).map((item) => ({
         id: item.id,
         name: item.name,
@@ -491,16 +502,38 @@ export const onOrderCreated = functions.firestore
         budget: item.budget || null,
     }));
     if (budgetItems.length > 0)
-        projectBudgetData.budgetItems = budgetItems;
-    if (Object.keys(projectBudgetData).length > 0) {
-        await projRef.set(projectBudgetData, { merge: true });
-    }
+        projectUpdates.budgetItems = budgetItems;
+    projectUpdates.franchiseId = order.franchiseId || null;
+    projectUpdates.franchiseTerritoryId = order.franchiseTerritoryId || null;
+    projectUpdates.franchiseAssignment = order.franchiseAssignment || null;
+    projectUpdates.franchiseAssignedMemberId = order.franchiseAssignedMemberId || null;
+    projectUpdates.franchiseAssignedUserId = order.franchiseAssignedUserId || null;
+    projectUpdates.franchiseAssignedRole = order.franchiseAssignedRole || null;
+    projectUpdates.franchiseAssignedIsPrimary = order.franchiseAssignedIsPrimary === true;
+    projectUpdates.franchiseAssignedUser =
+        order.franchiseAssignedUser && typeof order.franchiseAssignedUser === 'object'
+            ? order.franchiseAssignedUser
+            : null;
+    projectUpdates.clientPostalCode = order.clientPostalCode || null;
+    projectUpdates.royalty = order.royalty || null;
+    projectUpdates.royaltyPercentage =
+        typeof order.royaltyPercentage === 'number' ? order.royaltyPercentage : null;
+    projectUpdates.royaltySource = order.royaltySource || null;
+    await projRef.set(projectUpdates, { merge: true });
     // Populate workflow/default tasks from the ordered product
     if (order.serviceId) {
         try {
             const prodDoc = await db.collection('products').doc(order.serviceId).get();
             const prod = prodDoc.data();
             const taskDocs = [];
+            const franchiseOperatorId = typeof order.franchiseAssignedUserId === 'string'
+                ? String(order.franchiseAssignedUserId)
+                : null;
+            const franchiseOperatorName = order.franchiseAssignedUser && typeof order.franchiseAssignedUser === 'object'
+                ? order.franchiseAssignedUser.displayName ||
+                    order.franchiseAssignedUser.email ||
+                    null
+                : null;
             // If the product references a workflow, load its tasks
             if (prod?.workflowId) {
                 const wfDoc = await db.collection('workflows').doc(prod.workflowId).get();
@@ -567,6 +600,7 @@ export const onOrderCreated = functions.firestore
                             dependsOn,
                             workflowTaskId: typeof t.id === 'string' ? t.id : null,
                             dueAt,
+                            dueDate: dueAt,
                             forCustomer: !!t.forCustomer,
                             status: 'todo',
                             createdAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -591,6 +625,56 @@ export const onOrderCreated = functions.firestore
                         assigneeName: null,
                     });
                 }
+            }
+            const filmingTaskTitle = 'Filming & Capture';
+            const hasFilmingTask = taskDocs.some((task) => {
+                const title = typeof task.title === 'string' ? task.title.toLowerCase() : '';
+                return title.includes('film');
+            });
+            if (!hasFilmingTask) {
+                taskDocs.push({
+                    title: filmingTaskTitle,
+                    description: 'Coordinate and complete the on-site shoot within the agreed SLA.',
+                    subtasks: [
+                        'Confirm shoot date, time, and location with the client.',
+                        'Prepare kit, crew, and travel logistics for the territory.',
+                        'Capture footage and upload raw files to the project workspace within 24 hours.',
+                    ],
+                    slaDays: DEFAULT_FILMING_SLA_DAYS,
+                    dueAt: filmingDueAt,
+                    dueDate: filmingDueAt,
+                    forCustomer: false,
+                    status: 'todo',
+                    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+                    assignedTo: franchiseOperatorId,
+                    assigneeName: franchiseOperatorName,
+                    assignmentScope: franchiseOperatorId ? 'franchise' : null,
+                });
+            }
+            const editingTaskTitle = 'Editing & Delivery';
+            const hasEditingTask = taskDocs.some((task) => {
+                const title = typeof task.title === 'string' ? task.title.toLowerCase() : '';
+                return title.includes('edit');
+            });
+            if (!hasEditingTask) {
+                taskDocs.push({
+                    title: editingTaskTitle,
+                    description: 'Ingest footage and deliver the first cut to HQ standards.',
+                    subtasks: [
+                        'Ingest and organise all footage in the project workspace.',
+                        'Produce the first cut following Pineapple Tapped brand guidelines.',
+                        'Submit edit for HQ quality check and client delivery.',
+                    ],
+                    slaDays: DEFAULT_EDITING_SLA_DAYS,
+                    dueAt: editingDueAt,
+                    dueDate: editingDueAt,
+                    forCustomer: false,
+                    status: 'todo',
+                    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+                    assignedTo: null,
+                    assigneeName: null,
+                    assignmentScope: null,
+                });
             }
             if (taskDocs.length) {
                 const tasksRef = projRef.collection('tasks');

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -32,6 +32,86 @@ admin.initializeApp({
 const db = admin.firestore();
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2024-06-20' });
 const VAT_RATE = 0.2;
+function defaultRoyaltyConfig() {
+    return {
+        hqTiers: [
+            { minOrder: 1, maxOrder: 1, percentage: 20 },
+            { minOrder: 2, maxOrder: 2, percentage: 15 },
+            { minOrder: 3, maxOrder: 5, percentage: 10 },
+            { minOrder: 6, maxOrder: null, percentage: 6 },
+        ],
+        franchiseSourcedPercentage: 6,
+    };
+}
+function parseRoyaltyTierDoc(input) {
+    if (!input || typeof input !== 'object') {
+        return null;
+    }
+    const data = input;
+    const min = Number(data.minOrder ?? data.orderFrom ?? data.start ?? data.from);
+    const maxValue = data.maxOrder ?? data.orderThrough ?? data.end ?? data.to;
+    const percentage = Number(data.percentage ?? data.rate ?? data.percent ?? data.value);
+    if (!Number.isFinite(min) || min <= 0 || !Number.isFinite(percentage)) {
+        return null;
+    }
+    const parsedMax = maxValue == null || maxValue === '' ? null : Number(maxValue);
+    const tier = {
+        minOrder: Math.max(1, Math.floor(min)),
+        maxOrder: null,
+        percentage,
+    };
+    if (parsedMax !== null && Number.isFinite(parsedMax)) {
+        const normalisedMax = Math.floor(Number(parsedMax));
+        tier.maxOrder = Math.max(normalisedMax, tier.minOrder);
+    }
+    return tier;
+}
+function parseRoyaltyConfigDoc(raw) {
+    const fallback = defaultRoyaltyConfig();
+    if (!raw || typeof raw !== 'object') {
+        return fallback;
+    }
+    const data = raw;
+    const tierValues = data.hqTiers ?? data.hq ?? data.slidingScale;
+    const tiers = Array.isArray(tierValues)
+        ? tierValues
+            .map((value) => parseRoyaltyTierDoc(value))
+            .filter((value) => value !== null)
+            .sort((a, b) => a.minOrder - b.minOrder)
+        : [];
+    const franchiseValue = Number(data.franchiseSourcedPercentage ?? data.franchise ?? data.local ?? data.direct);
+    const franchisePercentage = Number.isFinite(franchiseValue)
+        ? franchiseValue
+        : fallback.franchiseSourcedPercentage;
+    return {
+        hqTiers: tiers.length > 0 ? tiers : fallback.hqTiers,
+        franchiseSourcedPercentage: franchisePercentage,
+    };
+}
+function resolveRoyaltyTier(config, source, orderIndex) {
+    const fallback = defaultRoyaltyConfig();
+    if (source === 'franchisee') {
+        return {
+            percentage: config.franchiseSourcedPercentage ?? fallback.franchiseSourcedPercentage,
+            tier: null,
+        };
+    }
+    const tiers = (config.hqTiers?.length ? config.hqTiers : fallback.hqTiers).slice().sort((a, b) => a.minOrder - b.minOrder);
+    const index = Number(orderIndex);
+    if (!Number.isFinite(index) || index <= 0) {
+        const first = tiers[0] ?? fallback.hqTiers[0];
+        return { percentage: first.percentage, tier: first };
+    }
+    for (const tier of tiers) {
+        const withinLower = index >= tier.minOrder;
+        const withinUpper = tier.maxOrder == null || index <= tier.maxOrder;
+        if (withinLower && withinUpper) {
+            return { percentage: tier.percentage, tier };
+        }
+    }
+    const lastTier = tiers[tiers.length - 1] ?? fallback.hqTiers[fallback.hqTiers.length - 1];
+    return { percentage: lastTier.percentage, tier: lastTier };
+}
 function normalisePostalCode(value) {
     if (typeof value !== 'string') {
         return null;
@@ -1698,11 +1778,36 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     const parseOptional = (value) => value === undefined || value === null ? undefined : toNumber(value);
     const DEFAULT_TRAVEL_MILES = 100;
     const DEFAULT_TRAVEL_RATE = 0.3;
-    const { items, userEmail, customerName, companyName, location, postalCode, projectName, voucher, kitItems = [], rentalSubtotal = 0, } = data;
+    const { items, userEmail, customerName, companyName, location, postalCode, projectName, voucher, kitItems = [], rentalSubtotal = 0, leadSource: leadSourceInput, } = data;
     if (!items || !Array.isArray(items) || items.length === 0) {
         throw new functions.https.HttpsError('invalid-argument', 'items are required');
     }
     const productRefs = items.map((i) => db.collection('products').doc(i.id));
+    const leadSourceNormalised = typeof leadSourceInput === 'string' && leadSourceInput.toLowerCase().includes('franchise')
+        ? 'franchisee'
+        : 'hq';
+    const authEmail = typeof context.auth?.token.email === 'string' ? context.auth.token.email : null;
+    const requestEmail = typeof userEmail === 'string' ? userEmail : null;
+    const preferredEmail = authEmail || requestEmail;
+    const normalisedEmail = preferredEmail ? preferredEmail.trim().toLowerCase() : null;
+    const clientRoyaltyKeyType = context.auth?.uid
+        ? 'user_id'
+        : normalisedEmail
+            ? 'email'
+            : null;
+    const clientRoyaltyKey = clientRoyaltyKeyType === 'user_id'
+        ? `uid:${context.auth?.uid}`
+        : clientRoyaltyKeyType === 'email' && normalisedEmail
+            ? `email:${normalisedEmail}`
+            : null;
+    let clientRoyaltyOrderIndex = null;
+    if (clientRoyaltyKey) {
+        const priorOrdersSnap = await db
+            .collection('orders')
+            .where('clientRoyaltyKey', '==', clientRoyaltyKey)
+            .get();
+        clientRoyaltyOrderIndex = priorOrdersSnap.size + 1;
+    }
     const productSnaps = await db.getAll(...productRefs);
     const orderItems = [];
     let productSubtotal = 0;
@@ -1856,6 +1961,45 @@ export const createOrder = functions.https.onCall(async (data, context) => {
                 : 'skipped',
         resolvedAt: admin.firestore.FieldValue.serverTimestamp(),
     };
+    let royaltyAssessment = null;
+    if (assignmentResult?.franchiseId) {
+        try {
+            const franchiseDoc = await db.collection('franchises').doc(assignmentResult.franchiseId).get();
+            if (franchiseDoc.exists) {
+                const franchiseData = franchiseDoc.data();
+                const royaltyConfig = parseRoyaltyConfigDoc(franchiseData?.royalty);
+                const orderIndexForRoyalty = clientRoyaltyOrderIndex ?? 1;
+                const resolution = resolveRoyaltyTier(royaltyConfig, leadSourceNormalised, orderIndexForRoyalty);
+                royaltyAssessment = {
+                    source: leadSourceNormalised,
+                    orderIndex: orderIndexForRoyalty,
+                    previousOrdersCount: orderIndexForRoyalty > 0 ? orderIndexForRoyalty - 1 : 0,
+                    percentage: resolution.percentage,
+                    tier: resolution.tier
+                        ? {
+                            minOrder: resolution.tier.minOrder,
+                            maxOrder: resolution.tier.maxOrder,
+                            percentage: resolution.tier.percentage,
+                        }
+                        : null,
+                    configSnapshot: {
+                        hqTiers: royaltyConfig.hqTiers.map((tier) => ({
+                            minOrder: tier.minOrder,
+                            maxOrder: tier.maxOrder,
+                            percentage: tier.percentage,
+                        })),
+                        franchiseSourcedPercentage: royaltyConfig.franchiseSourcedPercentage,
+                    },
+                    clientKey: clientRoyaltyKey,
+                    clientKeyType: clientRoyaltyKeyType,
+                    computedAt: admin.firestore.FieldValue.serverTimestamp(),
+                };
+            }
+        }
+        catch (royaltyErr) {
+            console.warn('Failed to resolve royalty configuration', royaltyErr);
+        }
+    }
     const orderData = {
         userId: context.auth?.uid || null,
         userEmail: context.auth?.token.email || userEmail || null,
@@ -1886,6 +2030,10 @@ export const createOrder = functions.https.onCall(async (data, context) => {
         status: 'pending',
         createdAt: admin.firestore.FieldValue.serverTimestamp(),
         franchiseAssignment: assignmentMeta,
+        royaltySource: leadSourceNormalised,
+        clientRoyaltyKey: clientRoyaltyKey || null,
+        clientRoyaltyKeyType: clientRoyaltyKeyType || null,
+        clientRoyaltyOrderIndex: clientRoyaltyOrderIndex,
     };
     if (assignmentResult) {
         orderData.franchiseId = assignmentResult.franchiseId;
@@ -1924,6 +2072,14 @@ export const createOrder = functions.https.onCall(async (data, context) => {
         orderData.franchiseAssignedRole = null;
         orderData.franchiseAssignedIsPrimary = false;
         orderData.franchiseAssignedUser = null;
+    }
+    if (royaltyAssessment) {
+        orderData.royalty = royaltyAssessment;
+        orderData.royaltyPercentage = royaltyAssessment.percentage;
+    }
+    else {
+        orderData.royalty = null;
+        orderData.royaltyPercentage = null;
     }
     const orderRef = await db.collection('orders').add(orderData);
     return { orderId: orderRef.id };

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -907,6 +907,529 @@ export const reserveKit = functions.https.onCall(async (data) => {
     await batch.commit();
     return { conflicts: [], kitItems, rentalTotal };
 });
+function normaliseRoles(raw) {
+    if (!raw || typeof raw !== 'object') {
+        return {};
+    }
+    const roles = {};
+    Object.entries(raw).forEach(([key, value]) => {
+        if (value === true) {
+            roles[key] = true;
+        }
+    });
+    return roles;
+}
+async function loadUserContext(uid) {
+    const snap = await db.collection('users').doc(uid).get();
+    const data = snap.data() ?? {};
+    const roles = normaliseRoles(data.roles);
+    const displayName = typeof data.displayName === 'string' && data.displayName.trim().length
+        ? data.displayName.trim()
+        : typeof data.fullName === 'string' && data.fullName.trim().length
+            ? data.fullName.trim()
+            : null;
+    const email = typeof data.email === 'string' && data.email.includes('@') ? data.email : null;
+    const rawPrimary = typeof data.primaryFranchiseId === 'string' && data.primaryFranchiseId.trim().length
+        ? data.primaryFranchiseId.trim()
+        : null;
+    const rawFranchise = typeof data.franchiseId === 'string' && data.franchiseId.trim().length
+        ? data.franchiseId.trim()
+        : null;
+    const franchiseIds = new Set();
+    if (rawPrimary) {
+        franchiseIds.add(rawPrimary);
+    }
+    if (rawFranchise) {
+        franchiseIds.add(rawFranchise);
+    }
+    const extra = Array.isArray(data.franchiseIds)
+        ? data.franchiseIds.filter((value) => typeof value === 'string' && value.trim().length > 0)
+        : [];
+    extra.forEach((value) => franchiseIds.add(value.trim()));
+    const isStaff = data.isStaff === true || roles.admin === true || roles.operations === true || roles.projects === true;
+    return {
+        uid,
+        displayName,
+        email,
+        isStaff,
+        roles,
+        franchiseIds: Array.from(franchiseIds),
+        primaryFranchiseId: rawPrimary || rawFranchise || null,
+    };
+}
+function parseCurrency(value) {
+    if (typeof value === 'string' && value.trim().length >= 3) {
+        return value.trim().slice(0, 3).toUpperCase();
+    }
+    return 'GBP';
+}
+function parseMoney(value, fallback = 0) {
+    const numeric = typeof value === 'string' ? Number(value) : Number(value);
+    if (!Number.isFinite(numeric) || Number.isNaN(numeric)) {
+        return fallback;
+    }
+    return Math.max(0, Math.round(numeric * 100) / 100);
+}
+function assertPositive(value, field) {
+    if (value < 0) {
+        throw new functions.https.HttpsError('invalid-argument', `${field} must be zero or positive.`);
+    }
+}
+async function assertFranchiseMembership(uid, franchiseId) {
+    const snap = await db
+        .collection('franchiseMembers')
+        .where('userId', '==', uid)
+        .where('franchiseId', '==', franchiseId)
+        .limit(1)
+        .get();
+    return !snap.empty;
+}
+export const taskOffers_create = functions.https.onCall(async (data, context) => {
+    if (!context.auth) {
+        throw new functions.https.HttpsError('unauthenticated', 'Sign in required');
+    }
+    const uid = context.auth.uid;
+    const projectId = typeof data?.projectId === 'string' ? data.projectId.trim() : '';
+    const taskId = typeof data?.taskId === 'string' ? data.taskId.trim() : '';
+    if (!projectId || !taskId) {
+        throw new functions.https.HttpsError('invalid-argument', 'projectId and taskId are required');
+    }
+    const targetTypeRaw = typeof data?.targetType === 'string' ? data.targetType.trim().toLowerCase() : '';
+    if (targetTypeRaw !== 'hq' && targetTypeRaw !== 'franchise') {
+        throw new functions.https.HttpsError('invalid-argument', 'targetType must be "hq" or "franchise"');
+    }
+    const targetType = targetTypeRaw;
+    const targetFranchiseIdRaw = typeof data?.targetFranchiseId === 'string' ? data.targetFranchiseId.trim() : '';
+    const targetFranchiseId = targetType === 'franchise' ? targetFranchiseIdRaw : '';
+    if (targetType === 'franchise' && !targetFranchiseId) {
+        throw new functions.https.HttpsError('invalid-argument', 'targetFranchiseId is required for franchise offers');
+    }
+    const targetUserId = typeof data?.targetUserId === 'string' && data.targetUserId.trim().length
+        ? data.targetUserId.trim()
+        : null;
+    const role = typeof data?.role === 'string' && data.role.trim().length ? data.role.trim() : null;
+    const currency = parseCurrency(data?.currency);
+    const totalAmount = parseMoney(data?.totalAmount ?? data?.total ?? data?.feeTotal, NaN);
+    if (!Number.isFinite(totalAmount) || totalAmount <= 0) {
+        throw new functions.https.HttpsError('invalid-argument', 'totalAmount must be greater than zero');
+    }
+    let paymentMode = data?.paymentMode === 'balance_on_completion' ? 'balance_on_completion' : 'deposit_balance';
+    let depositAmount = parseMoney(data?.depositAmount ?? data?.deposit, 0);
+    assertPositive(depositAmount, 'depositAmount');
+    if (paymentMode === 'balance_on_completion') {
+        depositAmount = 0;
+    }
+    if (depositAmount > totalAmount) {
+        throw new functions.https.HttpsError('invalid-argument', 'depositAmount cannot exceed totalAmount');
+    }
+    let balanceAmount = parseMoney(data?.balanceAmount ?? data?.balance, totalAmount - depositAmount);
+    if (paymentMode === 'deposit_balance') {
+        balanceAmount = Math.max(0, Math.round((totalAmount - depositAmount) * 100) / 100);
+    }
+    else {
+        balanceAmount = totalAmount;
+    }
+    assertPositive(balanceAmount, 'balanceAmount');
+    const notes = typeof data?.notes === 'string' && data.notes.trim().length ? data.notes.trim() : null;
+    const [userContext, projectSnap, taskSnap] = await Promise.all([
+        loadUserContext(uid),
+        db.collection('projects').doc(projectId).get(),
+        db.collection('projects').doc(projectId).collection('tasks').doc(taskId).get(),
+    ]);
+    if (!projectSnap.exists) {
+        throw new functions.https.HttpsError('not-found', 'Project not found');
+    }
+    if (!taskSnap.exists) {
+        throw new functions.https.HttpsError('not-found', 'Task not found');
+    }
+    if (!userContext.isStaff && userContext.franchiseIds.length === 0) {
+        throw new functions.https.HttpsError('permission-denied', 'Franchise membership required to outsource tasks');
+    }
+    const proposerFranchiseId = userContext.primaryFranchiseId || userContext.franchiseIds[0] || null;
+    const projectData = projectSnap.data();
+    const projectFranchiseId = typeof projectData.franchiseId === 'string' ? projectData.franchiseId : null;
+    if (!userContext.isStaff && projectFranchiseId && !userContext.franchiseIds.includes(projectFranchiseId)) {
+        // Ensure the proposer belongs to the franchise that owns the project
+        const hasMembership = await assertFranchiseMembership(uid, projectFranchiseId);
+        if (!hasMembership) {
+            throw new functions.https.HttpsError('permission-denied', 'You are not assigned to this franchise project');
+        }
+    }
+    const taskRef = db.collection('projects').doc(projectId).collection('tasks').doc(taskId);
+    const offerRef = taskRef.collection('offers').doc();
+    const timestamp = admin.firestore.FieldValue.serverTimestamp();
+    const offerDoc = {
+        projectId,
+        taskId,
+        role,
+        status: 'pending',
+        requesterUid: uid,
+        requesterFranchiseId: proposerFranchiseId,
+        requesterName: userContext.displayName || userContext.email || uid,
+        targetType,
+        targetFranchiseId: targetType === 'franchise' ? targetFranchiseId : null,
+        targetUserId,
+        currency,
+        totalAmount,
+        depositAmount,
+        balanceAmount,
+        paymentMode,
+        notes,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+    };
+    await offerRef.set(offerDoc);
+    const existingProposal = taskSnap.data()?.outsourcingProposal;
+    const proposalPayload = {
+        ...existingProposal,
+        offerId: offerRef.id,
+        status: 'pending',
+        proposedByUid: uid,
+        proposedByFranchiseId: proposerFranchiseId,
+        proposedByName: userContext.displayName || userContext.email || uid,
+        targetType,
+        targetFranchiseId: targetType === 'franchise' ? targetFranchiseId : null,
+        targetUserId,
+        role,
+        currency,
+        totalAmount,
+        depositAmount,
+        balanceAmount,
+        paymentMode,
+        notes,
+        createdAt: existingProposal?.createdAt ?? timestamp,
+        updatedAt: timestamp,
+        respondedAt: null,
+        respondedByUid: null,
+        responseNotes: null,
+        counter: null,
+    };
+    await taskRef.set({
+        outsourcingProposal: proposalPayload,
+        outsourcingStatus: 'pending',
+    }, { merge: true });
+    await db.collection('taskHistory').add({
+        projectId,
+        taskId,
+        action: 'outsourcing_offer_created',
+        uid,
+        metadata: {
+            offerId: offerRef.id,
+            targetType,
+            targetFranchiseId: proposalPayload.targetFranchiseId,
+            targetUserId,
+            totalAmount,
+            currency,
+            paymentMode,
+        },
+        createdAt: timestamp,
+    });
+    return { offerId: offerRef.id };
+});
+export const taskOffers_respond = functions.https.onCall(async (data, context) => {
+    if (!context.auth) {
+        throw new functions.https.HttpsError('unauthenticated', 'Sign in required');
+    }
+    const uid = context.auth.uid;
+    const projectId = typeof data?.projectId === 'string' ? data.projectId.trim() : '';
+    const taskId = typeof data?.taskId === 'string' ? data.taskId.trim() : '';
+    const offerId = typeof data?.offerId === 'string' ? data.offerId.trim() : '';
+    if (!projectId || !taskId || !offerId) {
+        throw new functions.https.HttpsError('invalid-argument', 'projectId, taskId, and offerId are required');
+    }
+    const actionRaw = typeof data?.action === 'string' ? data.action.trim().toLowerCase() : '';
+    if (!['accept', 'reject', 'counter', 'withdraw'].includes(actionRaw)) {
+        throw new functions.https.HttpsError('invalid-argument', 'Unsupported action');
+    }
+    const action = actionRaw;
+    const notes = typeof data?.notes === 'string' && data.notes.trim().length ? data.notes.trim() : null;
+    const taskRef = db.collection('projects').doc(projectId).collection('tasks').doc(taskId);
+    const offerRef = taskRef.collection('offers').doc(offerId);
+    const [userContext, offerSnap, taskSnap] = await Promise.all([
+        loadUserContext(uid),
+        offerRef.get(),
+        taskRef.get(),
+    ]);
+    if (!offerSnap.exists) {
+        throw new functions.https.HttpsError('not-found', 'Offer not found');
+    }
+    const offer = offerSnap.data();
+    if (offer.projectId !== projectId || offer.taskId !== taskId) {
+        throw new functions.https.HttpsError('failed-precondition', 'Offer does not match project/task');
+    }
+    const proposal = taskSnap.data()?.outsourcingProposal;
+    const isRequester = offer.requesterUid === uid;
+    let isTargetFranchise = offer.targetType === 'franchise' && offer.targetFranchiseId
+        ? userContext.franchiseIds.includes(offer.targetFranchiseId)
+        : false;
+    const isTargetHq = offer.targetType === 'hq' ? userContext.isStaff : false;
+    if (offer.targetType === 'franchise' && !isTargetFranchise && offer.targetFranchiseId) {
+        const hasMembership = await assertFranchiseMembership(uid, offer.targetFranchiseId);
+        if (hasMembership) {
+            userContext.franchiseIds.push(offer.targetFranchiseId);
+            isTargetFranchise = true;
+        }
+    }
+    const isTarget = isTargetFranchise || isTargetHq;
+    const timestamp = admin.firestore.FieldValue.serverTimestamp();
+    if (action === 'withdraw') {
+        if (!isRequester) {
+            throw new functions.https.HttpsError('permission-denied', 'Only the requester can withdraw an offer');
+        }
+        if (offer.status !== 'pending' && offer.status !== 'countered') {
+            throw new functions.https.HttpsError('failed-precondition', 'Only pending offers can be withdrawn');
+        }
+        await offerRef.set({
+            status: 'withdrawn',
+            respondedByUid: uid,
+            respondedAt: timestamp,
+            responseNotes: notes ?? null,
+            updatedAt: timestamp,
+        }, { merge: true });
+        if (proposal) {
+            await taskRef.set({
+                outsourcingProposal: {
+                    ...proposal,
+                    status: 'withdrawn',
+                    respondedByUid: uid,
+                    respondedAt: timestamp,
+                    responseNotes: notes ?? null,
+                    updatedAt: timestamp,
+                },
+                outsourcingStatus: 'withdrawn',
+            }, { merge: true });
+        }
+        await db.collection('taskHistory').add({
+            projectId,
+            taskId,
+            action: 'outsourcing_offer_withdrawn',
+            uid,
+            metadata: { offerId },
+            createdAt: timestamp,
+        });
+        return { status: 'withdrawn' };
+    }
+    if (action === 'counter') {
+        if (!isTarget) {
+            throw new functions.https.HttpsError('permission-denied', 'Only the recipient can counter an offer');
+        }
+        if (offer.status !== 'pending') {
+            throw new functions.https.HttpsError('failed-precondition', 'Only pending offers can be countered');
+        }
+        const counterCurrency = parseCurrency(data?.currency ?? offer.currency);
+        const counterTotal = parseMoney(data?.totalAmount ?? data?.total ?? offer.totalAmount, offer.totalAmount);
+        if (counterTotal <= 0) {
+            throw new functions.https.HttpsError('invalid-argument', 'Counter total must be greater than zero');
+        }
+        const counterMode = data?.paymentMode === 'balance_on_completion' ? 'balance_on_completion' : 'deposit_balance';
+        let counterDeposit = parseMoney(data?.depositAmount ?? data?.deposit, offer.depositAmount);
+        if (counterMode === 'balance_on_completion') {
+            counterDeposit = 0;
+        }
+        if (counterDeposit > counterTotal) {
+            throw new functions.https.HttpsError('invalid-argument', 'Counter deposit cannot exceed total');
+        }
+        let counterBalance = parseMoney(data?.balanceAmount ?? data?.balance, counterMode === 'deposit_balance' ? counterTotal - counterDeposit : counterTotal);
+        if (counterMode === 'deposit_balance') {
+            counterBalance = Math.max(0, Math.round((counterTotal - counterDeposit) * 100) / 100);
+        }
+        else {
+            counterBalance = counterTotal;
+        }
+        await offerRef.set({
+            status: 'countered',
+            counterProposal: {
+                currency: counterCurrency,
+                totalAmount: counterTotal,
+                depositAmount: counterDeposit,
+                balanceAmount: counterBalance,
+                paymentMode: counterMode,
+                notes,
+                proposedByUid: uid,
+                proposedAt: timestamp,
+            },
+            respondedByUid: uid,
+            respondedAt: timestamp,
+            responseNotes: notes ?? null,
+            updatedAt: timestamp,
+        }, { merge: true });
+        if (proposal) {
+            await taskRef.set({
+                outsourcingProposal: {
+                    ...proposal,
+                    status: 'countered',
+                    counter: {
+                        currency: counterCurrency,
+                        totalAmount: counterTotal,
+                        depositAmount: counterDeposit,
+                        balanceAmount: counterBalance,
+                        paymentMode: counterMode,
+                        notes,
+                        proposedByUid: uid,
+                        proposedAt: timestamp,
+                    },
+                    respondedByUid: uid,
+                    respondedAt: timestamp,
+                    responseNotes: notes ?? null,
+                    updatedAt: timestamp,
+                },
+                outsourcingStatus: 'countered',
+            }, { merge: true });
+        }
+        await db.collection('taskHistory').add({
+            projectId,
+            taskId,
+            action: 'outsourcing_offer_countered',
+            uid,
+            metadata: { offerId, totalAmount: counterTotal, currency: counterCurrency },
+            createdAt: timestamp,
+        });
+        return { status: 'countered' };
+    }
+    if (action === 'reject') {
+        const canRejectTarget = isTarget && offer.status === 'pending';
+        const canRejectRequester = isRequester && offer.status === 'countered';
+        if (!canRejectTarget && !canRejectRequester) {
+            throw new functions.https.HttpsError('permission-denied', 'You cannot reject this offer');
+        }
+        await offerRef.set({
+            status: 'rejected',
+            respondedByUid: uid,
+            respondedAt: timestamp,
+            responseNotes: notes ?? null,
+            updatedAt: timestamp,
+        }, { merge: true });
+        if (proposal) {
+            await taskRef.set({
+                outsourcingProposal: {
+                    ...proposal,
+                    status: 'rejected',
+                    respondedByUid: uid,
+                    respondedAt: timestamp,
+                    responseNotes: notes ?? null,
+                    updatedAt: timestamp,
+                },
+                outsourcingStatus: 'rejected',
+            }, { merge: true });
+        }
+        await db.collection('taskHistory').add({
+            projectId,
+            taskId,
+            action: 'outsourcing_offer_rejected',
+            uid,
+            metadata: { offerId },
+            createdAt: timestamp,
+        });
+        return { status: 'rejected' };
+    }
+    if (action === 'accept') {
+        const acceptingTarget = isTarget && offer.status === 'pending';
+        const acceptingRequester = isRequester && offer.status === 'countered';
+        if (!acceptingTarget && !acceptingRequester) {
+            throw new functions.https.HttpsError('permission-denied', 'You cannot accept this offer');
+        }
+        const terms = offer.status === 'countered' && offer.counterProposal
+            ? {
+                currency: offer.counterProposal.currency,
+                totalAmount: offer.counterProposal.totalAmount,
+                depositAmount: offer.counterProposal.depositAmount,
+                balanceAmount: offer.counterProposal.balanceAmount,
+                paymentMode: offer.counterProposal.paymentMode,
+                notes: offer.counterProposal.notes ?? null,
+            }
+            : {
+                currency: offer.currency,
+                totalAmount: offer.totalAmount,
+                depositAmount: offer.depositAmount,
+                balanceAmount: offer.balanceAmount,
+                paymentMode: offer.paymentMode,
+                notes: offer.notes ?? null,
+            };
+        await offerRef.set({
+            status: 'accepted',
+            acceptedTerms: {
+                ...terms,
+                acceptedByUid: uid,
+                acceptedAt: timestamp,
+            },
+            respondedByUid: uid,
+            respondedAt: timestamp,
+            responseNotes: notes ?? null,
+            updatedAt: timestamp,
+        }, { merge: true });
+        let assigneeName = null;
+        const assignmentScope = offer.targetType === 'franchise' ? 'franchise' : 'hq';
+        const assignedTo = offer.targetUserId || null;
+        if (assignedTo) {
+            const assigneeSnap = await db.collection('users').doc(assignedTo).get();
+            const assigneeData = assigneeSnap.data();
+            if (assigneeData) {
+                assigneeName =
+                    (typeof assigneeData.displayName === 'string' && assigneeData.displayName.trim().length
+                        ? assigneeData.displayName.trim()
+                        : null) ||
+                        (typeof assigneeData.fullName === 'string' && assigneeData.fullName.trim().length
+                            ? assigneeData.fullName.trim()
+                            : null) ||
+                        (typeof assigneeData.email === 'string' ? assigneeData.email : null);
+            }
+        }
+        const agreement = {
+            offerId,
+            providerType: offer.targetType,
+            providerFranchiseId: offer.targetType === 'franchise' ? offer.targetFranchiseId ?? null : null,
+            providerUserId: offer.targetUserId || null,
+            currency: terms.currency,
+            totalAmount: terms.totalAmount,
+            depositAmount: terms.depositAmount,
+            balanceAmount: terms.balanceAmount,
+            paymentMode: terms.paymentMode,
+            notes: terms.notes ?? null,
+            acceptedAt: timestamp,
+            acceptedByUid: uid,
+            responseNotes: notes ?? null,
+        };
+        const taskUpdate = {
+            outsourcingAgreement: agreement,
+            outsourcingStatus: 'accepted',
+            assignmentScope,
+            updatedAt: timestamp,
+        };
+        if (assignedTo || offer.targetType === 'hq') {
+            taskUpdate.assignedTo = assignedTo;
+            taskUpdate.assigneeName = assigneeName;
+        }
+        if (proposal) {
+            taskUpdate.outsourcingProposal = {
+                ...proposal,
+                status: 'accepted',
+                respondedByUid: uid,
+                respondedAt: timestamp,
+                responseNotes: notes ?? null,
+                updatedAt: timestamp,
+                acceptedTerms: agreement,
+            };
+        }
+        await taskRef.set(taskUpdate, { merge: true });
+        await db.collection('taskHistory').add({
+            projectId,
+            taskId,
+            action: 'outsourcing_offer_accepted',
+            uid,
+            metadata: {
+                offerId,
+                providerType: offer.targetType,
+                providerFranchiseId: agreement.providerFranchiseId,
+                providerUserId: agreement.providerUserId,
+                totalAmount: terms.totalAmount,
+                currency: terms.currency,
+            },
+            createdAt: timestamp,
+        });
+        return { status: 'accepted' };
+    }
+    throw new functions.https.HttpsError('internal', 'Unhandled action');
+});
 async function sendEmail(to, subject, body) {
     try {
         const keyB64 = process.env.GMAIL_SERVICE_ACCOUNT_KEY_BASE64;

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -32,6 +32,149 @@ admin.initializeApp({
 const db = admin.firestore();
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2024-06-20' });
 const VAT_RATE = 0.2;
+function normalisePostalCode(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return null;
+    }
+    const cleaned = trimmed.toUpperCase().replace(/[^A-Z0-9]/g, '');
+    if (!cleaned) {
+        return null;
+    }
+    return cleaned;
+}
+function extractTerritoryPostalCodes(data) {
+    const raw = data.postalCodes;
+    const list = [];
+    if (Array.isArray(raw)) {
+        raw.forEach((value) => {
+            if (value == null) {
+                return;
+            }
+            list.push(String(value));
+        });
+    }
+    else if (typeof raw === 'string') {
+        raw
+            .split(/\r?\n|,/)
+            .map((item) => item.trim())
+            .filter(Boolean)
+            .forEach((item) => list.push(item));
+    }
+    return list
+        .map((value) => {
+        const normalised = normalisePostalCode(value);
+        if (!normalised) {
+            return null;
+        }
+        return { raw: value, normalised };
+    })
+        .filter((item) => item !== null);
+}
+async function resolveTerritoryForPostalCode(postalCode) {
+    const normalisedInput = normalisePostalCode(postalCode);
+    if (!normalisedInput) {
+        return null;
+    }
+    const territoriesSnap = await db.collection('franchiseTerritories').get();
+    let best = null;
+    for (const territoryDoc of territoriesSnap.docs) {
+        const data = territoryDoc.data();
+        if (!data?.franchiseId) {
+            continue;
+        }
+        if (data.type && data.type !== 'postal') {
+            // Radius-based routing requires geospatial inputs; skip for postal-only auto routing.
+            continue;
+        }
+        const codes = extractTerritoryPostalCodes(data);
+        for (const code of codes) {
+            if (!code.normalised) {
+                continue;
+            }
+            let matchType = null;
+            let score = 0;
+            if (code.normalised === normalisedInput) {
+                matchType = 'exact';
+                score = 2000 + code.normalised.length;
+            }
+            else if (normalisedInput.startsWith(code.normalised)) {
+                matchType = 'prefix';
+                score = 1200 + code.normalised.length;
+            }
+            else if (code.normalised.startsWith(normalisedInput)) {
+                // Allow territories defined with full codes while customer provided a broader area.
+                matchType = 'superset';
+                score = 800 + normalisedInput.length;
+            }
+            if (!matchType) {
+                continue;
+            }
+            if (data.exclusive !== false) {
+                score += 50;
+            }
+            if (!best || score > best.score) {
+                best = {
+                    score,
+                    result: {
+                        franchiseId: data.franchiseId,
+                        territoryId: territoryDoc.id,
+                        territoryLabel: typeof data.label === 'string' ? data.label : null,
+                        territoryPostalCode: code.normalised,
+                        matchType,
+                        exclusive: data.exclusive !== false,
+                    },
+                };
+            }
+        }
+    }
+    if (!best) {
+        return null;
+    }
+    return best.result;
+}
+async function resolvePrimaryFranchiseMember(franchiseId) {
+    const membersSnap = await db
+        .collection('franchiseMembers')
+        .where('franchiseId', '==', franchiseId)
+        .get();
+    if (membersSnap.empty) {
+        return null;
+    }
+    const members = membersSnap.docs.map((doc) => {
+        const data = doc.data();
+        return {
+            memberId: doc.id,
+            userId: data.userId ? String(data.userId) : '',
+            role: data.role ? String(data.role) : null,
+            primary: data.primary === true,
+        };
+    });
+    const prioritised = members.find((member) => member.primary && member.userId) ||
+        members.find((member) => member.role === 'franchisee' && member.userId) ||
+        members.find((member) => member.userId) ||
+        null;
+    if (!prioritised) {
+        return null;
+    }
+    const userSnap = await db.collection('users').doc(prioritised.userId).get();
+    const profile = userSnap.exists
+        ? {
+            displayName: userSnap.data()?.displayName ?? null,
+            email: userSnap.data()?.email ?? null,
+        }
+        : null;
+    return {
+        memberId: prioritised.memberId,
+        userId: prioritised.userId,
+        role: prioritised.role,
+        primary: prioritised.primary,
+        userProfile: profile,
+    };
+}
 const ROLE_KEYS = ['admin', 'operations', 'finance', 'projects', 'sales', 'marketing'];
 const AUDIT_LOG_RETENTION_DAYS = 180;
 const AUDIT_LOG_BATCH_SIZE = 500;
@@ -1555,7 +1698,7 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     const parseOptional = (value) => value === undefined || value === null ? undefined : toNumber(value);
     const DEFAULT_TRAVEL_MILES = 100;
     const DEFAULT_TRAVEL_RATE = 0.3;
-    const { items, userEmail, customerName, companyName, location, projectName, voucher, kitItems = [], rentalSubtotal = 0, } = data;
+    const { items, userEmail, customerName, companyName, location, postalCode, projectName, voucher, kitItems = [], rentalSubtotal = 0, } = data;
     if (!items || !Array.isArray(items) || items.length === 0) {
         throw new functions.https.HttpsError('invalid-argument', 'items are required');
     }
@@ -1694,12 +1837,33 @@ export const createOrder = functions.https.onCall(async (data, context) => {
         grossRevenue: price,
         profit,
     };
-    const orderRef = await db.collection('orders').add({
+    const postalCodeValue = typeof postalCode === 'string' ? postalCode : null;
+    const normalisedPostalCode = normalisePostalCode(postalCodeValue);
+    const assignmentResult = normalisedPostalCode
+        ? await resolveTerritoryForPostalCode(normalisedPostalCode)
+        : null;
+    const assignmentMember = assignmentResult
+        ? await resolvePrimaryFranchiseMember(assignmentResult.franchiseId)
+        : null;
+    const assignmentMeta = {
+        strategy: 'postal_code_auto_route',
+        inputPostalCode: postalCodeValue || null,
+        normalizedPostalCode: normalisedPostalCode || null,
+        status: assignmentResult
+            ? 'matched'
+            : normalisedPostalCode
+                ? 'unmatched'
+                : 'skipped',
+        resolvedAt: admin.firestore.FieldValue.serverTimestamp(),
+    };
+    const orderData = {
         userId: context.auth?.uid || null,
         userEmail: context.auth?.token.email || userEmail || null,
         customerName,
         companyName: companyName || null,
         location: location || null,
+        clientPostalCode: postalCodeValue || null,
+        clientPostalCodeNormalised: normalisedPostalCode || null,
         projectName: projectName || null,
         voucher: voucherCode,
         items: orderItems,
@@ -1721,7 +1885,47 @@ export const createOrder = functions.https.onCall(async (data, context) => {
         profit,
         status: 'pending',
         createdAt: admin.firestore.FieldValue.serverTimestamp(),
-    });
+        franchiseAssignment: assignmentMeta,
+    };
+    if (assignmentResult) {
+        orderData.franchiseId = assignmentResult.franchiseId;
+        orderData.franchiseTerritoryId = assignmentResult.territoryId;
+        assignmentMeta.matchType = assignmentResult.matchType;
+        assignmentMeta.franchiseId = assignmentResult.franchiseId;
+        assignmentMeta.territoryId = assignmentResult.territoryId;
+        assignmentMeta.territoryPostalCode = assignmentResult.territoryPostalCode;
+        assignmentMeta.territoryLabel = assignmentResult.territoryLabel;
+        assignmentMeta.exclusive = assignmentResult.exclusive;
+    }
+    else {
+        orderData.franchiseId = null;
+        orderData.franchiseTerritoryId = null;
+    }
+    if (assignmentMember) {
+        orderData.franchiseAssignedMemberId = assignmentMember.memberId;
+        orderData.franchiseAssignedUserId = assignmentMember.userId;
+        orderData.franchiseAssignedRole = assignmentMember.role || null;
+        orderData.franchiseAssignedIsPrimary = assignmentMember.primary;
+        orderData.franchiseAssignedUser = assignmentMember.userProfile
+            ? {
+                uid: assignmentMember.userId,
+                displayName: assignmentMember.userProfile.displayName || null,
+                email: assignmentMember.userProfile.email || null,
+            }
+            : {
+                uid: assignmentMember.userId,
+                displayName: null,
+                email: null,
+            };
+    }
+    else {
+        orderData.franchiseAssignedMemberId = null;
+        orderData.franchiseAssignedUserId = null;
+        orderData.franchiseAssignedRole = null;
+        orderData.franchiseAssignedIsPrimary = false;
+        orderData.franchiseAssignedUser = null;
+    }
+    const orderRef = await db.collection('orders').add(orderData);
     return { orderId: orderRef.id };
 });
 /**

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -53,6 +53,109 @@ type FranchiseMemberDoc = {
   primary?: boolean;
 };
 
+type RoyaltySource = 'hq' | 'franchisee';
+
+interface FranchiseRoyaltyTierConfig {
+  minOrder: number;
+  maxOrder: number | null;
+  percentage: number;
+}
+
+interface FranchiseRoyaltyConfigDoc {
+  hqTiers: FranchiseRoyaltyTierConfig[];
+  franchiseSourcedPercentage: number;
+}
+
+function defaultRoyaltyConfig(): FranchiseRoyaltyConfigDoc {
+  return {
+    hqTiers: [
+      { minOrder: 1, maxOrder: 1, percentage: 20 },
+      { minOrder: 2, maxOrder: 2, percentage: 15 },
+      { minOrder: 3, maxOrder: 5, percentage: 10 },
+      { minOrder: 6, maxOrder: null, percentage: 6 },
+    ],
+    franchiseSourcedPercentage: 6,
+  };
+}
+
+function parseRoyaltyTierDoc(input: unknown): FranchiseRoyaltyTierConfig | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+  const data = input as Record<string, unknown>;
+  const min = Number(data.minOrder ?? data.orderFrom ?? data.start ?? data.from);
+  const maxValue = data.maxOrder ?? data.orderThrough ?? data.end ?? data.to;
+  const percentage = Number(data.percentage ?? data.rate ?? data.percent ?? data.value);
+  if (!Number.isFinite(min) || min <= 0 || !Number.isFinite(percentage)) {
+    return null;
+  }
+  const parsedMax = maxValue == null || maxValue === '' ? null : Number(maxValue);
+  const tier: FranchiseRoyaltyTierConfig = {
+    minOrder: Math.max(1, Math.floor(min)),
+    maxOrder: null,
+    percentage,
+  };
+  if (parsedMax !== null && Number.isFinite(parsedMax)) {
+    const normalisedMax = Math.floor(Number(parsedMax));
+    tier.maxOrder = Math.max(normalisedMax, tier.minOrder);
+  }
+  return tier;
+}
+
+function parseRoyaltyConfigDoc(raw: unknown): FranchiseRoyaltyConfigDoc {
+  const fallback = defaultRoyaltyConfig();
+  if (!raw || typeof raw !== 'object') {
+    return fallback;
+  }
+  const data = raw as Record<string, unknown>;
+  const tierValues: unknown = data.hqTiers ?? data.hq ?? data.slidingScale;
+  const tiers = Array.isArray(tierValues)
+    ? tierValues
+        .map((value) => parseRoyaltyTierDoc(value))
+        .filter((value): value is FranchiseRoyaltyTierConfig => value !== null)
+        .sort((a, b) => a.minOrder - b.minOrder)
+    : [];
+  const franchiseValue = Number(
+    data.franchiseSourcedPercentage ?? data.franchise ?? data.local ?? data.direct
+  );
+  const franchisePercentage = Number.isFinite(franchiseValue)
+    ? franchiseValue
+    : fallback.franchiseSourcedPercentage;
+  return {
+    hqTiers: tiers.length > 0 ? tiers : fallback.hqTiers,
+    franchiseSourcedPercentage: franchisePercentage,
+  };
+}
+
+function resolveRoyaltyTier(
+  config: FranchiseRoyaltyConfigDoc,
+  source: RoyaltySource,
+  orderIndex: number
+): { percentage: number; tier: FranchiseRoyaltyTierConfig | null } {
+  const fallback = defaultRoyaltyConfig();
+  if (source === 'franchisee') {
+    return {
+      percentage: config.franchiseSourcedPercentage ?? fallback.franchiseSourcedPercentage,
+      tier: null,
+    };
+  }
+  const tiers = (config.hqTiers?.length ? config.hqTiers : fallback.hqTiers).slice().sort((a, b) => a.minOrder - b.minOrder);
+  const index = Number(orderIndex);
+  if (!Number.isFinite(index) || index <= 0) {
+    const first = tiers[0] ?? fallback.hqTiers[0];
+    return { percentage: first.percentage, tier: first };
+  }
+  for (const tier of tiers) {
+    const withinLower = index >= tier.minOrder;
+    const withinUpper = tier.maxOrder == null || index <= tier.maxOrder;
+    if (withinLower && withinUpper) {
+      return { percentage: tier.percentage, tier };
+    }
+  }
+  const lastTier = tiers[tiers.length - 1] ?? fallback.hqTiers[fallback.hqTiers.length - 1];
+  return { percentage: lastTier.percentage, tier: lastTier };
+}
+
 type FranchiseAssignmentMatchType = 'exact' | 'prefix' | 'superset';
 
 interface FranchiseAssignmentResult {
@@ -1831,12 +1934,41 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     voucher,
     kitItems = [],
     rentalSubtotal = 0,
+    leadSource: leadSourceInput,
   } = data;
   if (!items || !Array.isArray(items) || items.length === 0) {
     throw new functions.https.HttpsError('invalid-argument', 'items are required');
   }
 
   const productRefs = items.map((i: any) => db.collection('products').doc(i.id));
+  const leadSourceNormalised: RoyaltySource =
+    typeof leadSourceInput === 'string' && leadSourceInput.toLowerCase().includes('franchise')
+      ? 'franchisee'
+      : 'hq';
+  const authEmail =
+    typeof context.auth?.token.email === 'string' ? (context.auth.token.email as string) : null;
+  const requestEmail = typeof userEmail === 'string' ? (userEmail as string) : null;
+  const preferredEmail = authEmail || requestEmail;
+  const normalisedEmail = preferredEmail ? preferredEmail.trim().toLowerCase() : null;
+  const clientRoyaltyKeyType: 'user_id' | 'email' | null = context.auth?.uid
+    ? 'user_id'
+    : normalisedEmail
+      ? 'email'
+      : null;
+  const clientRoyaltyKey =
+    clientRoyaltyKeyType === 'user_id'
+      ? `uid:${context.auth?.uid as string}`
+      : clientRoyaltyKeyType === 'email' && normalisedEmail
+        ? `email:${normalisedEmail}`
+        : null;
+  let clientRoyaltyOrderIndex: number | null = null;
+  if (clientRoyaltyKey) {
+    const priorOrdersSnap = await db
+      .collection('orders')
+      .where('clientRoyaltyKey', '==', clientRoyaltyKey)
+      .get();
+    clientRoyaltyOrderIndex = priorOrdersSnap.size + 1;
+  }
   const productSnaps = await db.getAll(...productRefs);
   const orderItems: any[] = [];
   let productSubtotal = 0;
@@ -2002,6 +2134,45 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     resolvedAt: admin.firestore.FieldValue.serverTimestamp(),
   };
 
+  let royaltyAssessment: Record<string, any> | null = null;
+  if (assignmentResult?.franchiseId) {
+    try {
+      const franchiseDoc = await db.collection('franchises').doc(assignmentResult.franchiseId).get();
+      if (franchiseDoc.exists) {
+        const franchiseData = franchiseDoc.data() as any;
+        const royaltyConfig = parseRoyaltyConfigDoc(franchiseData?.royalty);
+        const orderIndexForRoyalty = clientRoyaltyOrderIndex ?? 1;
+        const resolution = resolveRoyaltyTier(royaltyConfig, leadSourceNormalised, orderIndexForRoyalty);
+        royaltyAssessment = {
+          source: leadSourceNormalised,
+          orderIndex: orderIndexForRoyalty,
+          previousOrdersCount: orderIndexForRoyalty > 0 ? orderIndexForRoyalty - 1 : 0,
+          percentage: resolution.percentage,
+          tier: resolution.tier
+            ? {
+                minOrder: resolution.tier.minOrder,
+                maxOrder: resolution.tier.maxOrder,
+                percentage: resolution.tier.percentage,
+              }
+            : null,
+          configSnapshot: {
+            hqTiers: royaltyConfig.hqTiers.map((tier) => ({
+              minOrder: tier.minOrder,
+              maxOrder: tier.maxOrder,
+              percentage: tier.percentage,
+            })),
+            franchiseSourcedPercentage: royaltyConfig.franchiseSourcedPercentage,
+          },
+          clientKey: clientRoyaltyKey,
+          clientKeyType: clientRoyaltyKeyType,
+          computedAt: admin.firestore.FieldValue.serverTimestamp(),
+        };
+      }
+    } catch (royaltyErr) {
+      console.warn('Failed to resolve royalty configuration', royaltyErr);
+    }
+  }
+
   const orderData: Record<string, any> = {
     userId: context.auth?.uid || null,
     userEmail: context.auth?.token.email || userEmail || null,
@@ -2032,6 +2203,10 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     status: 'pending',
     createdAt: admin.firestore.FieldValue.serverTimestamp(),
     franchiseAssignment: assignmentMeta,
+    royaltySource: leadSourceNormalised,
+    clientRoyaltyKey: clientRoyaltyKey || null,
+    clientRoyaltyKeyType: clientRoyaltyKeyType || null,
+    clientRoyaltyOrderIndex: clientRoyaltyOrderIndex,
   };
 
   if (assignmentResult) {
@@ -2070,6 +2245,14 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     orderData.franchiseAssignedRole = null;
     orderData.franchiseAssignedIsPrimary = false;
     orderData.franchiseAssignedUser = null;
+  }
+
+  if (royaltyAssessment) {
+    orderData.royalty = royaltyAssessment;
+    orderData.royaltyPercentage = royaltyAssessment.percentage;
+  } else {
+    orderData.royalty = null;
+    orderData.royaltyPercentage = null;
   }
 
   const orderRef = await db.collection('orders').add(orderData);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -48,6 +48,8 @@ type FranchiseTerritoryDoc = {
   type?: string;
   postalCodes?: unknown;
   exclusive?: boolean;
+  categories?: unknown;
+  licenseFee?: number;
 };
 
 type FranchiseMemberDoc = {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -39,6 +39,184 @@ const db = admin.firestore();
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2024-06-20' });
 const VAT_RATE = 0.2;
 
+type FranchiseTerritoryDoc = {
+  franchiseId?: string;
+  label?: string;
+  type?: string;
+  postalCodes?: unknown;
+  exclusive?: boolean;
+};
+
+type FranchiseMemberDoc = {
+  userId?: string;
+  role?: string;
+  primary?: boolean;
+};
+
+type FranchiseAssignmentMatchType = 'exact' | 'prefix' | 'superset';
+
+interface FranchiseAssignmentResult {
+  franchiseId: string;
+  territoryId: string;
+  territoryLabel: string | null;
+  territoryPostalCode: string;
+  matchType: FranchiseAssignmentMatchType;
+  exclusive: boolean;
+}
+
+interface FranchiseAssignmentMember {
+  memberId: string;
+  userId: string;
+  role: string | null;
+  primary: boolean;
+  userProfile: { displayName?: string | null; email?: string | null } | null;
+}
+
+function normalisePostalCode(value?: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const cleaned = trimmed.toUpperCase().replace(/[^A-Z0-9]/g, '');
+  if (!cleaned) {
+    return null;
+  }
+  return cleaned;
+}
+
+function extractTerritoryPostalCodes(data: FranchiseTerritoryDoc): Array<{ raw: string; normalised: string }> {
+  const raw = data.postalCodes;
+  const list: string[] = [];
+  if (Array.isArray(raw)) {
+    raw.forEach((value) => {
+      if (value == null) {
+        return;
+      }
+      list.push(String(value));
+    });
+  } else if (typeof raw === 'string') {
+    raw
+      .split(/\r?\n|,/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .forEach((item) => list.push(item));
+  }
+  return list
+    .map((value) => {
+      const normalised = normalisePostalCode(value);
+      if (!normalised) {
+        return null;
+      }
+      return { raw: value, normalised };
+    })
+    .filter((item): item is { raw: string; normalised: string } => item !== null);
+}
+
+async function resolveTerritoryForPostalCode(postalCode: string): Promise<FranchiseAssignmentResult | null> {
+  const normalisedInput = normalisePostalCode(postalCode);
+  if (!normalisedInput) {
+    return null;
+  }
+  const territoriesSnap = await db.collection('franchiseTerritories').get();
+  let best: { score: number; result: FranchiseAssignmentResult } | null = null;
+  for (const territoryDoc of territoriesSnap.docs) {
+    const data = territoryDoc.data() as FranchiseTerritoryDoc;
+    if (!data?.franchiseId) {
+      continue;
+    }
+    if (data.type && data.type !== 'postal') {
+      // Radius-based routing requires geospatial inputs; skip for postal-only auto routing.
+      continue;
+    }
+    const codes = extractTerritoryPostalCodes(data);
+    for (const code of codes) {
+      if (!code.normalised) {
+        continue;
+      }
+      let matchType: FranchiseAssignmentMatchType | null = null;
+      let score = 0;
+      if (code.normalised === normalisedInput) {
+        matchType = 'exact';
+        score = 2000 + code.normalised.length;
+      } else if (normalisedInput.startsWith(code.normalised)) {
+        matchType = 'prefix';
+        score = 1200 + code.normalised.length;
+      } else if (code.normalised.startsWith(normalisedInput)) {
+        // Allow territories defined with full codes while customer provided a broader area.
+        matchType = 'superset';
+        score = 800 + normalisedInput.length;
+      }
+      if (!matchType) {
+        continue;
+      }
+      if (data.exclusive !== false) {
+        score += 50;
+      }
+      if (!best || score > best.score) {
+        best = {
+          score,
+          result: {
+            franchiseId: data.franchiseId as string,
+            territoryId: territoryDoc.id,
+            territoryLabel: typeof data.label === 'string' ? data.label : null,
+            territoryPostalCode: code.normalised,
+            matchType,
+            exclusive: data.exclusive !== false,
+          },
+        };
+      }
+    }
+  }
+  if (!best) {
+    return null;
+  }
+  return best.result;
+}
+
+async function resolvePrimaryFranchiseMember(franchiseId: string): Promise<FranchiseAssignmentMember | null> {
+  const membersSnap = await db
+    .collection('franchiseMembers')
+    .where('franchiseId', '==', franchiseId)
+    .get();
+  if (membersSnap.empty) {
+    return null;
+  }
+  const members = membersSnap.docs.map((doc) => {
+    const data = doc.data() as FranchiseMemberDoc;
+    return {
+      memberId: doc.id,
+      userId: data.userId ? String(data.userId) : '',
+      role: data.role ? String(data.role) : null,
+      primary: data.primary === true,
+    };
+  });
+  const prioritised =
+    members.find((member) => member.primary && member.userId) ||
+    members.find((member) => member.role === 'franchisee' && member.userId) ||
+    members.find((member) => member.userId) ||
+    null;
+  if (!prioritised) {
+    return null;
+  }
+  const userSnap = await db.collection('users').doc(prioritised.userId).get();
+  const profile = userSnap.exists
+    ? {
+        displayName: (userSnap.data()?.displayName as string) ?? null,
+        email: (userSnap.data()?.email as string) ?? null,
+      }
+    : null;
+  return {
+    memberId: prioritised.memberId,
+    userId: prioritised.userId,
+    role: prioritised.role,
+    primary: prioritised.primary,
+    userProfile: profile,
+  };
+}
+
 type RoleKey = 'admin' | 'operations' | 'finance' | 'projects' | 'sales' | 'marketing';
 
 const ROLE_KEYS: RoleKey[] = ['admin', 'operations', 'finance', 'projects', 'sales', 'marketing'];
@@ -1648,6 +1826,7 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     customerName,
     companyName,
     location,
+    postalCode,
     projectName,
     voucher,
     kitItems = [],
@@ -1802,12 +1981,35 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     profit,
   };
 
-  const orderRef = await db.collection('orders').add({
+  const postalCodeValue = typeof postalCode === 'string' ? postalCode : null;
+  const normalisedPostalCode = normalisePostalCode(postalCodeValue);
+  const assignmentResult = normalisedPostalCode
+    ? await resolveTerritoryForPostalCode(normalisedPostalCode)
+    : null;
+  const assignmentMember = assignmentResult
+    ? await resolvePrimaryFranchiseMember(assignmentResult.franchiseId)
+    : null;
+
+  const assignmentMeta: Record<string, any> = {
+    strategy: 'postal_code_auto_route',
+    inputPostalCode: postalCodeValue || null,
+    normalizedPostalCode: normalisedPostalCode || null,
+    status: assignmentResult
+      ? 'matched'
+      : normalisedPostalCode
+        ? 'unmatched'
+        : 'skipped',
+    resolvedAt: admin.firestore.FieldValue.serverTimestamp(),
+  };
+
+  const orderData: Record<string, any> = {
     userId: context.auth?.uid || null,
     userEmail: context.auth?.token.email || userEmail || null,
     customerName,
     companyName: companyName || null,
     location: location || null,
+    clientPostalCode: postalCodeValue || null,
+    clientPostalCodeNormalised: normalisedPostalCode || null,
     projectName: projectName || null,
     voucher: voucherCode,
     items: orderItems,
@@ -1829,7 +2031,48 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     profit,
     status: 'pending',
     createdAt: admin.firestore.FieldValue.serverTimestamp(),
-  });
+    franchiseAssignment: assignmentMeta,
+  };
+
+  if (assignmentResult) {
+    orderData.franchiseId = assignmentResult.franchiseId;
+    orderData.franchiseTerritoryId = assignmentResult.territoryId;
+    assignmentMeta.matchType = assignmentResult.matchType;
+    assignmentMeta.franchiseId = assignmentResult.franchiseId;
+    assignmentMeta.territoryId = assignmentResult.territoryId;
+    assignmentMeta.territoryPostalCode = assignmentResult.territoryPostalCode;
+    assignmentMeta.territoryLabel = assignmentResult.territoryLabel;
+    assignmentMeta.exclusive = assignmentResult.exclusive;
+  } else {
+    orderData.franchiseId = null;
+    orderData.franchiseTerritoryId = null;
+  }
+
+  if (assignmentMember) {
+    orderData.franchiseAssignedMemberId = assignmentMember.memberId;
+    orderData.franchiseAssignedUserId = assignmentMember.userId;
+    orderData.franchiseAssignedRole = assignmentMember.role || null;
+    orderData.franchiseAssignedIsPrimary = assignmentMember.primary;
+    orderData.franchiseAssignedUser = assignmentMember.userProfile
+      ? {
+          uid: assignmentMember.userId,
+          displayName: assignmentMember.userProfile.displayName || null,
+          email: assignmentMember.userProfile.email || null,
+        }
+      : {
+          uid: assignmentMember.userId,
+          displayName: null,
+          email: null,
+        };
+  } else {
+    orderData.franchiseAssignedMemberId = null;
+    orderData.franchiseAssignedUserId = null;
+    orderData.franchiseAssignedRole = null;
+    orderData.franchiseAssignedIsPrimary = false;
+    orderData.franchiseAssignedUser = null;
+  }
+
+  const orderRef = await db.collection('orders').add(orderData);
 
   return { orderId: orderRef.id };
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -38,6 +38,9 @@ admin.initializeApp({
 const db = admin.firestore();
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2024-06-20' });
 const VAT_RATE = 0.2;
+const DAY_IN_MS = 86_400_000;
+const DEFAULT_FILMING_SLA_DAYS = 7;
+const DEFAULT_EDITING_SLA_DAYS = 14;
 
 type FranchiseTerritoryDoc = {
   franchiseId?: string;
@@ -582,18 +585,43 @@ export const onOrderCreated = functions.firestore
 
     await snap.ref.set({ projectId: projRef.id }, { merge: true });
 
-    const projectBudgetData: Record<string, any> = {};
-    if (order.budgetTotals) projectBudgetData.budgetTotals = order.budgetTotals;
+    const filmingDueDate = new Date(Date.now() + DEFAULT_FILMING_SLA_DAYS * DAY_IN_MS);
+    const editingDueDate = new Date(Date.now() + DEFAULT_EDITING_SLA_DAYS * DAY_IN_MS);
+    const filmingDueAt = admin.firestore.Timestamp.fromDate(filmingDueDate);
+    const editingDueAt = admin.firestore.Timestamp.fromDate(editingDueDate);
+
+    const projectUpdates: Record<string, any> = {
+      kickoffDate: admin.firestore.FieldValue.serverTimestamp(),
+      dueDate: editingDueAt,
+      filmingDueDate: filmingDueAt,
+    };
+    if (order.budgetTotals) projectUpdates.budgetTotals = order.budgetTotals;
     const budgetItems = (order.items || []).map((item: any) => ({
       id: item.id,
       name: item.name,
       quantity: item.quantity,
       budget: item.budget || null,
     }));
-    if (budgetItems.length > 0) projectBudgetData.budgetItems = budgetItems;
-    if (Object.keys(projectBudgetData).length > 0) {
-      await projRef.set(projectBudgetData, { merge: true });
-    }
+    if (budgetItems.length > 0) projectUpdates.budgetItems = budgetItems;
+
+    projectUpdates.franchiseId = order.franchiseId || null;
+    projectUpdates.franchiseTerritoryId = order.franchiseTerritoryId || null;
+    projectUpdates.franchiseAssignment = order.franchiseAssignment || null;
+    projectUpdates.franchiseAssignedMemberId = order.franchiseAssignedMemberId || null;
+    projectUpdates.franchiseAssignedUserId = order.franchiseAssignedUserId || null;
+    projectUpdates.franchiseAssignedRole = order.franchiseAssignedRole || null;
+    projectUpdates.franchiseAssignedIsPrimary = order.franchiseAssignedIsPrimary === true;
+    projectUpdates.franchiseAssignedUser =
+      order.franchiseAssignedUser && typeof order.franchiseAssignedUser === 'object'
+        ? order.franchiseAssignedUser
+        : null;
+    projectUpdates.clientPostalCode = order.clientPostalCode || null;
+    projectUpdates.royalty = order.royalty || null;
+    projectUpdates.royaltyPercentage =
+      typeof order.royaltyPercentage === 'number' ? order.royaltyPercentage : null;
+    projectUpdates.royaltySource = order.royaltySource || null;
+
+    await projRef.set(projectUpdates, { merge: true });
 
     // Populate workflow/default tasks from the ordered product
     if (order.serviceId) {
@@ -601,6 +629,17 @@ export const onOrderCreated = functions.firestore
         const prodDoc = await db.collection('products').doc(order.serviceId).get();
         const prod = prodDoc.data() as any;
         const taskDocs: any[] = [];
+
+        const franchiseOperatorId =
+          typeof order.franchiseAssignedUserId === 'string'
+            ? String(order.franchiseAssignedUserId)
+            : null;
+        const franchiseOperatorName =
+          order.franchiseAssignedUser && typeof order.franchiseAssignedUser === 'object'
+            ? (order.franchiseAssignedUser.displayName as string | undefined) ||
+              (order.franchiseAssignedUser.email as string | undefined) ||
+              null
+            : null;
 
         // If the product references a workflow, load its tasks
         if (prod?.workflowId) {
@@ -683,6 +722,7 @@ export const onOrderCreated = functions.firestore
                 dependsOn,
                 workflowTaskId: typeof t.id === 'string' ? t.id : null,
                 dueAt,
+                dueDate: dueAt,
                 forCustomer: !!t.forCustomer,
                 status: 'todo',
                 createdAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -708,6 +748,58 @@ export const onOrderCreated = functions.firestore
               assigneeName: null,
             });
           }
+        }
+
+        const filmingTaskTitle = 'Filming & Capture';
+        const hasFilmingTask = taskDocs.some((task) => {
+          const title = typeof task.title === 'string' ? task.title.toLowerCase() : '';
+          return title.includes('film');
+        });
+        if (!hasFilmingTask) {
+          taskDocs.push({
+            title: filmingTaskTitle,
+            description: 'Coordinate and complete the on-site shoot within the agreed SLA.',
+            subtasks: [
+              'Confirm shoot date, time, and location with the client.',
+              'Prepare kit, crew, and travel logistics for the territory.',
+              'Capture footage and upload raw files to the project workspace within 24 hours.',
+            ],
+            slaDays: DEFAULT_FILMING_SLA_DAYS,
+            dueAt: filmingDueAt,
+            dueDate: filmingDueAt,
+            forCustomer: false,
+            status: 'todo',
+            createdAt: admin.firestore.FieldValue.serverTimestamp(),
+            assignedTo: franchiseOperatorId,
+            assigneeName: franchiseOperatorName,
+            assignmentScope: franchiseOperatorId ? 'franchise' : null,
+          });
+        }
+
+        const editingTaskTitle = 'Editing & Delivery';
+        const hasEditingTask = taskDocs.some((task) => {
+          const title = typeof task.title === 'string' ? task.title.toLowerCase() : '';
+          return title.includes('edit');
+        });
+        if (!hasEditingTask) {
+          taskDocs.push({
+            title: editingTaskTitle,
+            description: 'Ingest footage and deliver the first cut to HQ standards.',
+            subtasks: [
+              'Ingest and organise all footage in the project workspace.',
+              'Produce the first cut following Pineapple Tapped brand guidelines.',
+              'Submit edit for HQ quality check and client delivery.',
+            ],
+            slaDays: DEFAULT_EDITING_SLA_DAYS,
+            dueAt: editingDueAt,
+            dueDate: editingDueAt,
+            forCustomer: false,
+            status: 'todo',
+            createdAt: admin.firestore.FieldValue.serverTimestamp(),
+            assignedTo: null,
+            assigneeName: null,
+            assignmentScope: null,
+          });
         }
 
         if (taskDocs.length) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1039,6 +1039,650 @@ export const reserveKit = functions.https.onCall(async (data) => {
   return { conflicts: [], kitItems, rentalTotal };
 });
 
+type NormalisedRoles = Record<string, boolean>;
+
+interface UserContext {
+  uid: string;
+  displayName: string | null;
+  email: string | null;
+  isStaff: boolean;
+  roles: NormalisedRoles;
+  franchiseIds: string[];
+  primaryFranchiseId: string | null;
+}
+
+function normaliseRoles(raw: unknown): NormalisedRoles {
+  if (!raw || typeof raw !== 'object') {
+    return {};
+  }
+  const roles: NormalisedRoles = {};
+  Object.entries(raw as Record<string, unknown>).forEach(([key, value]) => {
+    if (value === true) {
+      roles[key] = true;
+    }
+  });
+  return roles;
+}
+
+async function loadUserContext(uid: string): Promise<UserContext> {
+  const snap = await db.collection('users').doc(uid).get();
+  const data = (snap.data() as Record<string, unknown> | undefined) ?? {};
+  const roles = normaliseRoles(data.roles);
+  const displayName =
+    typeof data.displayName === 'string' && data.displayName.trim().length
+      ? data.displayName.trim()
+      : typeof data.fullName === 'string' && data.fullName.trim().length
+        ? data.fullName.trim()
+        : null;
+  const email = typeof data.email === 'string' && data.email.includes('@') ? data.email : null;
+  const rawPrimary =
+    typeof data.primaryFranchiseId === 'string' && data.primaryFranchiseId.trim().length
+      ? data.primaryFranchiseId.trim()
+      : null;
+  const rawFranchise =
+    typeof data.franchiseId === 'string' && data.franchiseId.trim().length
+      ? data.franchiseId.trim()
+      : null;
+  const franchiseIds = new Set<string>();
+  if (rawPrimary) {
+    franchiseIds.add(rawPrimary);
+  }
+  if (rawFranchise) {
+    franchiseIds.add(rawFranchise);
+  }
+  const extra = Array.isArray(data.franchiseIds)
+    ? (data.franchiseIds as unknown[]).filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    : [];
+  extra.forEach((value) => franchiseIds.add(value.trim()));
+  const isStaff = data.isStaff === true || roles.admin === true || roles.operations === true || roles.projects === true;
+  return {
+    uid,
+    displayName,
+    email,
+    isStaff,
+    roles,
+    franchiseIds: Array.from(franchiseIds),
+    primaryFranchiseId: rawPrimary || rawFranchise || null,
+  };
+}
+
+type TaskOfferStatus = 'pending' | 'countered' | 'accepted' | 'rejected' | 'withdrawn';
+
+interface TaskOfferTerms {
+  currency: string;
+  totalAmount: number;
+  depositAmount: number;
+  balanceAmount: number;
+  paymentMode: 'deposit_balance' | 'balance_on_completion';
+  notes: string | null;
+}
+
+interface TaskOfferDoc extends TaskOfferTerms {
+  projectId: string;
+  taskId: string;
+  role: string | null;
+  status: TaskOfferStatus;
+  requesterUid: string;
+  requesterFranchiseId: string | null;
+  requesterName: string | null;
+  targetType: 'hq' | 'franchise';
+  targetFranchiseId: string | null;
+  targetUserId: string | null;
+  createdAt: FirebaseFirestore.FieldValue | FirebaseFirestore.Timestamp | null;
+  updatedAt: FirebaseFirestore.FieldValue | FirebaseFirestore.Timestamp | null;
+  respondedAt?: FirebaseFirestore.FieldValue | FirebaseFirestore.Timestamp | null;
+  respondedByUid?: string | null;
+  responseNotes?: string | null;
+  counterProposal?: TaskOfferTerms & {
+    proposedByUid: string;
+    proposedAt: FirebaseFirestore.FieldValue | FirebaseFirestore.Timestamp | null;
+  };
+  acceptedTerms?: TaskOfferTerms & {
+    acceptedByUid: string;
+    acceptedAt: FirebaseFirestore.FieldValue | FirebaseFirestore.Timestamp | null;
+  };
+}
+
+function parseCurrency(value: unknown): string {
+  if (typeof value === 'string' && value.trim().length >= 3) {
+    return value.trim().slice(0, 3).toUpperCase();
+  }
+  return 'GBP';
+}
+
+function parseMoney(value: unknown, fallback = 0): number {
+  const numeric = typeof value === 'string' ? Number(value) : Number(value);
+  if (!Number.isFinite(numeric) || Number.isNaN(numeric)) {
+    return fallback;
+  }
+  return Math.max(0, Math.round(numeric * 100) / 100);
+}
+
+function assertPositive(value: number, field: string) {
+  if (value < 0) {
+    throw new functions.https.HttpsError('invalid-argument', `${field} must be zero or positive.`);
+  }
+}
+
+async function assertFranchiseMembership(uid: string, franchiseId: string): Promise<boolean> {
+  const snap = await db
+    .collection('franchiseMembers')
+    .where('userId', '==', uid)
+    .where('franchiseId', '==', franchiseId)
+    .limit(1)
+    .get();
+  return !snap.empty;
+}
+
+export const taskOffers_create = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in required');
+  }
+  const uid = context.auth.uid;
+  const projectId = typeof data?.projectId === 'string' ? data.projectId.trim() : '';
+  const taskId = typeof data?.taskId === 'string' ? data.taskId.trim() : '';
+  if (!projectId || !taskId) {
+    throw new functions.https.HttpsError('invalid-argument', 'projectId and taskId are required');
+  }
+  const targetTypeRaw = typeof data?.targetType === 'string' ? data.targetType.trim().toLowerCase() : '';
+  if (targetTypeRaw !== 'hq' && targetTypeRaw !== 'franchise') {
+    throw new functions.https.HttpsError('invalid-argument', 'targetType must be "hq" or "franchise"');
+  }
+  const targetType = targetTypeRaw as 'hq' | 'franchise';
+  const targetFranchiseIdRaw = typeof data?.targetFranchiseId === 'string' ? data.targetFranchiseId.trim() : '';
+  const targetFranchiseId = targetType === 'franchise' ? targetFranchiseIdRaw : '';
+  if (targetType === 'franchise' && !targetFranchiseId) {
+    throw new functions.https.HttpsError('invalid-argument', 'targetFranchiseId is required for franchise offers');
+  }
+  const targetUserId = typeof data?.targetUserId === 'string' && data.targetUserId.trim().length
+    ? data.targetUserId.trim()
+    : null;
+  const role = typeof data?.role === 'string' && data.role.trim().length ? data.role.trim() : null;
+  const currency = parseCurrency(data?.currency);
+  const totalAmount = parseMoney(data?.totalAmount ?? data?.total ?? data?.feeTotal, NaN);
+  if (!Number.isFinite(totalAmount) || totalAmount <= 0) {
+    throw new functions.https.HttpsError('invalid-argument', 'totalAmount must be greater than zero');
+  }
+  let paymentMode: 'deposit_balance' | 'balance_on_completion' =
+    data?.paymentMode === 'balance_on_completion' ? 'balance_on_completion' : 'deposit_balance';
+  let depositAmount = parseMoney(data?.depositAmount ?? data?.deposit, 0);
+  assertPositive(depositAmount, 'depositAmount');
+  if (paymentMode === 'balance_on_completion') {
+    depositAmount = 0;
+  }
+  if (depositAmount > totalAmount) {
+    throw new functions.https.HttpsError('invalid-argument', 'depositAmount cannot exceed totalAmount');
+  }
+  let balanceAmount = parseMoney(data?.balanceAmount ?? data?.balance, totalAmount - depositAmount);
+  if (paymentMode === 'deposit_balance') {
+    balanceAmount = Math.max(0, Math.round((totalAmount - depositAmount) * 100) / 100);
+  } else {
+    balanceAmount = totalAmount;
+  }
+  assertPositive(balanceAmount, 'balanceAmount');
+  const notes = typeof data?.notes === 'string' && data.notes.trim().length ? data.notes.trim() : null;
+
+  const [userContext, projectSnap, taskSnap] = await Promise.all([
+    loadUserContext(uid),
+    db.collection('projects').doc(projectId).get(),
+    db.collection('projects').doc(projectId).collection('tasks').doc(taskId).get(),
+  ]);
+
+  if (!projectSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Project not found');
+  }
+  if (!taskSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Task not found');
+  }
+
+  if (!userContext.isStaff && userContext.franchiseIds.length === 0) {
+    throw new functions.https.HttpsError('permission-denied', 'Franchise membership required to outsource tasks');
+  }
+
+  const proposerFranchiseId = userContext.primaryFranchiseId || userContext.franchiseIds[0] || null;
+  const projectData = projectSnap.data() as Record<string, unknown>;
+  const projectFranchiseId = typeof projectData.franchiseId === 'string' ? projectData.franchiseId : null;
+  if (!userContext.isStaff && projectFranchiseId && !userContext.franchiseIds.includes(projectFranchiseId)) {
+    // Ensure the proposer belongs to the franchise that owns the project
+    const hasMembership = await assertFranchiseMembership(uid, projectFranchiseId);
+    if (!hasMembership) {
+      throw new functions.https.HttpsError('permission-denied', 'You are not assigned to this franchise project');
+    }
+  }
+
+  const taskRef = db.collection('projects').doc(projectId).collection('tasks').doc(taskId);
+  const offerRef = taskRef.collection('offers').doc();
+  const timestamp = admin.firestore.FieldValue.serverTimestamp();
+  const offerDoc: TaskOfferDoc = {
+    projectId,
+    taskId,
+    role,
+    status: 'pending',
+    requesterUid: uid,
+    requesterFranchiseId: proposerFranchiseId,
+    requesterName: userContext.displayName || userContext.email || uid,
+    targetType,
+    targetFranchiseId: targetType === 'franchise' ? targetFranchiseId : null,
+    targetUserId,
+    currency,
+    totalAmount,
+    depositAmount,
+    balanceAmount,
+    paymentMode,
+    notes,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+
+  await offerRef.set(offerDoc);
+
+  const existingProposal = (taskSnap.data() as Record<string, unknown> | undefined)?.outsourcingProposal as
+    | Record<string, unknown>
+    | undefined;
+  const proposalPayload = {
+    ...existingProposal,
+    offerId: offerRef.id,
+    status: 'pending',
+    proposedByUid: uid,
+    proposedByFranchiseId: proposerFranchiseId,
+    proposedByName: userContext.displayName || userContext.email || uid,
+    targetType,
+    targetFranchiseId: targetType === 'franchise' ? targetFranchiseId : null,
+    targetUserId,
+    role,
+    currency,
+    totalAmount,
+    depositAmount,
+    balanceAmount,
+    paymentMode,
+    notes,
+    createdAt: existingProposal?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+    respondedAt: null,
+    respondedByUid: null,
+    responseNotes: null,
+    counter: null,
+  };
+
+  await taskRef.set(
+    {
+      outsourcingProposal: proposalPayload,
+      outsourcingStatus: 'pending',
+    },
+    { merge: true }
+  );
+
+  await db.collection('taskHistory').add({
+    projectId,
+    taskId,
+    action: 'outsourcing_offer_created',
+    uid,
+    metadata: {
+      offerId: offerRef.id,
+      targetType,
+      targetFranchiseId: proposalPayload.targetFranchiseId,
+      targetUserId,
+      totalAmount,
+      currency,
+      paymentMode,
+    },
+    createdAt: timestamp,
+  });
+
+  return { offerId: offerRef.id };
+});
+
+export const taskOffers_respond = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in required');
+  }
+  const uid = context.auth.uid;
+  const projectId = typeof data?.projectId === 'string' ? data.projectId.trim() : '';
+  const taskId = typeof data?.taskId === 'string' ? data.taskId.trim() : '';
+  const offerId = typeof data?.offerId === 'string' ? data.offerId.trim() : '';
+  if (!projectId || !taskId || !offerId) {
+    throw new functions.https.HttpsError('invalid-argument', 'projectId, taskId, and offerId are required');
+  }
+  const actionRaw = typeof data?.action === 'string' ? data.action.trim().toLowerCase() : '';
+  if (!['accept', 'reject', 'counter', 'withdraw'].includes(actionRaw)) {
+    throw new functions.https.HttpsError('invalid-argument', 'Unsupported action');
+  }
+  const action = actionRaw as 'accept' | 'reject' | 'counter' | 'withdraw';
+  const notes = typeof data?.notes === 'string' && data.notes.trim().length ? data.notes.trim() : null;
+
+  const taskRef = db.collection('projects').doc(projectId).collection('tasks').doc(taskId);
+  const offerRef = taskRef.collection('offers').doc(offerId);
+
+  const [userContext, offerSnap, taskSnap] = await Promise.all([
+    loadUserContext(uid),
+    offerRef.get(),
+    taskRef.get(),
+  ]);
+
+  if (!offerSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Offer not found');
+  }
+  const offer = offerSnap.data() as TaskOfferDoc;
+  if (offer.projectId !== projectId || offer.taskId !== taskId) {
+    throw new functions.https.HttpsError('failed-precondition', 'Offer does not match project/task');
+  }
+  const proposal = (taskSnap.data() as Record<string, unknown> | undefined)?.outsourcingProposal as
+    | Record<string, unknown>
+    | undefined;
+
+  const isRequester = offer.requesterUid === uid;
+  let isTargetFranchise =
+    offer.targetType === 'franchise' && offer.targetFranchiseId
+      ? userContext.franchiseIds.includes(offer.targetFranchiseId)
+      : false;
+  const isTargetHq = offer.targetType === 'hq' ? userContext.isStaff : false;
+
+  if (offer.targetType === 'franchise' && !isTargetFranchise && offer.targetFranchiseId) {
+    const hasMembership = await assertFranchiseMembership(uid, offer.targetFranchiseId);
+    if (hasMembership) {
+      userContext.franchiseIds.push(offer.targetFranchiseId);
+      isTargetFranchise = true;
+    }
+  }
+
+  const isTarget = isTargetFranchise || isTargetHq;
+
+  const timestamp = admin.firestore.FieldValue.serverTimestamp();
+
+  if (action === 'withdraw') {
+    if (!isRequester) {
+      throw new functions.https.HttpsError('permission-denied', 'Only the requester can withdraw an offer');
+    }
+    if (offer.status !== 'pending' && offer.status !== 'countered') {
+      throw new functions.https.HttpsError('failed-precondition', 'Only pending offers can be withdrawn');
+    }
+    await offerRef.set(
+      {
+        status: 'withdrawn',
+        respondedByUid: uid,
+        respondedAt: timestamp,
+        responseNotes: notes ?? null,
+        updatedAt: timestamp,
+      },
+      { merge: true }
+    );
+    if (proposal) {
+      await taskRef.set(
+        {
+          outsourcingProposal: {
+            ...proposal,
+            status: 'withdrawn',
+            respondedByUid: uid,
+            respondedAt: timestamp,
+            responseNotes: notes ?? null,
+            updatedAt: timestamp,
+          },
+          outsourcingStatus: 'withdrawn',
+        },
+        { merge: true }
+      );
+    }
+    await db.collection('taskHistory').add({
+      projectId,
+      taskId,
+      action: 'outsourcing_offer_withdrawn',
+      uid,
+      metadata: { offerId },
+      createdAt: timestamp,
+    });
+    return { status: 'withdrawn' };
+  }
+
+  if (action === 'counter') {
+    if (!isTarget) {
+      throw new functions.https.HttpsError('permission-denied', 'Only the recipient can counter an offer');
+    }
+    if (offer.status !== 'pending') {
+      throw new functions.https.HttpsError('failed-precondition', 'Only pending offers can be countered');
+    }
+    const counterCurrency = parseCurrency(data?.currency ?? offer.currency);
+    const counterTotal = parseMoney(data?.totalAmount ?? data?.total ?? offer.totalAmount, offer.totalAmount);
+    if (counterTotal <= 0) {
+      throw new functions.https.HttpsError('invalid-argument', 'Counter total must be greater than zero');
+    }
+    const counterMode: 'deposit_balance' | 'balance_on_completion' =
+      data?.paymentMode === 'balance_on_completion' ? 'balance_on_completion' : 'deposit_balance';
+    let counterDeposit = parseMoney(data?.depositAmount ?? data?.deposit, offer.depositAmount);
+    if (counterMode === 'balance_on_completion') {
+      counterDeposit = 0;
+    }
+    if (counterDeposit > counterTotal) {
+      throw new functions.https.HttpsError('invalid-argument', 'Counter deposit cannot exceed total');
+    }
+    let counterBalance = parseMoney(
+      data?.balanceAmount ?? data?.balance,
+      counterMode === 'deposit_balance' ? counterTotal - counterDeposit : counterTotal
+    );
+    if (counterMode === 'deposit_balance') {
+      counterBalance = Math.max(0, Math.round((counterTotal - counterDeposit) * 100) / 100);
+    } else {
+      counterBalance = counterTotal;
+    }
+    await offerRef.set(
+      {
+        status: 'countered',
+        counterProposal: {
+          currency: counterCurrency,
+          totalAmount: counterTotal,
+          depositAmount: counterDeposit,
+          balanceAmount: counterBalance,
+          paymentMode: counterMode,
+          notes,
+          proposedByUid: uid,
+          proposedAt: timestamp,
+        },
+        respondedByUid: uid,
+        respondedAt: timestamp,
+        responseNotes: notes ?? null,
+        updatedAt: timestamp,
+      },
+      { merge: true }
+    );
+    if (proposal) {
+      await taskRef.set(
+        {
+          outsourcingProposal: {
+            ...proposal,
+            status: 'countered',
+            counter: {
+              currency: counterCurrency,
+              totalAmount: counterTotal,
+              depositAmount: counterDeposit,
+              balanceAmount: counterBalance,
+              paymentMode: counterMode,
+              notes,
+              proposedByUid: uid,
+              proposedAt: timestamp,
+            },
+            respondedByUid: uid,
+            respondedAt: timestamp,
+            responseNotes: notes ?? null,
+            updatedAt: timestamp,
+          },
+          outsourcingStatus: 'countered',
+        },
+        { merge: true }
+      );
+    }
+    await db.collection('taskHistory').add({
+      projectId,
+      taskId,
+      action: 'outsourcing_offer_countered',
+      uid,
+      metadata: { offerId, totalAmount: counterTotal, currency: counterCurrency },
+      createdAt: timestamp,
+    });
+    return { status: 'countered' };
+  }
+
+  if (action === 'reject') {
+    const canRejectTarget = isTarget && offer.status === 'pending';
+    const canRejectRequester = isRequester && offer.status === 'countered';
+    if (!canRejectTarget && !canRejectRequester) {
+      throw new functions.https.HttpsError('permission-denied', 'You cannot reject this offer');
+    }
+    await offerRef.set(
+      {
+        status: 'rejected',
+        respondedByUid: uid,
+        respondedAt: timestamp,
+        responseNotes: notes ?? null,
+        updatedAt: timestamp,
+      },
+      { merge: true }
+    );
+    if (proposal) {
+      await taskRef.set(
+        {
+          outsourcingProposal: {
+            ...proposal,
+            status: 'rejected',
+            respondedByUid: uid,
+            respondedAt: timestamp,
+            responseNotes: notes ?? null,
+            updatedAt: timestamp,
+          },
+          outsourcingStatus: 'rejected',
+        },
+        { merge: true }
+      );
+    }
+    await db.collection('taskHistory').add({
+      projectId,
+      taskId,
+      action: 'outsourcing_offer_rejected',
+      uid,
+      metadata: { offerId },
+      createdAt: timestamp,
+    });
+    return { status: 'rejected' };
+  }
+
+  if (action === 'accept') {
+    const acceptingTarget = isTarget && offer.status === 'pending';
+    const acceptingRequester = isRequester && offer.status === 'countered';
+    if (!acceptingTarget && !acceptingRequester) {
+      throw new functions.https.HttpsError('permission-denied', 'You cannot accept this offer');
+    }
+    const terms = offer.status === 'countered' && offer.counterProposal
+      ? {
+          currency: offer.counterProposal.currency,
+          totalAmount: offer.counterProposal.totalAmount,
+          depositAmount: offer.counterProposal.depositAmount,
+          balanceAmount: offer.counterProposal.balanceAmount,
+          paymentMode: offer.counterProposal.paymentMode,
+          notes: offer.counterProposal.notes ?? null,
+        }
+      : {
+          currency: offer.currency,
+          totalAmount: offer.totalAmount,
+          depositAmount: offer.depositAmount,
+          balanceAmount: offer.balanceAmount,
+          paymentMode: offer.paymentMode,
+          notes: offer.notes ?? null,
+        };
+
+    await offerRef.set(
+      {
+        status: 'accepted',
+        acceptedTerms: {
+          ...terms,
+          acceptedByUid: uid,
+          acceptedAt: timestamp,
+        },
+        respondedByUid: uid,
+        respondedAt: timestamp,
+        responseNotes: notes ?? null,
+        updatedAt: timestamp,
+      },
+      { merge: true }
+    );
+
+    let assigneeName: string | null = null;
+    const assignmentScope = offer.targetType === 'franchise' ? 'franchise' : 'hq';
+    const assignedTo = offer.targetUserId || null;
+    if (assignedTo) {
+      const assigneeSnap = await db.collection('users').doc(assignedTo).get();
+      const assigneeData = assigneeSnap.data() as Record<string, unknown> | undefined;
+      if (assigneeData) {
+        assigneeName =
+          (typeof assigneeData.displayName === 'string' && assigneeData.displayName.trim().length
+            ? assigneeData.displayName.trim()
+            : null) ||
+          (typeof assigneeData.fullName === 'string' && assigneeData.fullName.trim().length
+            ? assigneeData.fullName.trim()
+            : null) ||
+          (typeof assigneeData.email === 'string' ? assigneeData.email : null);
+      }
+    }
+
+    const agreement = {
+      offerId,
+      providerType: offer.targetType,
+      providerFranchiseId: offer.targetType === 'franchise' ? offer.targetFranchiseId ?? null : null,
+      providerUserId: offer.targetUserId || null,
+      currency: terms.currency,
+      totalAmount: terms.totalAmount,
+      depositAmount: terms.depositAmount,
+      balanceAmount: terms.balanceAmount,
+      paymentMode: terms.paymentMode,
+      notes: terms.notes ?? null,
+      acceptedAt: timestamp,
+      acceptedByUid: uid,
+      responseNotes: notes ?? null,
+    };
+
+    const taskUpdate: Record<string, unknown> = {
+      outsourcingAgreement: agreement,
+      outsourcingStatus: 'accepted',
+      assignmentScope,
+      updatedAt: timestamp,
+    };
+    if (assignedTo || offer.targetType === 'hq') {
+      taskUpdate.assignedTo = assignedTo;
+      taskUpdate.assigneeName = assigneeName;
+    }
+    if (proposal) {
+      taskUpdate.outsourcingProposal = {
+        ...proposal,
+        status: 'accepted',
+        respondedByUid: uid,
+        respondedAt: timestamp,
+        responseNotes: notes ?? null,
+        updatedAt: timestamp,
+        acceptedTerms: agreement,
+      };
+    }
+
+    await taskRef.set(taskUpdate, { merge: true });
+
+    await db.collection('taskHistory').add({
+      projectId,
+      taskId,
+      action: 'outsourcing_offer_accepted',
+      uid,
+      metadata: {
+        offerId,
+        providerType: offer.targetType,
+        providerFranchiseId: agreement.providerFranchiseId,
+        providerUserId: agreement.providerUserId,
+        totalAmount: terms.totalAmount,
+        currency: terms.currency,
+      },
+      createdAt: timestamp,
+    });
+
+    return { status: 'accepted' };
+  }
+
+  throw new functions.https.HttpsError('internal', 'Unhandled action');
+});
+
 async function sendEmail(to: string, subject: string, body: string) {
   try {
     const keyB64 = process.env.GMAIL_SERVICE_ACCOUNT_KEY_BASE64;


### PR DESCRIPTION
## Summary
- add franchise data model helpers for franchises, territories, and member assignments
- introduce an admin franchise management surface for creating territories and linking users
- expose the new management area in admin breadcrumbs and quick links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d44eafd5608323b7c86a12b508f03f