### PR TITLE
Refine kit reservation flow with franchise fallbacks

### DIFF
--- a/apps/web/app/admin/availability/ClientPage.tsx
+++ b/apps/web/app/admin/availability/ClientPage.tsx
@@ -25,11 +25,6 @@ import {
 } from "firebase/firestore";
 import { adminListUsers } from "@/lib/admin";
 import { useRoleGate } from "@/hooks/useRoleGate";
-import {
-  CRM_STATUS_LABELS,
-  normaliseCrmStatus,
-  type CRMStatus,
-} from "@/lib/crm";
 import { ROLE_LABELS, extractUserRoles, type RoleKey, type UserRoles } from "@/lib/roles";
 
 interface RawMember {
@@ -49,7 +44,6 @@ interface RawMember {
 }
 
 interface Member extends RawMember {
-  crmStatus: CRMStatus;
   roles: UserRoles;
   isTeam: boolean;
   franchiseIds: string[];
@@ -78,11 +72,6 @@ export default function AdminAvailabilityPage() {
     [members]
   );
 
-  const crmContacts = useMemo(
-    () => members.filter((member) => !member.isTeam),
-    [members]
-  );
-
   // load staff status and team list
   useEffect(() => {
     (async () => {
@@ -98,7 +87,6 @@ export default function AdminAvailabilityPage() {
           : [];
         const enriched: Member[] = rawUsers.map((entry) => {
           const roles = extractUserRoles({ ...(entry ?? {}), uid: entry?.id });
-          const crmStatus = normaliseCrmStatus(entry?.crmStatus);
           const franchiseIds = normaliseFranchiseIds(entry?.franchiseIds);
           const primaryFranchiseId = normaliseFranchiseId(entry?.primaryFranchiseId);
           const isTeam =
@@ -113,7 +101,6 @@ export default function AdminAvailabilityPage() {
           return {
             ...entry,
             roles,
-            crmStatus,
             isTeam,
             franchiseIds,
             primaryFranchiseId,
@@ -392,46 +379,6 @@ export default function AdminAvailabilityPage() {
           )}
         </section>
 
-        {crmContacts.length > 0 && (
-          <section>
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
-              CRM contacts
-            </h2>
-            <p className="mt-1 text-xs text-slate-500">
-              Prospects and clients appear here for reference and are not selectable for calendar availability.
-            </p>
-            <ul className="mt-3 space-y-2">
-              {crmContacts.map((contact) => {
-                const primary = resolveContactLabel(contact);
-                const organisation = resolveOrganisation(contact);
-                const positionLabel = resolveContactPosition(contact);
-                const stageLabel = CRM_STATUS_LABELS[contact.crmStatus];
-                return (
-                  <li
-                    key={contact.id}
-                    className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700"
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <p className="font-medium text-slate-900">{primary}</p>
-                      <span className="inline-flex items-center rounded-full bg-slate-200 px-2 py-0.5 text-xs font-semibold text-slate-700">
-                        {stageLabel}
-                      </span>
-                    </div>
-                    <div className="mt-1 space-y-1 text-xs text-slate-600">
-                      {organisation ? <p>{organisation}</p> : <p>{contact.email}</p>}
-                      {organisation && contact.email && (
-                        <p className="text-slate-500">{contact.email}</p>
-                      )}
-                      {positionLabel && (
-                        <p className="text-slate-500">Role: {positionLabel}</p>
-                      )}
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
-          </section>
-        )}
       </div>
       <div className="flex-1">
         <h1 className="mb-4 text-xl font-semibold text-slate-900">Manage availability</h1>
@@ -563,43 +510,6 @@ function describeTeamPosition(member: Member): string | null {
   }
   if (member.isStaff) {
     return "Staff";
-  }
-  return null;
-}
-
-function resolveContactLabel(member: Member): string {
-  const candidates = [member.displayName, member.fullName];
-  for (const candidate of candidates) {
-    if (typeof candidate === "string") {
-      const trimmed = candidate.trim();
-      if (trimmed.length > 0) {
-        return trimmed;
-      }
-    }
-  }
-  const organisation = resolveOrganisation(member);
-  if (organisation) {
-    return organisation;
-  }
-  return member.email;
-}
-
-function resolveOrganisation(member: Member): string | null {
-  if (typeof member.organisation === "string") {
-    const trimmed = member.organisation.trim();
-    if (trimmed.length > 0) {
-      return trimmed;
-    }
-  }
-  return null;
-}
-
-function resolveContactPosition(member: Member): string | null {
-  if (typeof member.position === "string") {
-    const trimmed = member.position.trim();
-    if (trimmed.length > 0) {
-      return trimmed;
-    }
   }
   return null;
 }

--- a/apps/web/app/admin/finance/ClientPage.tsx
+++ b/apps/web/app/admin/finance/ClientPage.tsx
@@ -318,6 +318,9 @@ export default function AdminFinancePage() {
               </select>
             </label>
             <div className="flex flex-wrap gap-2 sm:justify-end">
+              <Link href="/admin/finance/invoices" className="btn-outline btn-sm">
+                Manage invoices
+              </Link>
               <Link href="/admin/finance/invoices/new" className="btn btn-sm">
                 Create invoice
               </Link>

--- a/apps/web/app/admin/finance/invoices/ClientPage.tsx
+++ b/apps/web/app/admin/finance/invoices/ClientPage.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+import PortalContainer from "@/components/PortalContainer";
+import { useRoleGate } from "@/hooks/useRoleGate";
+
+interface InvoiceRecord extends Record<string, unknown> {
+  id: string;
+  organisationName?: string;
+  clientName?: string;
+  clientEmail?: string | null;
+  status?: string;
+  total?: number;
+  dueDate?: string | null;
+  stripePaymentUrl?: string | null;
+  portalPublished?: boolean;
+  updatedAt?: string | null;
+  sentAt?: string | null;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: "bg-slate-100 text-slate-700",
+  sent: "bg-blue-100 text-blue-700",
+  unpaid: "bg-amber-100 text-amber-700",
+  overdue: "bg-rose-100 text-rose-700",
+  paid: "bg-emerald-100 text-emerald-700",
+  void: "bg-gray-200 text-gray-600",
+};
+
+const formatCurrency = (value: unknown) => {
+  const numeric = typeof value === "number" ? value : Number(value) || 0;
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: 2,
+  }).format(numeric);
+};
+
+const formatDate = (value: unknown) => {
+  if (!value) {
+    return "—";
+  }
+  const raw = typeof value === "string" ? value : String(value);
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return "—";
+  }
+  return parsed.toLocaleDateString();
+};
+
+export default function InvoiceManagementPage() {
+  const { allowed, loading: guardLoading } = useRoleGate(["admin", "finance"]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [invoices, setInvoices] = useState<InvoiceRecord[]>([]);
+  const [busyInvoices, setBusyInvoices] = useState<Record<string, boolean>>({});
+
+  const loadInvoices = useCallback(async () => {
+    if (!allowed) {
+      setInvoices([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/admin/invoices", { cache: "no-store" });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.error === "string" ? payload.error : "Failed to load invoices.";
+        throw new Error(message);
+      }
+      const data = await response.json();
+      const records: InvoiceRecord[] = Array.isArray(data?.invoices)
+        ? data.invoices.map((entry: Record<string, unknown>) => ({
+            ...(entry as InvoiceRecord),
+            id: typeof entry?.id === "string" ? (entry.id as string) : "",
+          }))
+        : [];
+      setInvoices(records.filter((record) => record.id));
+    } catch (err) {
+      console.error("Failed to load invoices", err);
+      setError(err instanceof Error ? err.message : "Failed to load invoices.");
+    } finally {
+      setLoading(false);
+    }
+  }, [allowed]);
+
+  useEffect(() => {
+    if (guardLoading) {
+      return;
+    }
+    if (!allowed) {
+      setLoading(false);
+      return;
+    }
+    loadInvoices();
+  }, [allowed, guardLoading, loadInvoices]);
+
+  const markInvoiceBusy = useCallback((id: string, busy: boolean) => {
+    setBusyInvoices((prev) => ({ ...prev, [id]: busy }));
+  }, []);
+
+  const applyInvoiceUpdate = useCallback((invoice: InvoiceRecord) => {
+    setInvoices((prev) => {
+      const exists = prev.some((entry) => entry.id === invoice.id);
+      if (!exists) {
+        return [invoice, ...prev];
+      }
+      return prev.map((entry) => (entry.id === invoice.id ? invoice : entry));
+    });
+  }, []);
+
+  const updateInvoice = useCallback(
+    async (id: string, payload: Record<string, unknown>) => {
+      markInvoiceBusy(id, true);
+      try {
+        const response = await fetch(`/api/admin/invoices/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          const message = typeof data?.error === "string" ? data.error : "Failed to update invoice.";
+          throw new Error(message);
+        }
+        const result = await response.json();
+        if (result?.invoice) {
+          applyInvoiceUpdate(result.invoice as InvoiceRecord);
+        }
+      } catch (err) {
+        console.error("Invoice update failed", err);
+        alert(err instanceof Error ? err.message : "Failed to update invoice.");
+      } finally {
+        markInvoiceBusy(id, false);
+      }
+    },
+    [applyInvoiceUpdate, markInvoiceBusy]
+  );
+
+  const sortedInvoices = useMemo(() => {
+    return [...invoices].sort((a, b) => {
+      const left = typeof a.updatedAt === "string" ? Date.parse(a.updatedAt) : 0;
+      const right = typeof b.updatedAt === "string" ? Date.parse(b.updatedAt) : 0;
+      return right - left;
+    });
+  }, [invoices]);
+
+  if (guardLoading || loading) {
+    return (
+      <PortalContainer>
+        <p className="py-16 text-center text-sm text-gray-600">Loading invoices…</p>
+      </PortalContainer>
+    );
+  }
+
+  if (!allowed) {
+    return (
+      <PortalContainer>
+        <p className="py-16 text-center text-sm text-gray-600">You do not have access to invoice management.</p>
+      </PortalContainer>
+    );
+  }
+
+  return (
+    <PortalContainer>
+      <div className="grid gap-6">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Invoices</p>
+            <h1 className="text-2xl font-semibold text-gray-900">Client invoicing</h1>
+            <p className="text-sm text-gray-600">
+              Track invoices raised for clients, share payment links, and keep records up to date.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2 sm:justify-end">
+            <button type="button" className="btn-outline btn-sm" onClick={loadInvoices}>
+              Refresh
+            </button>
+            <Link href="/admin/finance/invoices/new" className="btn btn-sm">
+              Create invoice
+            </Link>
+          </div>
+        </header>
+
+        {error ? (
+          <div className="rounded-3xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">
+            {error}
+          </div>
+        ) : null}
+
+        {sortedInvoices.length === 0 ? (
+          <div className="rounded-3xl border border-dashed border-gray-300 bg-white p-8 text-center text-sm text-gray-500">
+            No invoices have been created yet.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-100 text-sm">
+              <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="px-6 py-3 text-left font-medium">Invoice</th>
+                  <th className="px-6 py-3 text-left font-medium">Client</th>
+                  <th className="px-6 py-3 text-left font-medium">Due</th>
+                  <th className="px-6 py-3 text-right font-medium">Total</th>
+                  <th className="px-6 py-3 text-left font-medium">Status</th>
+                  <th className="px-6 py-3 text-left font-medium">Portal</th>
+                  <th className="px-6 py-3 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {sortedInvoices.map((invoice) => {
+                  const statusKey = typeof invoice.status === "string" ? invoice.status.toLowerCase() : "";
+                  const badgeClass = STATUS_STYLES[statusKey] || "bg-gray-100 text-gray-700";
+                  const busy = Boolean(busyInvoices[invoice.id]);
+                  return (
+                    <tr key={invoice.id} className={busy ? "opacity-70" : undefined}>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-col">
+                          <Link
+                            href={`/admin/finance/invoices/${invoice.id}`}
+                            className="text-sm font-semibold text-gray-900 hover:underline"
+                          >
+                            {invoice.organisationName || invoice.clientName || `Invoice ${invoice.id}`}
+                          </Link>
+                          {invoice.clientEmail ? (
+                            <span className="text-xs text-gray-500">{invoice.clientEmail}</span>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-col text-sm text-gray-700">
+                          <span>{invoice.clientName || invoice.organisationName || '—'}</span>
+                          {invoice.sentAt ? (
+                            <span className="text-xs text-gray-500">Sent {formatDate(invoice.sentAt)}</span>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-700">{formatDate(invoice.dueDate)}</td>
+                      <td className="px-6 py-4 text-right text-sm font-semibold text-gray-900">
+                        {formatCurrency(invoice.total)}
+                      </td>
+                      <td className="px-6 py-4">
+                        <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${badgeClass}`}>
+                          {statusKey ? statusKey.replace(/_/g, " ") : "Draft"}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-700">
+                        {invoice.portalPublished ? (
+                          <span className="text-emerald-600">Published</span>
+                        ) : (
+                          <span className="text-gray-400">Hidden</span>
+                        )}
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-wrap items-center justify-end gap-2 text-xs">
+                          {invoice.stripePaymentUrl ? (
+                            <button
+                              type="button"
+                              className="btn-outline btn-xs"
+                              disabled={busy}
+                              onClick={() => {
+                                if (
+                                  invoice.stripePaymentUrl &&
+                                  typeof navigator !== "undefined" &&
+                                  navigator.clipboard?.writeText
+                                ) {
+                                  navigator.clipboard
+                                    .writeText(invoice.stripePaymentUrl)
+                                    .then(() => {
+                                      alert("Payment link copied to clipboard.");
+                                    })
+                                    .catch(() => {
+                                      alert("Unable to copy the payment link.");
+                                    });
+                                }
+                              }}
+                            >
+                              Copy link
+                            </button>
+                          ) : null}
+                          <button
+                            type="button"
+                            className="btn-outline btn-xs"
+                            disabled={busy}
+                            onClick={() => updateInvoice(invoice.id, { markSent: true })}
+                          >
+                            Mark sent
+                          </button>
+                          <button
+                            type="button"
+                            className="btn-outline btn-xs"
+                            disabled={busy}
+                            onClick={() => updateInvoice(invoice.id, { markPaid: true })}
+                          >
+                            Mark paid
+                          </button>
+                          <button
+                            type="button"
+                            className="btn-outline btn-xs"
+                            disabled={busy}
+                            onClick={() =>
+                              updateInvoice(invoice.id, {
+                                portalPublished: !invoice.portalPublished,
+                              })
+                            }
+                          >
+                            {invoice.portalPublished ? "Unpublish" : "Publish"}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </PortalContainer>
+  );
+}

--- a/apps/web/app/admin/finance/invoices/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/finance/invoices/[id]/ClientPage.tsx
@@ -1,0 +1,796 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { PDFDownloadLink } from "@react-pdf/renderer";
+
+import PortalContainer from "@/components/PortalContainer";
+import InvoicePDF from "@/components/InvoicePDF";
+import { useRoleGate } from "@/hooks/useRoleGate";
+
+interface InvoiceLineItemRecord {
+  description?: string;
+  amount?: number;
+  productId?: string | null;
+}
+
+interface InvoiceSplitPaymentRecord {
+  amount?: number;
+  dueDate?: string | null;
+}
+
+interface InvoiceRecord extends Record<string, unknown> {
+  id: string;
+  organisationName?: string | null;
+  clientName?: string | null;
+  clientEmail?: string | null;
+  paymentTerms?: string | null;
+  termsUrl?: string | null;
+  allowStripePayment?: boolean;
+  dueDate?: string | null;
+  items?: InvoiceLineItemRecord[];
+  splitPayments?: InvoiceSplitPaymentRecord[];
+  total?: number;
+  notes?: string | null;
+  portalPublished?: boolean;
+  status?: string;
+  stripePaymentUrl?: string | null;
+  history?: Array<{ event?: string; at?: string; notes?: string }>;
+}
+
+interface EditableLineItem {
+  description: string;
+  amount: string;
+  productId: string;
+}
+
+interface EditableSplitPayment {
+  amount: string;
+  dueDate: string;
+}
+
+interface InvoiceFormState {
+  organisationName: string;
+  clientName: string;
+  clientEmail: string;
+  paymentTerms: string;
+  termsUrl: string;
+  allowStripePayment: boolean;
+  dueDate: string;
+  items: EditableLineItem[];
+  splitPaymentsEnabled: boolean;
+  splitPayments: EditableSplitPayment[];
+  notes: string;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: "bg-slate-100 text-slate-700",
+  sent: "bg-blue-100 text-blue-700",
+  unpaid: "bg-amber-100 text-amber-700",
+  overdue: "bg-rose-100 text-rose-700",
+  paid: "bg-emerald-100 text-emerald-700",
+  void: "bg-gray-200 text-gray-600",
+};
+
+const formatCurrency = (value: number | string | null | undefined) => {
+  const numeric = typeof value === "number" ? value : Number.parseFloat(String(value ?? "0"));
+  return new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP", maximumFractionDigits: 2 }).format(
+    Number.isFinite(numeric) ? numeric : 0
+  );
+};
+
+const toDateInput = (value: string | null | undefined) => {
+  if (!value) {
+    return "";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "";
+  }
+  return parsed.toISOString().split("T")[0];
+};
+
+const normaliseDateInput = (value: string | null | undefined) => {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    const iso = new Date(`${trimmed}T00:00:00.000Z`);
+    return Number.isNaN(iso.getTime()) ? null : iso.toISOString();
+  }
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+};
+
+function ensureLineItems(items: EditableLineItem[]): EditableLineItem[] {
+  if (items.length > 0) {
+    return items;
+  }
+  return [{ description: "", amount: "", productId: "" }];
+}
+
+interface InvoiceDetailProps {
+  invoiceId: string;
+}
+
+export default function InvoiceDetailClient({ invoiceId }: InvoiceDetailProps) {
+  const router = useRouter();
+  const { allowed, loading: guardLoading } = useRoleGate(["admin", "finance"]);
+  const [invoice, setInvoice] = useState<InvoiceRecord | null>(null);
+  const [form, setForm] = useState<InvoiceFormState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const buildFormState = useCallback((data: InvoiceRecord): InvoiceFormState => {
+    const rawItems = Array.isArray(data.items) ? data.items : [];
+    const editableItems: EditableLineItem[] = rawItems.map((item) => ({
+      description: typeof item.description === "string" ? item.description : "",
+      amount:
+        typeof item.amount === "number"
+          ? item.amount.toFixed(2)
+          : typeof item.amount === "string"
+          ? item.amount
+          : "",
+      productId: typeof item.productId === "string" ? item.productId : "",
+    }));
+    const rawSchedule = Array.isArray(data.splitPayments) ? data.splitPayments : [];
+    const editableSchedule: EditableSplitPayment[] = rawSchedule.map((entry) => ({
+      amount:
+        typeof entry.amount === "number"
+          ? entry.amount.toFixed(2)
+          : typeof entry.amount === "string"
+          ? entry.amount
+          : "",
+      dueDate: toDateInput(entry.dueDate ?? null),
+    }));
+    return {
+      organisationName: typeof data.organisationName === "string" ? data.organisationName : "",
+      clientName: typeof data.clientName === "string" ? data.clientName : "",
+      clientEmail: typeof data.clientEmail === "string" ? data.clientEmail : "",
+      paymentTerms: typeof data.paymentTerms === "string" ? data.paymentTerms : "",
+      termsUrl: typeof data.termsUrl === "string" ? data.termsUrl : "",
+      allowStripePayment: data.allowStripePayment !== false,
+      dueDate: toDateInput(data.dueDate ?? null),
+      items: ensureLineItems(editableItems),
+      splitPaymentsEnabled: editableSchedule.length > 0,
+      splitPayments: editableSchedule.length > 0 ? editableSchedule : [{ amount: "", dueDate: "" }],
+      notes: typeof data.notes === "string" ? data.notes : "",
+    };
+  }, []);
+
+  const loadInvoice = useCallback(async () => {
+    if (!invoiceId) {
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/admin/invoices/${invoiceId}`, { cache: "no-store" });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        const message = typeof payload?.error === "string" ? payload.error : "Failed to load invoice.";
+        throw new Error(message);
+      }
+      const result = await response.json();
+      const record = result?.invoice as InvoiceRecord | undefined;
+      if (record && record.id) {
+        setInvoice(record);
+        setForm(buildFormState(record));
+      } else {
+        throw new Error("Invoice not found.");
+      }
+    } catch (err) {
+      console.error("Failed to load invoice", err);
+      setError(err instanceof Error ? err.message : "Failed to load invoice.");
+    } finally {
+      setLoading(false);
+    }
+  }, [invoiceId, buildFormState]);
+
+  useEffect(() => {
+    if (!guardLoading && allowed) {
+      loadInvoice();
+    }
+    if (!allowed && !guardLoading) {
+      setLoading(false);
+    }
+  }, [allowed, guardLoading, loadInvoice]);
+
+  const handleFieldChange = (field: keyof InvoiceFormState, value: string | boolean) => {
+    setForm((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      return { ...prev, [field]: value };
+    });
+  };
+
+  const handleItemChange = (index: number, key: keyof EditableLineItem, value: string) => {
+    setForm((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      const items = [...prev.items];
+      items[index] = { ...items[index], [key]: value };
+      return { ...prev, items };
+    });
+  };
+
+  const addItem = () => {
+    setForm((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      return { ...prev, items: [...prev.items, { description: "", amount: "", productId: "" }] };
+    });
+  };
+
+  const removeItem = (index: number) => {
+    setForm((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      const next = prev.items.filter((_, idx) => idx !== index);
+      return { ...prev, items: ensureLineItems(next) };
+    });
+  };
+
+  const handleSplitPaymentChange = (index: number, key: keyof EditableSplitPayment, value: string) => {
+    setForm((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      const schedule = [...prev.splitPayments];
+      schedule[index] = { ...schedule[index], [key]: value };
+      return { ...prev, splitPayments: schedule };
+    });
+  };
+
+  const addSplitPayment = () => {
+    setForm((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      return { ...prev, splitPayments: [...prev.splitPayments, { amount: "", dueDate: "" }] };
+    });
+  };
+
+  const removeSplitPayment = (index: number) => {
+    setForm((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      const next = prev.splitPayments.filter((_, idx) => idx !== index);
+      return { ...prev, splitPayments: next.length > 0 ? next : [{ amount: "", dueDate: "" }] };
+    });
+  };
+
+  const sanitiseLineItems = () => {
+    if (!form) {
+      return [] as { description: string; amount: number; productId: string | null }[];
+    }
+    return form.items
+      .map((item) => {
+        const amountValue = Number.parseFloat(item.amount || "0");
+        const amount = Number.isFinite(amountValue) ? amountValue : 0;
+        const description = item.description.trim();
+        return {
+          description,
+          amount,
+          productId: item.productId.trim() || null,
+        };
+      })
+      .filter((item) => item.description || item.amount > 0);
+  };
+
+  const buildSplitSchedule = () => {
+    if (!form || !form.splitPaymentsEnabled) {
+      return [] as { amount: number; dueDate: string | null }[];
+    }
+    return form.splitPayments
+      .map((entry) => {
+        const amountValue = Number.parseFloat(entry.amount || "0");
+        const amount = Number.isFinite(amountValue) ? amountValue : 0;
+        return {
+          amount,
+          dueDate: normaliseDateInput(entry.dueDate),
+        };
+      })
+      .filter((entry) => entry.amount > 0 && entry.dueDate);
+  };
+
+  const invoiceTotal = useMemo(() => {
+    if (!form) {
+      return 0;
+    }
+    return form.items.reduce((sum, item) => {
+      const value = Number.parseFloat(item.amount || "0");
+      return sum + (Number.isFinite(value) ? value : 0);
+    }, 0);
+  }, [form]);
+
+  const scheduleTotal = useMemo(() => {
+    if (!form || !form.splitPaymentsEnabled) {
+      return 0;
+    }
+    return form.splitPayments.reduce((sum, entry) => {
+      const value = Number.parseFloat(entry.amount || "0");
+      return sum + (Number.isFinite(value) ? value : 0);
+    }, 0);
+  }, [form]);
+
+  const handleSave = async () => {
+    if (!form || !invoice) {
+      return;
+    }
+    const lineItems = sanitiseLineItems();
+    if (lineItems.length === 0) {
+      alert("Add at least one line item with a description or amount.");
+      return;
+    }
+    const schedule = buildSplitSchedule();
+    if (form.splitPaymentsEnabled && schedule.length === 0) {
+      alert("Add at least one split payment with an amount and due date.");
+      return;
+    }
+    if (form.splitPaymentsEnabled) {
+      const scheduleSum = schedule.reduce((sum, entry) => sum + entry.amount, 0);
+      if (Math.abs(scheduleSum - invoiceTotal) > 0.5) {
+        alert("Split payments must match the invoice total before saving.");
+        return;
+      }
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        organisationName: form.organisationName.trim() || null,
+        clientName: form.clientName.trim() || null,
+        clientEmail: form.clientEmail.trim() || null,
+        dueDate: normaliseDateInput(form.dueDate),
+        paymentTerms: form.paymentTerms.trim() || null,
+        termsUrl: form.termsUrl.trim() || null,
+        allowStripePayment: form.allowStripePayment,
+        items: lineItems,
+        splitPayments: form.splitPaymentsEnabled ? schedule : [],
+        notes: form.notes.trim() || null,
+      };
+      const response = await fetch(`/api/admin/invoices/${invoice.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const message = typeof data?.error === "string" ? data.error : "Failed to update invoice.";
+        throw new Error(message);
+      }
+      const result = await response.json();
+      if (result?.invoice) {
+        setInvoice(result.invoice as InvoiceRecord);
+        setForm(buildFormState(result.invoice as InvoiceRecord));
+        alert("Invoice updated");
+      }
+    } catch (err) {
+      console.error("Failed to update invoice", err);
+      alert(err instanceof Error ? err.message : "Failed to update invoice.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleQuickAction = async (payload: Record<string, unknown>) => {
+    if (!invoice) {
+      return;
+    }
+    try {
+      const response = await fetch(`/api/admin/invoices/${invoice.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const message = typeof data?.error === "string" ? data.error : "Failed to update invoice.";
+        throw new Error(message);
+      }
+      const result = await response.json();
+      if (result?.invoice) {
+        setInvoice(result.invoice as InvoiceRecord);
+        setForm(buildFormState(result.invoice as InvoiceRecord));
+      }
+    } catch (err) {
+      console.error("Invoice action failed", err);
+      alert(err instanceof Error ? err.message : "Failed to update invoice.");
+    }
+  };
+
+  if (guardLoading || loading || !form || !invoice) {
+    return (
+      <PortalContainer>
+        <p className="py-16 text-center text-sm text-gray-600">Loading invoice…</p>
+      </PortalContainer>
+    );
+  }
+
+  if (!allowed) {
+    return (
+      <PortalContainer>
+        <p className="py-16 text-center text-sm text-gray-600">You do not have access to this invoice.</p>
+      </PortalContainer>
+    );
+  }
+
+  const statusKey = typeof invoice.status === "string" ? invoice.status.toLowerCase() : "draft";
+  const badgeClass = STATUS_STYLES[statusKey] || "bg-gray-100 text-gray-700";
+
+  return (
+    <PortalContainer>
+      <div className="grid gap-6">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Invoice</p>
+            <h1 className="text-2xl font-semibold text-gray-900">{form.organisationName || form.clientName || invoice.id}</h1>
+            <p className="text-sm text-gray-600">Update billing details, resend payment links, and manage the client view.</p>
+            <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${badgeClass}`}>
+              {statusKey.replace(/_/g, " ")}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-2 sm:justify-end">
+            <Link href="/admin/finance/invoices" className="btn-outline btn-sm">
+              Back to invoices
+            </Link>
+            <button type="button" className="btn btn-sm" onClick={handleSave} disabled={saving}>
+              {saving ? "Saving…" : "Save changes"}
+            </button>
+          </div>
+        </header>
+
+        {error ? (
+          <div className="rounded-3xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">{error}</div>
+        ) : null}
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <section className="rounded-3xl border border-gray-200 bg-white shadow-sm">
+            <div className="border-b border-gray-100 px-6 py-4">
+              <h2 className="text-lg font-semibold text-gray-900">Invoice details</h2>
+              <p className="text-sm text-gray-600">Edit the billing recipient, line items, and optional notes.</p>
+            </div>
+            <div className="space-y-5 px-6 py-6">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Organisation name
+                  <input
+                    type="text"
+                    className="input mt-1 w-full"
+                    value={form.organisationName}
+                    onChange={(event) => handleFieldChange("organisationName", event.target.value)}
+                  />
+                </label>
+                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Client name
+                  <input
+                    type="text"
+                    className="input mt-1 w-full"
+                    value={form.clientName}
+                    onChange={(event) => handleFieldChange("clientName", event.target.value)}
+                  />
+                </label>
+                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Client email
+                  <input
+                    type="email"
+                    className="input mt-1 w-full"
+                    value={form.clientEmail}
+                    onChange={(event) => handleFieldChange("clientEmail", event.target.value)}
+                  />
+                </label>
+                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Payment due date
+                  <input
+                    type="date"
+                    className="input mt-1 w-full"
+                    value={form.dueDate}
+                    onChange={(event) => handleFieldChange("dueDate", event.target.value)}
+                  />
+                </label>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold text-gray-900">Line items</h3>
+                  <button type="button" className="btn-outline btn-xs" onClick={addItem}>
+                    Add line item
+                  </button>
+                </div>
+                <div className="space-y-3">
+                  {form.items.map((item, index) => (
+                    <div key={index} className="rounded-2xl border border-gray-200 p-4">
+                      <div className="grid gap-3 sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+                        <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Description
+                          <input
+                            type="text"
+                            className="input mt-1 w-full"
+                            value={item.description}
+                            onChange={(event) => handleItemChange(index, "description", event.target.value)}
+                          />
+                        </label>
+                        <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Amount
+                          <input
+                            type="number"
+                            min="0"
+                            step="0.01"
+                            className="input mt-1 w-full"
+                            value={item.amount}
+                            onChange={(event) => handleItemChange(index, "amount", event.target.value)}
+                          />
+                        </label>
+                      </div>
+                      <div className="mt-3 flex items-center justify-between">
+                        <input
+                          type="text"
+                          className="input w-full"
+                          placeholder="Product reference (optional)"
+                          value={item.productId}
+                          onChange={(event) => handleItemChange(index, "productId", event.target.value)}
+                        />
+                        {form.items.length > 1 ? (
+                          <button
+                            type="button"
+                            className="btn-outline btn-xs ml-3 text-red-600"
+                            onClick={() => removeItem(index)}
+                          >
+                            Remove
+                          </button>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Notes (internal)
+                <textarea
+                  className="input mt-1 h-24 resize-none"
+                  value={form.notes}
+                  onChange={(event) => handleFieldChange("notes", event.target.value)}
+                />
+              </label>
+            </div>
+          </section>
+
+          <aside className="grid gap-6">
+            <section className="rounded-3xl border border-gray-200 bg-white shadow-sm">
+              <div className="border-b border-gray-100 px-6 py-4">
+                <h2 className="text-lg font-semibold text-gray-900">Payment &amp; schedule</h2>
+                <p className="text-sm text-gray-600">Manage payment terms, the online checkout, and optional split payments.</p>
+              </div>
+              <div className="space-y-4 px-6 py-6">
+                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Payment terms
+                  <textarea
+                    className="input mt-1 h-24 resize-none"
+                    value={form.paymentTerms}
+                    onChange={(event) => handleFieldChange("paymentTerms", event.target.value)}
+                  />
+                </label>
+                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Terms &amp; conditions link
+                  <input
+                    type="url"
+                    className="input mt-1 w-full"
+                    value={form.termsUrl}
+                    onChange={(event) => handleFieldChange("termsUrl", event.target.value)}
+                  />
+                </label>
+                <label className="flex items-center justify-between rounded-2xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+                  <span>Allow Stripe payments</span>
+                  <input
+                    type="checkbox"
+                    checked={form.allowStripePayment}
+                    onChange={(event) => handleFieldChange("allowStripePayment", event.target.checked)}
+                  />
+                </label>
+                <div className="space-y-3 rounded-2xl border border-gray-200 p-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900">Payment schedule</p>
+                      <p className="text-xs text-gray-600">Enable instalments to collect the balance over multiple dates.</p>
+                    </div>
+                    <label className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                      <input
+                        type="checkbox"
+                        checked={form.splitPaymentsEnabled}
+                        onChange={(event) =>
+                          setForm((prev) =>
+                            prev
+                              ? {
+                                  ...prev,
+                                  splitPaymentsEnabled: event.target.checked,
+                                }
+                              : prev
+                          )
+                        }
+                      />
+                      Split payments
+                    </label>
+                  </div>
+                  {!form.splitPaymentsEnabled ? (
+                    <p className="text-xs text-gray-500">Use the payment due date above for a single instalment.</p>
+                  ) : (
+                    <div className="space-y-3">
+                      {form.splitPayments.map((split, index) => (
+                        <div key={index} className="rounded-2xl border border-dashed border-gray-300 p-3">
+                          <div className="grid gap-3 sm:grid-cols-2">
+                            <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                              Amount
+                              <input
+                                type="number"
+                                min="0"
+                                step="0.01"
+                                className="input mt-1 w-full"
+                                value={split.amount}
+                                onChange={(event) => handleSplitPaymentChange(index, "amount", event.target.value)}
+                              />
+                            </label>
+                            <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                              Due date
+                              <input
+                                type="date"
+                                className="input mt-1 w-full"
+                                value={split.dueDate}
+                                onChange={(event) => handleSplitPaymentChange(index, "dueDate", event.target.value)}
+                              />
+                            </label>
+                          </div>
+                          {form.splitPayments.length > 1 ? (
+                            <button
+                              type="button"
+                              className="btn-outline btn-xs mt-3 text-red-600"
+                              onClick={() => removeSplitPayment(index)}
+                            >
+                              Remove payment
+                            </button>
+                          ) : null}
+                        </div>
+                      ))}
+                      <button type="button" className="btn-outline btn-xs" onClick={addSplitPayment}>
+                        Add payment
+                      </button>
+                      <div className="rounded-2xl bg-gray-50 p-3 text-xs text-gray-600">
+                        <p>
+                          Scheduled total: <span className="font-semibold text-gray-800">{formatCurrency(scheduleTotal)}</span>
+                        </p>
+                        <p>
+                          {Math.abs(scheduleTotal - invoiceTotal) < 0.5
+                            ? "The schedule matches the invoice total."
+                            : scheduleTotal > invoiceTotal
+                            ? `Reduce the schedule by ${formatCurrency(scheduleTotal - invoiceTotal)}.`
+                            : `Add ${formatCurrency(invoiceTotal - scheduleTotal)} to match the invoice total.`}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            <section className="rounded-3xl border border-gray-200 bg-white shadow-sm">
+              <div className="border-b border-gray-100 px-6 py-4">
+                <h2 className="text-lg font-semibold text-gray-900">Summary &amp; actions</h2>
+                <p className="text-sm text-gray-600">Keep the invoice status aligned with reality and share payment options.</p>
+              </div>
+              <div className="space-y-4 px-6 py-6 text-sm text-gray-700">
+                <div className="flex items-center justify-between">
+                  <span>Total</span>
+                  <span className="text-base font-semibold text-gray-900">{formatCurrency(invoiceTotal)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Due</span>
+                  <span className="font-semibold text-gray-900">{form.dueDate || "—"}</span>
+                </div>
+                {invoice.stripePaymentUrl ? (
+                  <div className="space-y-2">
+                    <p className="text-xs uppercase tracking-wide text-gray-500">Stripe payment link</p>
+                    <p className="break-all text-xs text-gray-600">{invoice.stripePaymentUrl}</p>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="btn-outline btn-xs"
+                        onClick={() => {
+                          if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+                            navigator.clipboard.writeText(invoice.stripePaymentUrl!);
+                            alert("Payment link copied to clipboard.");
+                          }
+                        }}
+                      >
+                        Copy link
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-outline btn-xs"
+                        onClick={() =>
+                          handleQuickAction({
+                            regenerateStripeLink: true,
+                            items: sanitiseLineItems(),
+                            allowStripePayment: true,
+                          })
+                        }
+                      >
+                        Regenerate link
+                      </button>
+                    </div>
+                  </div>
+                ) : form.allowStripePayment ? (
+                  <button
+                    type="button"
+                    className="btn-outline btn-xs"
+                    onClick={() =>
+                      handleQuickAction({
+                        regenerateStripeLink: true,
+                        items: sanitiseLineItems(),
+                        allowStripePayment: true,
+                      })
+                    }
+                  >
+                    Create payment link
+                  </button>
+                ) : null}
+
+                <div className="flex flex-wrap gap-2">
+                  <button type="button" className="btn-outline btn-xs" onClick={() => handleQuickAction({ markSent: true })}>
+                    Mark sent
+                  </button>
+                  <button type="button" className="btn-outline btn-xs" onClick={() => handleQuickAction({ markPaid: true })}>
+                    Mark paid
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-outline btn-xs"
+                    onClick={() => handleQuickAction({ portalPublished: !invoice.portalPublished })}
+                  >
+                    {invoice.portalPublished ? "Unpublish" : "Publish to portal"}
+                  </button>
+                </div>
+
+                <PDFDownloadLink
+                  document={
+                    <InvoicePDF
+                      invoice={{
+                        id: invoice.id,
+                        organisationName: form.organisationName || form.clientName || invoice.id,
+                        clientName: form.clientName,
+                        clientEmail: form.clientEmail,
+                        dueDate: form.dueDate,
+                        items: sanitiseLineItems(),
+                        total: invoiceTotal,
+                        paymentTerms: form.paymentTerms,
+                        notes: form.notes,
+                      }}
+                    />
+                  }
+                  fileName={`${invoice.id || "invoice"}.pdf`}
+                  className="btn-outline btn-xs"
+                >
+                  Download PDF
+                </PDFDownloadLink>
+
+                <button type="button" className="btn-outline btn-xs" onClick={() => router.push("/admin/finance/invoices")}> 
+                  Close
+                </button>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </PortalContainer>
+  );
+}

--- a/apps/web/app/admin/finance/invoices/[id]/page.tsx
+++ b/apps/web/app/admin/finance/invoices/[id]/page.tsx
@@ -1,0 +1,7 @@
+import ClientPage from './ClientPage';
+
+export const metadata = { title: 'Admin – Invoice | Pineapple Tapped' };
+
+export default function Page({ params }: { params: { id: string } }) {
+  return <ClientPage invoiceId={params.id} />;
+}

--- a/apps/web/app/admin/finance/invoices/new/ClientPage.tsx
+++ b/apps/web/app/admin/finance/invoices/new/ClientPage.tsx
@@ -10,7 +10,8 @@ import {
   type KeyboardEvent,
 } from "react";
 import Link from "next/link";
-import { addDoc, collection, getDocs, query, where } from "firebase/firestore";
+import { useRouter } from "next/navigation";
+import { collection, getDocs, query, where } from "firebase/firestore";
 
 import { useRoleGate } from "@/hooks/useRoleGate";
 import { adminListUsers } from "@/lib/admin";
@@ -43,7 +44,6 @@ interface InvoiceFormState {
   paymentTerms: string;
   termsUrl: string;
   allowStripe: boolean;
-  stripePaymentLink: string;
   splitPaymentsEnabled: boolean;
   splitPayments: SplitPayment[];
 }
@@ -108,7 +108,6 @@ const createInitialForm = (): InvoiceFormState => ({
   paymentTerms: "",
   termsUrl: "",
   allowStripe: true,
-  stripePaymentLink: "",
   splitPaymentsEnabled: false,
   splitPayments: [{ ...emptySplitPayment }],
 });
@@ -531,6 +530,24 @@ export default function NewInvoicePage() {
     }
   };
 
+  const router = useRouter();
+
+  const normaliseDateInput = (value: string | null | undefined) => {
+    if (!value) {
+      return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      const iso = new Date(`${trimmed}T00:00:00.000Z`);
+      return Number.isNaN(iso.getTime()) ? null : iso.toISOString();
+    }
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  };
+
   const sanitiseLineItems = () => {
     return form.items
       .map((item) => {
@@ -604,7 +621,13 @@ export default function NewInvoicePage() {
       const finalDueDate = form.splitPaymentsEnabled
         ? sortedSchedule.at(-1)?.dueDate || null
         : form.dueDate || null;
-      const payload: Record<string, unknown> = {
+      const splitSchedulePayload = form.splitPaymentsEnabled
+        ? sortedSchedule.map((entry) => ({
+            amount: entry.amount,
+            dueDate: normaliseDateInput(entry.dueDate),
+          }))
+        : [];
+      const payload = {
         orgId: form.orgId || null,
         organisationName: billingName,
         crmRecordId: form.crmRecordId || null,
@@ -614,32 +637,34 @@ export default function NewInvoicePage() {
         clientStatus: form.clientStatus || null,
         billingEntityType: selectedEntry?.type || (billingName ? "custom" : null),
         projectId: form.projectId || null,
-        dueDate: finalDueDate,
+        dueDate: normaliseDateInput(finalDueDate),
         items: lineItems,
-        total: invoiceTotal,
-        status: "unpaid",
-        createdAt: new Date().toISOString(),
         paymentTerms: form.paymentTerms || null,
         termsUrl: form.termsUrl || null,
         allowStripePayment: form.allowStripe,
-        stripePaymentLink: form.stripePaymentLink || null,
-        splitPayments: form.splitPaymentsEnabled ? sortedSchedule : [],
-        splitPaymentsTotal: form.splitPaymentsEnabled
-          ? sortedSchedule.reduce((sum, entry) => sum + entry.amount, 0)
-          : null,
-        splitPaymentsCount: form.splitPaymentsEnabled
-          ? sortedSchedule.length
-          : null,
-        firstPaymentDueDate: form.splitPaymentsEnabled
-          ? sortedSchedule.at(0)?.dueDate || null
-          : null,
+        splitPayments: splitSchedulePayload,
       };
-      await addDoc(collection(db, "clientInvoices"), payload);
+      const response = await fetch("/api/admin/invoices", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => ({}));
+        const message =
+          typeof errorPayload?.error === "string"
+            ? errorPayload.error
+            : "Failed to create invoice.";
+        throw new Error(message);
+      }
+      const result = await response.json();
       alert("Invoice created");
-      setForm(createInitialForm());
-      setOrganisationQuery("");
-      setSelectedDirectoryKey(null);
-      setShowDirectory(false);
+      const invoiceId = result?.invoice?.id as string | undefined;
+      if (invoiceId) {
+        router.push(`/admin/finance/invoices/${invoiceId}`);
+      } else {
+        router.push("/admin/finance/invoices");
+      }
     } catch (error: any) {
       console.error(error);
       alert(error?.message || "Error creating invoice");
@@ -915,19 +940,6 @@ export default function NewInvoicePage() {
                   Enable
                 </label>
               </div>
-              {form.allowStripe ? (
-                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-                  Stripe payment link (optional)
-                  <input
-                    type="url"
-                    name="stripePaymentLink"
-                    className="input mt-1 w-full"
-                    placeholder="https://checkout.stripe.com/..."
-                    value={form.stripePaymentLink}
-                    onChange={handleFormFieldChange}
-                  />
-                </label>
-              ) : null}
               <div className="space-y-3 rounded-2xl border border-gray-200 p-4">
                 <div className="flex items-center justify-between">
                   <div>

--- a/apps/web/app/admin/finance/invoices/page.tsx
+++ b/apps/web/app/admin/finance/invoices/page.tsx
@@ -1,0 +1,7 @@
+import ClientPage from './ClientPage';
+
+export const metadata = { title: 'Admin – Invoices | Pineapple Tapped' };
+
+export default function Page() {
+  return <ClientPage />;
+}

--- a/apps/web/app/admin/products/ClientPage.tsx
+++ b/apps/web/app/admin/products/ClientPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "firebase/firestore";
 import Papa from "papaparse";
 import type { Product } from "@/lib/products";
+import { getProductEventRangeLabel, formatProductOnsiteDuration } from "@/lib/products";
 import type { Category } from "@/lib/categories";
 
 export default function AdminProductsPage() {
@@ -196,11 +197,14 @@ export default function AdminProductsPage() {
         <p>No products found.</p>
       ) : (
         <div className="grid gap-3">
-          {filtered.map((p) => (
-            <div
-              key={p.id}
-              className="card p-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4"
-            >
+          {filtered.map((p) => {
+            const eventLabel = getProductEventRangeLabel(p);
+            const onsiteLabel = formatProductOnsiteDuration(p);
+            return (
+              <div
+                key={p.id}
+                className="card p-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4"
+              >
               <div className="flex items-center gap-4">
                 {p.imageUrl && (
                   <Image
@@ -226,10 +230,11 @@ export default function AdminProductsPage() {
                   {p.venue && (
                     <p className="text-xs text-gray-600">{p.venue}</p>
                   )}
-                  {p.eventDate && (
-                    <p className="text-xs text-gray-600">
-                      {new Date(p.eventDate).toLocaleDateString()}
-                    </p>
+                  {eventLabel && (
+                    <p className="text-xs text-gray-600">{eventLabel}</p>
+                  )}
+                  {onsiteLabel && (
+                    <p className="text-xs text-gray-500">{onsiteLabel}</p>
                   )}
                 </div>
               </div>
@@ -257,7 +262,8 @@ export default function AdminProductsPage() {
                 </button>
               </div>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -685,7 +685,9 @@ export default function EditProductPage() {
   const [category, setCategory] = useState("");
   const [salesMode, setSalesMode] = useState<"ecommerce" | "quote">("ecommerce");
   const [workflowId, setWorkflowId] = useState("");
-  const [eventDate, setEventDate] = useState("");
+  const [eventStartDate, setEventStartDate] = useState("");
+  const [eventEndDate, setEventEndDate] = useState("");
+  const [eventSetupDate, setEventSetupDate] = useState("");
   const [venueId, setVenueId] = useState("");
   const [venue, setVenue] = useState("");
   const [hidden, setHidden] = useState(false);
@@ -731,6 +733,7 @@ export default function EditProductPage() {
   const [roleLibraryMessage, setRoleLibraryMessage] = useState<
     { tone: "success" | "error"; text: string } | null
   >(null);
+  const [onsiteDays, setOnsiteDays] = useState("");
   const [kitCostMode, setKitCostMode] = useState<"manual" | "guided">("manual");
   const [manualKitCost, setManualKitCost] = useState("0");
   const [travelMiles, setTravelMiles] = useState("100");
@@ -1127,7 +1130,11 @@ export default function EditProductPage() {
           setSeo(p.seo || {});
           setCategory(p.category || "");
           setSalesMode((p as any).salesMode === "quote" ? "quote" : "ecommerce");
-          setEventDate(p.eventDate || "");
+          setEventStartDate(p.eventStartDate || p.eventDate || "");
+          setEventEndDate(
+            p.eventEndDate || p.eventStartDate || p.eventDate || ""
+          );
+          setEventSetupDate(p.eventSetupDate || "");
           initialVenueId = (p as any).venueId || "";
           initialVenueName = p.venue || "";
           setVenueId(initialVenueId);
@@ -1145,6 +1152,13 @@ export default function EditProductPage() {
           );
           setTasks(p.defaultTasks || []);
           setWorkflowId((p as any).workflowId || "");
+          setOnsiteDays(
+            typeof (p as any).onsiteDays === "number"
+              ? String((p as any).onsiteDays)
+              : typeof (p as any).onsiteDays === "string"
+                ? (p as any).onsiteDays
+                : ""
+          );
           const requiredKit = Array.isArray((p as any).requiredKit)
             ? (p as any).requiredKit
             : [];
@@ -1623,6 +1637,11 @@ export default function EditProductPage() {
       priceTier2,
       priceTier3
     );
+    const onsiteDaysValueRaw = Number(onsiteDays);
+    const onsiteDaysValue =
+      onsiteDays.trim().length > 0 && Number.isFinite(onsiteDaysValueRaw) && onsiteDaysValueRaw > 0
+        ? onsiteDaysValueRaw
+        : null;
     await updateDoc(doc(db, "products", id), {
       name,
       description,
@@ -1655,9 +1674,13 @@ export default function EditProductPage() {
       modifierGroups: enabledGroups,
       modifiers: modifierData,
       category: category || null,
-      eventDate: eventDate || null,
+      eventDate: eventStartDate || null,
+      eventStartDate: eventStartDate || null,
+      eventEndDate: eventEndDate || null,
+      eventSetupDate: eventSetupDate || null,
       venue: venueLabel,
       venueId: venueId || null,
+      onsiteDays: onsiteDaysValue,
       hidden,
       driveTemplateFolderId:
         driveTemplateFolderId.trim().length > 0 ? driveTemplateFolderId.trim() : null,
@@ -2377,13 +2400,45 @@ export default function EditProductPage() {
           </select>
           {cats.find((c) => c.id === category)?.name === "Exhibition Videography" && (
             <>
-              <label className="text-sm font-medium">Event Date</label>
+              <label className="text-sm font-medium">Show start date</label>
               <input
                 type="date"
                 className="input"
-                value={eventDate}
-                onChange={(e) => setEventDate(e.target.value)}
+                value={eventStartDate}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setEventStartDate(value);
+                  setEventEndDate((prev) => (prev ? prev : value));
+                  setEventSetupDate((prev) => {
+                    if (prev || !value) return prev;
+                    const parsed = new Date(`${value}T00:00:00`);
+                    if (Number.isNaN(parsed.getTime())) return prev;
+                    const setup = new Date(parsed.getTime() - 24 * 60 * 60 * 1000);
+                    return setup.toISOString().slice(0, 10);
+                  });
+                }}
               />
+              <label className="text-sm font-medium">Show end date</label>
+              <input
+                type="date"
+                className="input"
+                value={eventEndDate}
+                onChange={(e) => setEventEndDate(e.target.value)}
+                min={eventStartDate || undefined}
+              />
+              <p className="text-xs text-gray-500 -mt-1">
+                Clients will see the full run so they can pick the right day for filming.
+              </p>
+              <label className="text-sm font-medium">Optional setup day</label>
+              <input
+                type="date"
+                className="input"
+                value={eventSetupDate}
+                onChange={(e) => setEventSetupDate(e.target.value)}
+              />
+              <p className="text-xs text-gray-500 -mt-1">
+                Provide a date if you want to offer coverage the day before the show.
+              </p>
               <label className="text-sm font-medium">Linked Venue</label>
               <select
                 className="input"
@@ -2464,6 +2519,19 @@ export default function EditProductPage() {
             value={deliveryIndex}
             onChange={(e) => setDeliveryIndex(Number(e.target.value))}
           />
+          <label className="text-sm font-medium">On-site duration (days)</label>
+          <input
+            type="number"
+            min="0.25"
+            step="0.25"
+            className="input"
+            value={onsiteDays}
+            onChange={(e) => setOnsiteDays(e.target.value)}
+            placeholder="1"
+          />
+          <p className="text-xs text-gray-500 -mt-1">
+            Used to block calendar availability for multi-day shoots.
+          </p>
           <label className="text-sm font-medium">Our Operations</label>
           <textarea
             className="input"

--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -734,6 +734,11 @@ export default function EditProductPage() {
     { tone: "success" | "error"; text: string } | null
   >(null);
   const [onsiteDays, setOnsiteDays] = useState("");
+  const [onsiteSetupMinutes, setOnsiteSetupMinutes] = useState("");
+  const [onsiteShootMinutes, setOnsiteShootMinutes] = useState("");
+  const [onsiteBreakdownMinutes, setOnsiteBreakdownMinutes] = useState("");
+  const [onsiteWindowStart, setOnsiteWindowStart] = useState("");
+  const [onsiteWindowEnd, setOnsiteWindowEnd] = useState("");
   const [kitCostMode, setKitCostMode] = useState<"manual" | "guided">("manual");
   const [manualKitCost, setManualKitCost] = useState("0");
   const [travelMiles, setTravelMiles] = useState("100");
@@ -756,6 +761,32 @@ export default function EditProductPage() {
     if (!value || value.trim().length === 0) return null;
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : null;
+  };
+  const parseOptionalMinutes = (value: string): number | null => {
+    if (!value || value.trim().length === 0) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  const normaliseTimeOfDay = (value: string): string | null => {
+    if (!value) return null;
+    const trimmed = value.trim();
+    if (!/^\d{1,2}:\d{2}$/.test(trimmed)) {
+      return null;
+    }
+    const [hoursStr, minutesStr] = trimmed.split(":");
+    const hours = Number.parseInt(hoursStr, 10);
+    const minutes = Number.parseInt(minutesStr, 10);
+    if (
+      !Number.isFinite(hours) ||
+      !Number.isFinite(minutes) ||
+      hours < 0 ||
+      hours > 23 ||
+      minutes < 0 ||
+      minutes > 59
+    ) {
+      return null;
+    }
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
   };
   const buildPriceTierPayload = (
     tier1: number | null,
@@ -1158,6 +1189,37 @@ export default function EditProductPage() {
               : typeof (p as any).onsiteDays === "string"
                 ? (p as any).onsiteDays
                 : ""
+          );
+          setOnsiteSetupMinutes(
+            typeof (p as any).onsiteSetupMinutes === "number"
+              ? String((p as any).onsiteSetupMinutes)
+              : typeof (p as any).onsiteSetupMinutes === "string"
+                ? (p as any).onsiteSetupMinutes
+                : ""
+          );
+          setOnsiteShootMinutes(
+            typeof (p as any).onsiteShootMinutes === "number"
+              ? String((p as any).onsiteShootMinutes)
+              : typeof (p as any).onsiteShootMinutes === "string"
+                ? (p as any).onsiteShootMinutes
+                : ""
+          );
+          setOnsiteBreakdownMinutes(
+            typeof (p as any).onsiteBreakdownMinutes === "number"
+              ? String((p as any).onsiteBreakdownMinutes)
+              : typeof (p as any).onsiteBreakdownMinutes === "string"
+                ? (p as any).onsiteBreakdownMinutes
+                : ""
+          );
+          setOnsiteWindowStart(
+            typeof (p as any).onsiteTimeWindowStart === "string"
+              ? (p as any).onsiteTimeWindowStart
+              : ""
+          );
+          setOnsiteWindowEnd(
+            typeof (p as any).onsiteTimeWindowEnd === "string"
+              ? (p as any).onsiteTimeWindowEnd
+              : ""
           );
           const requiredKit = Array.isArray((p as any).requiredKit)
             ? (p as any).requiredKit
@@ -1642,6 +1704,11 @@ export default function EditProductPage() {
       onsiteDays.trim().length > 0 && Number.isFinite(onsiteDaysValueRaw) && onsiteDaysValueRaw > 0
         ? onsiteDaysValueRaw
         : null;
+    const onsiteSetupValue = parseOptionalMinutes(onsiteSetupMinutes);
+    const onsiteShootValue = parseOptionalMinutes(onsiteShootMinutes);
+    const onsiteBreakdownValue = parseOptionalMinutes(onsiteBreakdownMinutes);
+    const onsiteWindowStartValue = normaliseTimeOfDay(onsiteWindowStart);
+    const onsiteWindowEndValue = normaliseTimeOfDay(onsiteWindowEnd);
     await updateDoc(doc(db, "products", id), {
       name,
       description,
@@ -1681,6 +1748,11 @@ export default function EditProductPage() {
       venue: venueLabel,
       venueId: venueId || null,
       onsiteDays: onsiteDaysValue,
+      onsiteSetupMinutes: onsiteSetupValue,
+      onsiteShootMinutes: onsiteShootValue,
+      onsiteBreakdownMinutes: onsiteBreakdownValue,
+      onsiteTimeWindowStart: onsiteWindowStartValue,
+      onsiteTimeWindowEnd: onsiteWindowEndValue,
       hidden,
       driveTemplateFolderId:
         driveTemplateFolderId.trim().length > 0 ? driveTemplateFolderId.trim() : null,
@@ -2532,6 +2604,81 @@ export default function EditProductPage() {
           <p className="text-xs text-gray-500 -mt-1">
             Used to block calendar availability for multi-day shoots.
           </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Setup minutes</label>
+              <input
+                type="number"
+                min="0"
+                step="15"
+                className="input"
+                value={onsiteSetupMinutes}
+                onChange={(e) => setOnsiteSetupMinutes(e.target.value)}
+                placeholder="60"
+              />
+              <p className="text-xs text-gray-500">
+                Optional. Time your crew needs on site before filming begins.
+              </p>
+            </div>
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Filming minutes</label>
+              <input
+                type="number"
+                min="0"
+                step="15"
+                className="input"
+                value={onsiteShootMinutes}
+                onChange={(e) => setOnsiteShootMinutes(e.target.value)}
+                placeholder="45"
+              />
+              <p className="text-xs text-gray-500">
+                Optional. Core filming window customers should reserve.
+              </p>
+            </div>
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Breakdown minutes</label>
+              <input
+                type="number"
+                min="0"
+                step="15"
+                className="input"
+                value={onsiteBreakdownMinutes}
+                onChange={(e) => setOnsiteBreakdownMinutes(e.target.value)}
+                placeholder="15"
+              />
+              <p className="text-xs text-gray-500">
+                Optional. Packing and wrap-up time after filming.
+              </p>
+            </div>
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Earliest arrival</label>
+              <input
+                type="time"
+                className="input"
+                value={onsiteWindowStart}
+                onChange={(e) => setOnsiteWindowStart(e.target.value)}
+                step={900}
+                placeholder="08:00"
+              />
+              <p className="text-xs text-gray-500">
+                Leave blank to default to 08:00.
+              </p>
+            </div>
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Latest finish</label>
+              <input
+                type="time"
+                className="input"
+                value={onsiteWindowEnd}
+                onChange={(e) => setOnsiteWindowEnd(e.target.value)}
+                step={900}
+                placeholder="18:00"
+              />
+              <p className="text-xs text-gray-500">
+                Leave blank to default to 18:00 or extend to fit the shoot.
+              </p>
+            </div>
+          </div>
           <label className="text-sm font-medium">Our Operations</label>
           <textarea
             className="input"

--- a/apps/web/app/admin/products/new/ClientPage.tsx
+++ b/apps/web/app/admin/products/new/ClientPage.tsx
@@ -521,7 +521,9 @@ export default function NewProductPage() {
   const [category, setCategory] = useState("");
   const [salesMode, setSalesMode] = useState<"ecommerce" | "quote">("ecommerce");
   const [workflowId, setWorkflowId] = useState("");
-  const [eventDate, setEventDate] = useState("");
+  const [eventStartDate, setEventStartDate] = useState("");
+  const [eventEndDate, setEventEndDate] = useState("");
+  const [eventSetupDate, setEventSetupDate] = useState("");
   const [venueId, setVenueId] = useState("");
   const [venue, setVenue] = useState("");
   const [hidden, setHidden] = useState(false);
@@ -548,6 +550,7 @@ export default function NewProductPage() {
   const [roleLibraryMessage, setRoleLibraryMessage] = useState<
     { tone: "success" | "error"; text: string } | null
   >(null);
+  const [onsiteDays, setOnsiteDays] = useState("1");
   const selectedVenue = useMemo(
     () => venues.find((v) => v.id === venueId) || null,
     [venues, venueId]
@@ -1305,6 +1308,11 @@ export default function NewProductPage() {
       priceTier2,
       priceTier3
     );
+    const onsiteDaysValueRaw = Number(onsiteDays);
+    const onsiteDaysValue =
+      onsiteDays.trim().length > 0 && Number.isFinite(onsiteDaysValueRaw) && onsiteDaysValueRaw > 0
+        ? onsiteDaysValueRaw
+        : null;
     const docRef = await addDoc(collection(db, "products"), {
       name,
       description,
@@ -1330,9 +1338,13 @@ export default function NewProductPage() {
       operationsInfo: operationsInfo || null,
       deliveryTime: deliveryOptions[deliveryIndex],
       category: category || null,
-      eventDate: eventDate || null,
+      eventDate: eventStartDate || null,
+      eventStartDate: eventStartDate || null,
+      eventEndDate: eventEndDate || null,
+      eventSetupDate: eventSetupDate || null,
       venue: venueLabel,
       venueId: venueId || null,
+      onsiteDays: onsiteDaysValue,
       hidden,
       driveTemplateFolderId:
         driveTemplateFolderId.trim().length > 0 ? driveTemplateFolderId.trim() : null,
@@ -1815,13 +1827,46 @@ export default function NewProductPage() {
           </select>
           {cats.find((c) => c.id === category)?.name === "Exhibition Videography" && (
             <>
-              <label className="text-sm font-medium">Event Date</label>
+              <label className="text-sm font-medium">Show start date</label>
               <input
                 type="date"
                 className="input"
-                value={eventDate}
-                onChange={(e) => setEventDate(e.target.value)}
+                value={eventStartDate}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setEventStartDate(value);
+                  setEventEndDate((prev) => (prev ? prev : value));
+                  setEventSetupDate((prev) => {
+                    if (prev || !value) return prev;
+                    const parsed = new Date(`${value}T00:00:00`);
+                    if (Number.isNaN(parsed.getTime())) return prev;
+                    const setup = new Date(parsed.getTime() - 24 * 60 * 60 * 1000);
+                    return setup.toISOString().slice(0, 10);
+                  });
+                }}
               />
+              <label className="text-sm font-medium">Show end date</label>
+              <input
+                type="date"
+                className="input"
+                value={eventEndDate}
+                onChange={(e) => setEventEndDate(e.target.value)}
+                min={eventStartDate || undefined}
+              />
+              <p className="text-xs text-gray-500 -mt-1">
+                Clients will see the full run so they can pick the right day for filming.
+              </p>
+              <label className="text-sm font-medium">Optional setup day</label>
+              <input
+                type="date"
+                className="input"
+                value={eventSetupDate}
+                onChange={(e) => setEventSetupDate(e.target.value)}
+                placeholder="Day before the show opens"
+              />
+              <p className="text-xs text-gray-500 -mt-1">
+                Provide a date if you want to offer coverage the day before the show.
+              </p>
               <label className="text-sm font-medium">Linked Venue</label>
               <select
                 className="input"
@@ -1902,6 +1947,19 @@ export default function NewProductPage() {
             value={deliveryIndex}
             onChange={(e) => setDeliveryIndex(Number(e.target.value))}
           />
+          <label className="text-sm font-medium">On-site duration (days)</label>
+          <input
+            type="number"
+            min="0.25"
+            step="0.25"
+            className="input"
+            value={onsiteDays}
+            onChange={(e) => setOnsiteDays(e.target.value)}
+            placeholder="1"
+          />
+          <p className="text-xs text-gray-500 -mt-1">
+            Used to block calendar availability for multi-day shoots.
+          </p>
           <label className="text-sm font-medium">Our Operations</label>
           <textarea
             className="input"

--- a/apps/web/app/admin/products/new/ClientPage.tsx
+++ b/apps/web/app/admin/products/new/ClientPage.tsx
@@ -551,6 +551,11 @@ export default function NewProductPage() {
     { tone: "success" | "error"; text: string } | null
   >(null);
   const [onsiteDays, setOnsiteDays] = useState("1");
+  const [onsiteSetupMinutes, setOnsiteSetupMinutes] = useState("");
+  const [onsiteShootMinutes, setOnsiteShootMinutes] = useState("");
+  const [onsiteBreakdownMinutes, setOnsiteBreakdownMinutes] = useState("");
+  const [onsiteWindowStart, setOnsiteWindowStart] = useState("");
+  const [onsiteWindowEnd, setOnsiteWindowEnd] = useState("");
   const selectedVenue = useMemo(
     () => venues.find((v) => v.id === venueId) || null,
     [venues, venueId]
@@ -565,6 +570,32 @@ export default function NewProductPage() {
     if (!value || value.trim().length === 0) return null;
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : null;
+  };
+  const parseOptionalMinutes = (value: string): number | null => {
+    if (!value || value.trim().length === 0) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  const normaliseTimeOfDay = (value: string): string | null => {
+    if (!value) return null;
+    const trimmed = value.trim();
+    if (!/^\d{1,2}:\d{2}$/.test(trimmed)) {
+      return null;
+    }
+    const [hoursStr, minutesStr] = trimmed.split(":");
+    const hours = Number.parseInt(hoursStr, 10);
+    const minutes = Number.parseInt(minutesStr, 10);
+    if (
+      !Number.isFinite(hours) ||
+      !Number.isFinite(minutes) ||
+      hours < 0 ||
+      hours > 23 ||
+      minutes < 0 ||
+      minutes > 59
+    ) {
+      return null;
+    }
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
   };
   const buildPriceTierPayload = (
     tier1: number | null,
@@ -1313,6 +1344,11 @@ export default function NewProductPage() {
       onsiteDays.trim().length > 0 && Number.isFinite(onsiteDaysValueRaw) && onsiteDaysValueRaw > 0
         ? onsiteDaysValueRaw
         : null;
+    const onsiteSetupValue = parseOptionalMinutes(onsiteSetupMinutes);
+    const onsiteShootValue = parseOptionalMinutes(onsiteShootMinutes);
+    const onsiteBreakdownValue = parseOptionalMinutes(onsiteBreakdownMinutes);
+    const onsiteWindowStartValue = normaliseTimeOfDay(onsiteWindowStart);
+    const onsiteWindowEndValue = normaliseTimeOfDay(onsiteWindowEnd);
     const docRef = await addDoc(collection(db, "products"), {
       name,
       description,
@@ -1345,6 +1381,11 @@ export default function NewProductPage() {
       venue: venueLabel,
       venueId: venueId || null,
       onsiteDays: onsiteDaysValue,
+      onsiteSetupMinutes: onsiteSetupValue,
+      onsiteShootMinutes: onsiteShootValue,
+      onsiteBreakdownMinutes: onsiteBreakdownValue,
+      onsiteTimeWindowStart: onsiteWindowStartValue,
+      onsiteTimeWindowEnd: onsiteWindowEndValue,
       hidden,
       driveTemplateFolderId:
         driveTemplateFolderId.trim().length > 0 ? driveTemplateFolderId.trim() : null,
@@ -1960,6 +2001,81 @@ export default function NewProductPage() {
           <p className="text-xs text-gray-500 -mt-1">
             Used to block calendar availability for multi-day shoots.
           </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Setup minutes</label>
+              <input
+                type="number"
+                min="0"
+                step="15"
+                className="input"
+                value={onsiteSetupMinutes}
+                onChange={(e) => setOnsiteSetupMinutes(e.target.value)}
+                placeholder="60"
+              />
+              <p className="text-xs text-gray-500">
+                Optional. Time your crew needs on site before filming begins.
+              </p>
+            </div>
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Filming minutes</label>
+              <input
+                type="number"
+                min="0"
+                step="15"
+                className="input"
+                value={onsiteShootMinutes}
+                onChange={(e) => setOnsiteShootMinutes(e.target.value)}
+                placeholder="45"
+              />
+              <p className="text-xs text-gray-500">
+                Optional. Core filming window customers should reserve.
+              </p>
+            </div>
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Breakdown minutes</label>
+              <input
+                type="number"
+                min="0"
+                step="15"
+                className="input"
+                value={onsiteBreakdownMinutes}
+                onChange={(e) => setOnsiteBreakdownMinutes(e.target.value)}
+                placeholder="15"
+              />
+              <p className="text-xs text-gray-500">
+                Optional. Packing and wrap-up time after filming.
+              </p>
+            </div>
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Earliest arrival</label>
+              <input
+                type="time"
+                className="input"
+                value={onsiteWindowStart}
+                onChange={(e) => setOnsiteWindowStart(e.target.value)}
+                step={900}
+                placeholder="08:00"
+              />
+              <p className="text-xs text-gray-500">
+                Leave blank to default to 08:00.
+              </p>
+            </div>
+            <div className="grid gap-1">
+              <label className="text-sm font-medium">Latest finish</label>
+              <input
+                type="time"
+                className="input"
+                value={onsiteWindowEnd}
+                onChange={(e) => setOnsiteWindowEnd(e.target.value)}
+                step={900}
+                placeholder="18:00"
+              />
+              <p className="text-xs text-gray-500">
+                Leave blank to default to 18:00 or extend to fit the shoot.
+              </p>
+            </div>
+          </div>
           <label className="text-sm font-medium">Our Operations</label>
           <textarea
             className="input"

--- a/apps/web/app/admin/users/ClientPage.tsx
+++ b/apps/web/app/admin/users/ClientPage.tsx
@@ -61,6 +61,8 @@ interface AdminUser {
   organisation?: string | null;
   phone?: string | null;
   notes?: string | null;
+  linkedinBio?: string | null;
+  origin?: string | null;
   updatedAt?: unknown;
   lastContactedAt?: unknown;
   createdAt?: unknown;
@@ -130,6 +132,7 @@ export default function AdminUsersPage() {
   const [auditLogs, setAuditLogs] = useState<CrmAuditLogEntry[]>([]);
   const [auditLoading, setAuditLoading] = useState(true);
   const [auditError, setAuditError] = useState<string | null>(null);
+  const [auditExpanded, setAuditExpanded] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -761,11 +764,15 @@ export default function AdminUsersPage() {
       showSuggestedProduct = false,
       showClientValue = false,
       showCompliance = false,
+      primaryColumnLabel = 'Email',
+      getPrimaryValue,
     }: {
       allowedStatuses: CRMStatus[];
       showSuggestedProduct?: boolean;
       showClientValue?: boolean;
       showCompliance?: boolean;
+      primaryColumnLabel?: string;
+      getPrimaryValue?: (user: AdminUser) => string | null | undefined;
     }
   ) => {
     if (list.length === 0) {
@@ -778,7 +785,7 @@ export default function AdminUsersPage() {
       <table className="w-full text-sm border">
         <thead>
           <tr className="bg-gray-100 text-left">
-            <th className="p-2">Email</th>
+            <th className="p-2">{primaryColumnLabel}</th>
             <th className="p-2">Name</th>
             <th className="p-2">Stage</th>
             <th className="p-2">Affiliate</th>
@@ -795,7 +802,9 @@ export default function AdminUsersPage() {
             const complianceEntry = showCompliance ? complianceByUser.get(user.id) : null;
             return (
               <tr key={user.id} className="border-t">
-                <td className="p-2">{user.email}</td>
+                <td className="p-2">
+                  {(getPrimaryValue ? getPrimaryValue(user) : user.email) || '—'}
+                </td>
                 <td className="p-2">{user.fullName || user.organisation || '-'}</td>
                 <td className="p-2">
                   <select
@@ -1095,6 +1104,8 @@ export default function AdminUsersPage() {
               {renderTable(clients, {
                 allowedStatuses: CRM_ALL_STATUSES,
                 showClientValue: true,
+                primaryColumnLabel: 'Organisation',
+                getPrimaryValue: (record) => record.organisation || record.email,
               })}
             </div>
           )}
@@ -1120,36 +1131,49 @@ export default function AdminUsersPage() {
           <section className="rounded-3xl border border-gray-200 bg-white p-4 shadow-sm">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <h2 className="text-base font-semibold text-gray-900">Activity log</h2>
-              {filteredAuditLogs.length > 0 ? (
-                <span className="text-xs text-gray-500">
-                  Showing {Math.min(auditEntries.length, 25)} of {filteredAuditLogs.length} updates
-                </span>
-              ) : null}
+              <div className="flex items-center gap-3">
+                {auditExpanded && filteredAuditLogs.length > 0 ? (
+                  <span className="text-xs text-gray-500">
+                    Showing {Math.min(auditEntries.length, 25)} of {filteredAuditLogs.length} updates
+                  </span>
+                ) : null}
+                <button
+                  type="button"
+                  className="text-sm font-medium text-orange"
+                  onClick={() => setAuditExpanded((prev) => !prev)}
+                >
+                  {auditExpanded ? 'Hide activity' : 'Show activity'}
+                </button>
+              </div>
             </div>
-            <div className="mt-3 grid gap-2">
-              {auditLoading ? (
-                <p className="text-sm text-gray-600">Loading recent updates…</p>
-              ) : auditError ? (
-                <p className="text-sm text-red-600">{auditError}</p>
-              ) : auditEntries.length === 0 ? (
-                <p className="text-sm text-gray-600">No recent activity for this view.</p>
-              ) : (
-                <ul className="grid gap-2">
-                  {auditEntries.slice(0, 25).map((log) => (
-                    <li
-                      key={log.id}
-                      className="rounded-lg border border-gray-200 bg-white p-3 text-sm shadow-sm"
-                    >
-                      <div className="flex flex-wrap items-center justify-between gap-2">
-                        <p className="font-medium text-gray-900">{log.description}</p>
-                        <span className="text-xs text-gray-500">{log.timestamp}</span>
-                      </div>
-                      <p className="text-xs text-gray-500">By {log.actor}</p>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
+            {auditExpanded ? (
+              <div className="mt-3 grid gap-2">
+                {auditLoading ? (
+                  <p className="text-sm text-gray-600">Loading recent updates…</p>
+                ) : auditError ? (
+                  <p className="text-sm text-red-600">{auditError}</p>
+                ) : auditEntries.length === 0 ? (
+                  <p className="text-sm text-gray-600">No recent activity for this view.</p>
+                ) : (
+                  <ul className="grid gap-2">
+                    {auditEntries.slice(0, 25).map((log) => (
+                      <li
+                        key={log.id}
+                        className="rounded-lg border border-gray-200 bg-white p-3 text-sm shadow-sm"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="font-medium text-gray-900">{log.description}</p>
+                          <span className="text-xs text-gray-500">{log.timestamp}</span>
+                        </div>
+                        <p className="text-xs text-gray-500">By {log.actor}</p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ) : (
+              <p className="mt-3 text-sm text-gray-600">Activity log hidden. Select “Show activity” to view recent updates.</p>
+            )}
           </section>
           {crmStage === 'outreach' &&
             renderTable(filteredOutreach, {

--- a/apps/web/app/admin/users/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/users/[id]/ClientPage.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { httpsCallable } from 'firebase/functions';
 import {
   collection,
+  deleteDoc,
   doc,
   getDoc,
   getDocs,
@@ -31,7 +32,16 @@ interface CRMUserRecord {
   crmStatus?: string | null;
   discount?: number | null;
   aiBio?: string | null;
+  linkedinBio?: string | null;
   [key: string]: any;
+}
+
+interface ContactDraft {
+  fullName: string;
+  email: string;
+  phone: string;
+  organisation: string;
+  linkedinBio: string;
 }
 
 interface OrderRecord {
@@ -172,6 +182,7 @@ function resolveProposalLabel(proposal: ProposalRecord): string {
 export default function AdminUserDetailPage() {
   const params = useParams<{ id: string }>();
   const userId = params?.id;
+  const router = useRouter();
   const { allowed, loading: guardLoading } = useRoleGate(['sales']);
 
   const [loading, setLoading] = useState(true);
@@ -189,6 +200,16 @@ export default function AdminUserDetailPage() {
   const [discountDraft, setDiscountDraft] = useState<number>(0);
   const [discountSaving, setDiscountSaving] = useState(false);
   const [mergeLoading, setMergeLoading] = useState(false);
+  const [editingContact, setEditingContact] = useState(false);
+  const [contactSaving, setContactSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [contactDraft, setContactDraft] = useState<ContactDraft>({
+    fullName: '',
+    email: '',
+    phone: '',
+    organisation: '',
+    linkedinBio: '',
+  });
 
   useEffect(() => {
     let active = true;
@@ -230,6 +251,15 @@ export default function AdminUserDetailPage() {
             ? payload.discount
             : 0
         );
+        setContactDraft({
+          fullName: typeof payload.fullName === 'string' ? payload.fullName : '',
+          email: typeof payload.email === 'string' ? payload.email : '',
+          phone: typeof payload.phone === 'string' ? payload.phone : '',
+          organisation:
+            typeof payload.organisation === 'string' ? payload.organisation : '',
+          linkedinBio:
+            typeof payload.linkedinBio === 'string' ? payload.linkedinBio : '',
+        });
 
         const email = typeof payload.email === 'string' ? payload.email : null;
 
@@ -441,6 +471,100 @@ export default function AdminUserDetailPage() {
     }
   };
 
+  useEffect(() => {
+    if (!user || editingContact) {
+      return;
+    }
+    setContactDraft({
+      fullName: typeof user.fullName === 'string' ? user.fullName : '',
+      email: typeof user.email === 'string' ? user.email : '',
+      phone: typeof user.phone === 'string' ? user.phone : '',
+      organisation: typeof user.organisation === 'string' ? user.organisation : '',
+      linkedinBio: typeof user.linkedinBio === 'string' ? user.linkedinBio : '',
+    });
+  }, [user, editingContact]);
+
+  const startEditingContact = () => {
+    if (!user) return;
+    setContactDraft({
+      fullName: typeof user.fullName === 'string' ? user.fullName : '',
+      email: typeof user.email === 'string' ? user.email : '',
+      phone: typeof user.phone === 'string' ? user.phone : '',
+      organisation: typeof user.organisation === 'string' ? user.organisation : '',
+      linkedinBio: typeof user.linkedinBio === 'string' ? user.linkedinBio : '',
+    });
+    setEditingContact(true);
+  };
+
+  const cancelEditingContact = () => {
+    if (!user) return;
+    setContactDraft({
+      fullName: typeof user.fullName === 'string' ? user.fullName : '',
+      email: typeof user.email === 'string' ? user.email : '',
+      phone: typeof user.phone === 'string' ? user.phone : '',
+      organisation: typeof user.organisation === 'string' ? user.organisation : '',
+      linkedinBio: typeof user.linkedinBio === 'string' ? user.linkedinBio : '',
+    });
+    setEditingContact(false);
+  };
+
+  const handleContactDraftChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = event.target;
+    setContactDraft((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleContactSave = async () => {
+    if (!user) return;
+    const email = contactDraft.email.trim();
+    if (!email) {
+      alert('Email is required.');
+      return;
+    }
+    setContactSaving(true);
+    try {
+      const updates = {
+        fullName: contactDraft.fullName.trim() || null,
+        email,
+        phone: contactDraft.phone.trim() || null,
+        organisation: contactDraft.organisation.trim() || null,
+        linkedinBio: contactDraft.linkedinBio.trim() || null,
+      };
+      await adminUpdateUser({ userId, updates });
+      setUser((prev) => (prev ? { ...prev, ...updates } : prev));
+      setEditingContact(false);
+    } catch (err: any) {
+      console.error('Failed to update contact details', err);
+      alert(err?.message || 'Failed to update contact details');
+    } finally {
+      setContactSaving(false);
+    }
+  };
+
+  const handleDeleteRecord = async () => {
+    if (!userId || !user) return;
+    const name = user.fullName || user.organisation || user.email || 'this record';
+    const confirmed = window.confirm(
+      `Delete ${name}? This action cannot be undone and will remove the CRM record.`,
+    );
+    if (!confirmed) return;
+    setDeleting(true);
+    try {
+      const { db } = await ensureFirebase();
+      if (!db) {
+        throw new Error('Firestore is unavailable.');
+      }
+      await deleteDoc(doc(db, 'users', userId));
+      router.push('/admin/users');
+    } catch (err: any) {
+      console.error('Failed to delete CRM record', err);
+      alert(err?.message || 'Failed to delete CRM record');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   if (guardLoading || loading) {
     return <p>Loading…</p>;
   }
@@ -493,9 +617,27 @@ export default function AdminUserDetailPage() {
             ) : null}
           </div>
         </div>
-        <Link className="btn-outline" href="/admin/users">
-          Back to CRM
-        </Link>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            className="btn-outline disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={contactSaving || deleting}
+            onClick={() => (editingContact ? cancelEditingContact() : startEditingContact())}
+            type="button"
+          >
+            {editingContact ? 'Cancel edit' : 'Edit contact details'}
+          </button>
+          <button
+            className="btn-outline border-red-200 text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={deleting || contactSaving}
+            onClick={handleDeleteRecord}
+            type="button"
+          >
+            {deleting ? 'Deleting…' : 'Delete record'}
+          </button>
+          <Link className="btn-outline" href="/admin/users">
+            Back to CRM
+          </Link>
+        </div>
       </div>
 
       {error ? (
@@ -503,6 +645,112 @@ export default function AdminUserDetailPage() {
           {error}
         </div>
       ) : null}
+
+      <section className="rounded-3xl border border-gray-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-lg font-semibold">Contact details</h2>
+        </div>
+        {editingContact ? (
+          <form
+            className="mt-4 grid gap-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleContactSave();
+            }}
+          >
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="grid gap-1 text-sm font-medium text-gray-700">
+                Full name
+                <input
+                  className="border p-2"
+                  name="fullName"
+                  onChange={handleContactDraftChange}
+                  type="text"
+                  value={contactDraft.fullName}
+                />
+              </label>
+              <label className="grid gap-1 text-sm font-medium text-gray-700">
+                Organisation
+                <input
+                  className="border p-2"
+                  name="organisation"
+                  onChange={handleContactDraftChange}
+                  type="text"
+                  value={contactDraft.organisation}
+                />
+              </label>
+              <label className="grid gap-1 text-sm font-medium text-gray-700">
+                Email
+                <input
+                  className="border p-2"
+                  name="email"
+                  onChange={handleContactDraftChange}
+                  type="email"
+                  value={contactDraft.email}
+                />
+              </label>
+              <label className="grid gap-1 text-sm font-medium text-gray-700">
+                Phone
+                <input
+                  className="border p-2"
+                  name="phone"
+                  onChange={handleContactDraftChange}
+                  type="tel"
+                  value={contactDraft.phone}
+                />
+              </label>
+            </div>
+            <label className="grid gap-1 text-sm font-medium text-gray-700">
+              LinkedIn bio
+              <textarea
+                className="border p-2"
+                name="linkedinBio"
+                onChange={handleContactDraftChange}
+                rows={4}
+                value={contactDraft.linkedinBio}
+              />
+            </label>
+            <div className="flex justify-end gap-2">
+              <button className="btn-sm" disabled={contactSaving} type="submit">
+                {contactSaving ? 'Saving…' : 'Save changes'}
+              </button>
+              <button
+                className="btn-sm btn-outline"
+                disabled={contactSaving}
+                onClick={cancelEditingContact}
+                type="button"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        ) : (
+          <dl className="mt-4 grid gap-4 text-sm text-gray-700 sm:grid-cols-2">
+            <div>
+              <dt className="text-xs font-semibold uppercase text-gray-500">Email</dt>
+              <dd className="mt-1 text-gray-900">{user.email || '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase text-gray-500">Phone</dt>
+              <dd className="mt-1 text-gray-900">{user.phone || '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase text-gray-500">Full name</dt>
+              <dd className="mt-1 text-gray-900">{user.fullName || '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase text-gray-500">Organisation</dt>
+              <dd className="mt-1 text-gray-900">{user.organisation || '—'}</dd>
+            </div>
+            <div className="sm:col-span-2">
+              <dt className="text-xs font-semibold uppercase text-gray-500">LinkedIn bio</dt>
+              <dd className="mt-1 whitespace-pre-line text-gray-900">
+                {user.linkedinBio ? user.linkedinBio : '—'}
+              </dd>
+            </div>
+          </dl>
+        )}
+      </section>
 
       <section className="grid gap-4">
         <h2 className="text-lg font-semibold">Account snapshot</h2>

--- a/apps/web/app/api/admin/invoices/[id]/route.ts
+++ b/apps/web/app/api/admin/invoices/[id]/route.ts
@@ -6,6 +6,7 @@ import type { DocumentSnapshot, QueryDocumentSnapshot } from 'firebase-admin/fir
 import { getFirebaseAdminAuth, getFirebaseAdminFirestore } from '@/lib/firebase-admin';
 import { extractUserRoles, hasRole, type RoleKey, type UserRoles } from '@/lib/roles';
 import { getStripeClient } from '@/lib/stripe-config';
+import type Stripe from 'stripe';
 
 const FINANCE_ROLES: RoleKey[] = ['admin', 'finance'];
 
@@ -524,7 +525,11 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
           }));
         if (lineItems.length > 0) {
           const paymentLink = await stripe.paymentLinks.create({
-            line_items: lineItems,
+            // Stripe's API accepts inline `price_data`, but the current type
+            // definition only models the `price` field. Cast to keep the code
+            // aligned with the documented request shape until the upstream
+            // types catch up.
+            line_items: lineItems as unknown as Stripe.PaymentLinkCreateParams.LineItem[],
             after_completion: { type: 'hosted_confirmation', custom_message: 'Thanks for your payment!' },
             metadata: {
               invoiceId: id,

--- a/apps/web/app/api/admin/invoices/[id]/route.ts
+++ b/apps/web/app/api/admin/invoices/[id]/route.ts
@@ -1,0 +1,563 @@
+import { cookies } from 'next/headers';
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import type { DocumentSnapshot, QueryDocumentSnapshot } from 'firebase-admin/firestore';
+
+import { getFirebaseAdminAuth, getFirebaseAdminFirestore } from '@/lib/firebase-admin';
+import { extractUserRoles, hasRole, type RoleKey, type UserRoles } from '@/lib/roles';
+import { getStripeClient } from '@/lib/stripe-config';
+
+const FINANCE_ROLES: RoleKey[] = ['admin', 'finance'];
+
+type FinanceContext = { uid: string; email: string | null; roles: UserRoles };
+
+type HistoryEntry = {
+  event: string;
+  at: string;
+  actor: { uid: string; email: string | null } | null;
+  notes?: string | null;
+};
+
+const LINE_ITEM_SCHEMA = z
+  .array(
+    z
+      .object({
+        description: z
+          .string({ required_error: 'Description is required.' })
+          .trim()
+          .min(1, 'Description is required.'),
+        amount: z
+          .union([z.number(), z.string()])
+          .transform((value) => {
+            if (typeof value === 'number' && Number.isFinite(value)) {
+              return value;
+            }
+            if (typeof value === 'string') {
+              const parsed = Number.parseFloat(value.trim());
+              if (Number.isFinite(parsed)) {
+                return parsed;
+              }
+            }
+            throw new Error('Amount must be a number.');
+          })
+          .refine((value) => value >= 0, 'Amount must be zero or greater.'),
+        productId: z
+          .union([z.string(), z.null(), z.undefined()])
+          .transform((value) => {
+            if (typeof value === 'string') {
+              const trimmed = value.trim();
+              return trimmed.length > 0 ? trimmed : null;
+            }
+            return null;
+          })
+          .optional(),
+      })
+      .transform((item) => ({
+        description: item.description,
+        amount: Number.parseFloat(item.amount.toFixed(2)),
+        productId: item.productId ?? null,
+      }))
+  )
+  .optional();
+
+const SPLIT_PAYMENT_SCHEMA = z
+  .array(
+    z
+      .object({
+        amount: z
+          .union([z.number(), z.string()])
+          .transform((value) => {
+            if (typeof value === 'number' && Number.isFinite(value)) {
+              return value;
+            }
+            if (typeof value === 'string') {
+              const parsed = Number.parseFloat(value.trim());
+              if (Number.isFinite(parsed)) {
+                return parsed;
+              }
+            }
+            throw new Error('Split payment amount must be a number.');
+          })
+          .refine((value) => value >= 0, 'Split payment amount must be zero or greater.'),
+        dueDate: z
+          .union([z.string(), z.null(), z.undefined()])
+          .transform((value) => {
+            if (!value) {
+              return null;
+            }
+            const trimmed = value.trim();
+            if (!trimmed) {
+              return null;
+            }
+            const isoDate = parseDateInput(trimmed);
+            if (!isoDate) {
+              throw new Error('Invalid split payment due date.');
+            }
+            return isoDate;
+          })
+          .nullable(),
+      })
+      .transform((payment) => ({
+        amount: Number.parseFloat(payment.amount.toFixed(2)),
+        dueDate: payment.dueDate,
+      }))
+  )
+  .optional();
+
+const UPDATE_SCHEMA = z.object({
+  organisationName: z
+    .union([z.string(), z.undefined()])
+    .transform((value) => {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+      }
+      return value;
+    })
+    .optional(),
+  clientName: z
+    .union([z.string(), z.undefined()])
+    .transform((value) => {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+      }
+      return value;
+    })
+    .optional(),
+  clientEmail: z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((value) => {
+      if (typeof value !== 'string') {
+        return value ?? undefined;
+      }
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      if (!/^\S+@\S+\.\S+$/.test(trimmed)) {
+        throw new Error('Client email is invalid.');
+      }
+      return trimmed.toLowerCase();
+    })
+    .optional(),
+  dueDate: z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((value) => {
+      if (!value && value !== '') {
+        return undefined;
+      }
+      if (value === null || value === '') {
+        return null;
+      }
+      const isoDate = parseDateInput(value.trim());
+      if (!isoDate) {
+        throw new Error('Invalid due date.');
+      }
+      return isoDate;
+    })
+    .optional(),
+  paymentTerms: z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((value) => {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : null;
+      }
+      if (value === null) {
+        return null;
+      }
+      return undefined;
+    })
+    .optional(),
+  termsUrl: z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((value) => {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return null;
+        }
+        try {
+          const url = new URL(trimmed);
+          return url.toString();
+        } catch (error) {
+          throw new Error('Terms URL is invalid.');
+        }
+      }
+      if (value === null) {
+        return null;
+      }
+      return undefined;
+    })
+    .optional(),
+  status: z
+    .union([
+      z.literal('draft'),
+      z.literal('sent'),
+      z.literal('unpaid'),
+      z.literal('paid'),
+      z.literal('overdue'),
+      z.literal('void'),
+      z.undefined(),
+    ])
+    .optional(),
+  portalPublished: z.boolean().optional(),
+  allowStripePayment: z.boolean().optional(),
+  items: LINE_ITEM_SCHEMA,
+  splitPayments: SPLIT_PAYMENT_SCHEMA,
+  notes: z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((value) => {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : null;
+      }
+      if (value === null) {
+        return null;
+      }
+      return undefined;
+    })
+    .optional(),
+  regenerateStripeLink: z.boolean().optional(),
+  markSent: z.boolean().optional(),
+  markPaid: z.boolean().optional(),
+});
+
+function unauthorized(message = 'Unauthorized') {
+  return NextResponse.json({ error: message }, { status: 401 });
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function parseDateInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    const iso = new Date(`${trimmed}T00:00:00.000Z`);
+    if (Number.isNaN(iso.getTime())) {
+      return null;
+    }
+    return iso.toISOString();
+  }
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+async function resolveFinanceContext(): Promise<FinanceContext | null> {
+  const cookieStore = cookies();
+  const sessionCookie =
+    cookieStore.get('session')?.value ??
+    cookieStore.get('__session')?.value ??
+    cookieStore.get('firebase-session')?.value ??
+    null;
+
+  if (!sessionCookie) {
+    return null;
+  }
+
+  try {
+    const auth = getFirebaseAdminAuth();
+    const decoded = await auth.verifySessionCookie(sessionCookie, true);
+    const firestore = getFirebaseAdminFirestore();
+    const snapshot = await firestore.collection('users').doc(decoded.uid).get();
+    const data = snapshot.exists ? snapshot.data() ?? {} : {};
+    const emailFromStore = typeof data?.email === 'string' ? (data.email as string) : null;
+    const email = typeof decoded.email === 'string' ? decoded.email : emailFromStore;
+    const enrichedDoc = {
+      ...data,
+      id: snapshot.id || decoded.uid,
+      uid: decoded.uid,
+      email,
+    };
+    const roles = extractUserRoles(enrichedDoc);
+    if (!hasRole(roles, FINANCE_ROLES)) {
+      return null;
+    }
+    return { uid: decoded.uid, email, roles };
+  } catch (error) {
+    console.warn('Failed to verify finance session', error);
+    return null;
+  }
+}
+
+function serialiseValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => serialiseValue(entry));
+  }
+  if (typeof value !== 'object') {
+    return value;
+  }
+  const maybeDate = value as { toDate?: () => Date };
+  if (typeof maybeDate.toDate === 'function') {
+    try {
+      return maybeDate.toDate().toISOString();
+    } catch (error) {
+      console.warn('Failed to serialise Firestore timestamp', error);
+      return value;
+    }
+  }
+  const proto = Object.getPrototypeOf(value);
+  if (!proto || proto === Object.prototype) {
+    const result: Record<string, unknown> = {};
+    Object.entries(value as Record<string, unknown>).forEach(([key, entry]) => {
+      result[key] = serialiseValue(entry);
+    });
+    return result;
+  }
+  return value;
+}
+
+function serialiseDoc(doc: DocumentSnapshot | QueryDocumentSnapshot) {
+  const data = doc.data() ?? {};
+  const result: Record<string, unknown> = { id: doc.id };
+  Object.entries(data as Record<string, unknown>).forEach(([key, value]) => {
+    result[key] = serialiseValue(value);
+  });
+  return result;
+}
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const context = await resolveFinanceContext();
+  if (!context) {
+    return unauthorized();
+  }
+
+  const { id } = params;
+  if (!id) {
+    return badRequest('Invoice ID is required.');
+  }
+
+  try {
+    const firestore = getFirebaseAdminFirestore();
+    const invoiceRef = firestore.collection('clientInvoices').doc(id);
+    const snapshot = await invoiceRef.get();
+    if (!snapshot.exists) {
+      return NextResponse.json({ error: 'Invoice not found.' }, { status: 404 });
+    }
+    const invoice = serialiseDoc(snapshot);
+    return NextResponse.json({ invoice });
+  } catch (error) {
+    console.error('Failed to load invoice', error);
+    return NextResponse.json({ error: 'Failed to load invoice.' }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const context = await resolveFinanceContext();
+  if (!context) {
+    return unauthorized();
+  }
+
+  const { id } = params;
+  if (!id) {
+    return badRequest('Invoice ID is required.');
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    return badRequest('Invalid JSON payload.');
+  }
+
+  const parseResult = UPDATE_SCHEMA.safeParse(payload ?? {});
+  if (!parseResult.success) {
+    const message = parseResult.error.errors.at(0)?.message ?? 'Invalid invoice update payload.';
+    return badRequest(message);
+  }
+
+  const updatesInput = parseResult.data;
+  const firestore = getFirebaseAdminFirestore();
+  const invoiceRef = firestore.collection('clientInvoices').doc(id);
+  const snapshot = await invoiceRef.get();
+  if (!snapshot.exists) {
+    return NextResponse.json({ error: 'Invoice not found.' }, { status: 404 });
+  }
+
+  const existing = snapshot.data() ?? {};
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const updates: Record<string, unknown> = { updatedAt: nowIso };
+  const history: HistoryEntry[] = Array.isArray(existing.history)
+    ? ([...existing.history] as HistoryEntry[])
+    : [];
+  const historyEvents: HistoryEntry[] = [];
+
+  if (updatesInput.organisationName !== undefined) {
+    updates.organisationName = updatesInput.organisationName ?? null;
+  }
+  if (updatesInput.clientName !== undefined) {
+    updates.clientName = updatesInput.clientName ?? null;
+  }
+  if (updatesInput.clientEmail !== undefined) {
+    updates.clientEmail = updatesInput.clientEmail;
+  }
+  if (updatesInput.dueDate !== undefined) {
+    updates.dueDate = updatesInput.dueDate;
+  }
+  if (updatesInput.paymentTerms !== undefined) {
+    updates.paymentTerms = updatesInput.paymentTerms;
+  }
+  if (updatesInput.termsUrl !== undefined) {
+    updates.termsUrl = updatesInput.termsUrl;
+  }
+  if (updatesInput.notes !== undefined) {
+    updates.notes = updatesInput.notes;
+  }
+  if (typeof updatesInput.portalPublished === 'boolean') {
+    updates.portalPublished = updatesInput.portalPublished;
+    historyEvents.push({
+      event: updatesInput.portalPublished ? 'published_to_portal' : 'unpublished_from_portal',
+      at: nowIso,
+      actor: { uid: context.uid, email: context.email },
+    });
+  }
+  if (typeof updatesInput.allowStripePayment === 'boolean') {
+    updates.allowStripePayment = updatesInput.allowStripePayment;
+  }
+
+  let itemsChanged = false;
+  if (updatesInput.items) {
+    updates.items = updatesInput.items;
+    itemsChanged = true;
+  }
+  if (updatesInput.splitPayments) {
+    updates.splitPayments = updatesInput.splitPayments;
+    updates.splitPaymentsCount = updatesInput.splitPayments.length;
+  }
+
+  let statusChanged = false;
+  if (updatesInput.status) {
+    updates.status = updatesInput.status;
+    statusChanged = true;
+    historyEvents.push({
+      event: `status_${updatesInput.status}`,
+      at: nowIso,
+      actor: { uid: context.uid, email: context.email },
+    });
+    if (updatesInput.status === 'paid') {
+      updates.paidAt = nowIso;
+    }
+    if (updatesInput.status === 'sent') {
+      updates.sentAt = nowIso;
+    }
+  }
+
+  if (updatesInput.markSent) {
+    updates.status = 'sent';
+    updates.sentAt = nowIso;
+    statusChanged = true;
+    historyEvents.push({
+      event: 'status_sent',
+      at: nowIso,
+      actor: { uid: context.uid, email: context.email },
+    });
+  }
+
+  if (updatesInput.markPaid) {
+    updates.status = 'paid';
+    updates.paidAt = nowIso;
+    statusChanged = true;
+    historyEvents.push({
+      event: 'status_paid',
+      at: nowIso,
+      actor: { uid: context.uid, email: context.email },
+    });
+  }
+
+  let total = typeof existing.total === 'number' ? existing.total : 0;
+  if (itemsChanged && Array.isArray(updatesInput.items)) {
+    total = updatesInput.items.reduce((sum, item) => sum + item.amount, 0);
+    updates.total = Number.parseFloat(total.toFixed(2));
+    if (!statusChanged || updates.status !== 'paid') {
+      updates.outstandingBalance = Number.parseFloat(total.toFixed(2));
+    }
+  }
+
+  if (updatesInput.splitPayments && updatesInput.splitPayments.length > 0) {
+    const scheduleTotal = updatesInput.splitPayments.reduce((sum, item) => sum + item.amount, 0);
+    const roundedTotal = Number.parseFloat(total.toFixed(2));
+    const roundedSchedule = Number.parseFloat(scheduleTotal.toFixed(2));
+    if (Math.abs(roundedTotal - roundedSchedule) > 0.5) {
+      return badRequest('Split payment schedule total must match the invoice total.');
+    }
+  }
+
+  if (statusChanged && updates.status === 'paid') {
+    updates.outstandingBalance = 0;
+  }
+
+  let regenerateStripe = Boolean(updatesInput.regenerateStripeLink);
+  if (itemsChanged && updatesInput.allowStripePayment !== false && existing.allowStripePayment !== false) {
+    regenerateStripe = regenerateStripe || Boolean(existing.allowStripePayment ?? true);
+  }
+  if (updatesInput.allowStripePayment === false) {
+    regenerateStripe = false;
+    updates.stripePaymentUrl = null;
+    updates.stripePaymentLinkId = null;
+  }
+
+  if (regenerateStripe) {
+    try {
+      const stripe = await getStripeClient();
+      if (stripe && Array.isArray(updatesInput.items) && updatesInput.items.length > 0) {
+        const lineItems = updatesInput.items
+          .filter((item) => item.amount > 0)
+          .map((item) => ({
+            price_data: {
+              currency: 'gbp',
+              product_data: { name: item.description },
+              unit_amount: Math.round(item.amount * 100),
+            },
+            quantity: 1,
+          }));
+        if (lineItems.length > 0) {
+          const paymentLink = await stripe.paymentLinks.create({
+            line_items: lineItems,
+            after_completion: { type: 'hosted_confirmation', custom_message: 'Thanks for your payment!' },
+            metadata: {
+              invoiceId: id,
+              organisationName: (updates.organisationName as string | undefined) ?? existing.organisationName ?? '',
+              clientName: (updates.clientName as string | undefined) ?? existing.clientName ?? '',
+            },
+          });
+          updates.stripePaymentUrl = paymentLink.url;
+          updates.stripePaymentLinkId = paymentLink.id;
+          historyEvents.push({
+            event: 'stripe_link_regenerated',
+            at: nowIso,
+            actor: { uid: context.uid, email: context.email },
+          });
+        }
+      }
+    } catch (error) {
+      console.error('Failed to regenerate Stripe payment link for invoice', error);
+    }
+  }
+
+  if (historyEvents.length > 0) {
+    history.push(...historyEvents);
+    updates.history = history;
+  }
+
+  try {
+    await invoiceRef.set(updates, { merge: true });
+    const refreshed = await invoiceRef.get();
+    const invoice = serialiseDoc(refreshed);
+    return NextResponse.json({ invoice });
+  } catch (error) {
+    console.error('Failed to update invoice', error);
+    return NextResponse.json({ error: 'Failed to update invoice.' }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/admin/invoices/route.ts
+++ b/apps/web/app/api/admin/invoices/route.ts
@@ -1,0 +1,494 @@
+import { cookies } from 'next/headers';
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import type { DocumentSnapshot, QueryDocumentSnapshot } from 'firebase-admin/firestore';
+
+import { getFirebaseAdminAuth, getFirebaseAdminFirestore } from '@/lib/firebase-admin';
+import { extractUserRoles, hasRole, type RoleKey, type UserRoles } from '@/lib/roles';
+import { getStripeClient } from '@/lib/stripe-config';
+
+const FINANCE_ROLES: RoleKey[] = ['admin', 'finance'];
+
+type FinanceContext = { uid: string; email: string | null; roles: UserRoles };
+
+type FirestorePrimitive = string | number | boolean | null;
+
+type InvoiceHistoryEntry = {
+  event: string;
+  at: string;
+  actor: { uid: string; email: string | null } | null;
+  notes?: string | null;
+};
+
+const LINE_ITEM_SCHEMA = z
+  .object({
+    description: z
+      .string({ required_error: 'Description is required.' })
+      .trim()
+      .min(1, 'Description is required.'),
+    amount: z
+      .union([z.number(), z.string()])
+      .transform((value) => {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          return value;
+        }
+        if (typeof value === 'string') {
+          const parsed = Number.parseFloat(value.trim());
+          if (Number.isFinite(parsed)) {
+            return parsed;
+          }
+        }
+        throw new Error('Amount must be a number.');
+      })
+      .refine((value) => value >= 0, 'Amount must be zero or greater.'),
+    productId: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          return trimmed.length > 0 ? trimmed : null;
+        }
+        return null;
+      })
+      .optional(),
+  })
+  .transform((item) => ({
+    description: item.description,
+    amount: Number.parseFloat(item.amount.toFixed(2)),
+    productId: item.productId ?? null,
+  }));
+
+const SPLIT_PAYMENT_SCHEMA = z
+  .object({
+    amount: z
+      .union([z.number(), z.string()])
+      .transform((value) => {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          return value;
+        }
+        if (typeof value === 'string') {
+          const parsed = Number.parseFloat(value.trim());
+          if (Number.isFinite(parsed)) {
+            return parsed;
+          }
+        }
+        throw new Error('Split payment amount must be a number.');
+      })
+      .refine((value) => value >= 0, 'Split payment amount must be zero or greater.'),
+    dueDate: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (!value) {
+          return null;
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return null;
+        }
+        const isoDate = parseDateInput(trimmed);
+        if (!isoDate) {
+          throw new Error('Invalid split payment due date.');
+        }
+        return isoDate;
+      })
+      .nullable(),
+  })
+  .transform((payment) => ({
+    amount: Number.parseFloat(payment.amount.toFixed(2)),
+    dueDate: payment.dueDate,
+  }));
+
+const CREATE_INVOICE_SCHEMA = z
+  .object({
+    orgId: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          return trimmed.length > 0 ? trimmed : null;
+        }
+        return null;
+      })
+      .nullable(),
+    organisationName: z
+      .string({ required_error: 'Organisation name is required.' })
+      .trim()
+      .min(1, 'Organisation name is required.'),
+    crmRecordId: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          return trimmed.length > 0 ? trimmed : null;
+        }
+        return null;
+      })
+      .nullable(),
+    clientId: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          return trimmed.length > 0 ? trimmed : null;
+        }
+        return null;
+      })
+      .nullable(),
+    clientName: z
+      .string({ required_error: 'Client name is required.' })
+      .trim()
+      .min(1, 'Client name is required.'),
+    clientEmail: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value !== 'string') {
+          return null;
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return null;
+        }
+        if (!/^\S+@\S+\.\S+$/.test(trimmed)) {
+          throw new Error('Client email is invalid.');
+        }
+        return trimmed.toLowerCase();
+      })
+      .nullable(),
+    clientStatus: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          return trimmed.length > 0 ? trimmed : null;
+        }
+        return null;
+      })
+      .nullable(),
+    billingEntityType: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          return trimmed.length > 0 ? trimmed : null;
+        }
+        return null;
+      })
+      .nullable(),
+    projectId: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          return trimmed.length > 0 ? trimmed : null;
+        }
+        return null;
+      })
+      .nullable(),
+    dueDate: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (!value) {
+          return null;
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return null;
+        }
+        const isoDate = parseDateInput(trimmed);
+        if (!isoDate) {
+          throw new Error('Invalid due date.');
+        }
+        return isoDate;
+      })
+      .nullable(),
+    items: z.array(LINE_ITEM_SCHEMA).min(1, 'At least one line item is required.'),
+    paymentTerms: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          return trimmed.length > 0 ? trimmed : null;
+        }
+        return null;
+      })
+      .nullable(),
+    termsUrl: z
+      .union([z.string(), z.null(), z.undefined()])
+      .transform((value) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (!trimmed) {
+            return null;
+          }
+          try {
+            const url = new URL(trimmed);
+            return url.toString();
+          } catch (error) {
+            throw new Error('Terms URL is invalid.');
+          }
+        }
+        return null;
+      })
+      .nullable(),
+    allowStripePayment: z.boolean().optional().default(true),
+    splitPayments: z.array(SPLIT_PAYMENT_SCHEMA).optional().default([]),
+  })
+  .transform((payload) => ({
+    ...payload,
+    allowStripePayment: payload.allowStripePayment ?? true,
+  }));
+
+function unauthorized(message = 'Unauthorized') {
+  return NextResponse.json({ error: message }, { status: 401 });
+}
+
+function forbidden(message = 'Forbidden') {
+  return NextResponse.json({ error: message }, { status: 403 });
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function parseDateInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    const iso = new Date(`${trimmed}T00:00:00.000Z`);
+    if (Number.isNaN(iso.getTime())) {
+      return null;
+    }
+    return iso.toISOString();
+  }
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+async function resolveFinanceContext(): Promise<FinanceContext | null> {
+  const cookieStore = cookies();
+  const sessionCookie =
+    cookieStore.get('session')?.value ??
+    cookieStore.get('__session')?.value ??
+    cookieStore.get('firebase-session')?.value ??
+    null;
+
+  if (!sessionCookie) {
+    return null;
+  }
+
+  try {
+    const auth = getFirebaseAdminAuth();
+    const decoded = await auth.verifySessionCookie(sessionCookie, true);
+    const firestore = getFirebaseAdminFirestore();
+    const snapshot = await firestore.collection('users').doc(decoded.uid).get();
+    const data = snapshot.exists ? snapshot.data() ?? {} : {};
+    const emailFromStore = typeof data?.email === 'string' ? (data.email as string) : null;
+    const email = typeof decoded.email === 'string' ? decoded.email : emailFromStore;
+    const enrichedDoc = {
+      ...data,
+      id: snapshot.id || decoded.uid,
+      uid: decoded.uid,
+      email,
+    };
+    const roles = extractUserRoles(enrichedDoc);
+
+    if (!hasRole(roles, FINANCE_ROLES)) {
+      return null;
+    }
+
+    return { uid: decoded.uid, email, roles };
+  } catch (error) {
+    console.warn('Failed to verify finance session', error);
+    return null;
+  }
+}
+
+function serialiseValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value as null | undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => serialiseValue(entry));
+  }
+
+  if (typeof value !== 'object') {
+    return value as FirestorePrimitive;
+  }
+
+  const maybeDate = value as { toDate?: () => Date };
+  if (typeof maybeDate.toDate === 'function') {
+    try {
+      return maybeDate.toDate().toISOString();
+    } catch (error) {
+      console.warn('Failed to serialise Firestore timestamp', error);
+      return value;
+    }
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  if (!proto || proto === Object.prototype) {
+    const result: Record<string, unknown> = {};
+    Object.entries(value as Record<string, unknown>).forEach(([key, entry]) => {
+      result[key] = serialiseValue(entry);
+    });
+    return result;
+  }
+
+  return value;
+}
+
+function serialiseInvoiceDoc(doc: QueryDocumentSnapshot | DocumentSnapshot) {
+  const data = doc.data() ?? {};
+  const result: Record<string, unknown> = { id: doc.id };
+  Object.entries(data as Record<string, unknown>).forEach(([key, value]) => {
+    result[key] = serialiseValue(value);
+  });
+  return result;
+}
+
+export async function GET() {
+  const context = await resolveFinanceContext();
+  if (!context) {
+    return unauthorized();
+  }
+
+  try {
+    const firestore = getFirebaseAdminFirestore();
+    const snapshot = await firestore
+      .collection('clientInvoices')
+      .orderBy('createdAt', 'desc')
+      .limit(100)
+      .get();
+    const invoices = snapshot.docs.map((doc) => serialiseInvoiceDoc(doc));
+    return NextResponse.json({ invoices });
+  } catch (error) {
+    console.error('Failed to list invoices', error);
+    return NextResponse.json({ error: 'Failed to load invoices.' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const context = await resolveFinanceContext();
+  if (!context) {
+    return unauthorized();
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (error) {
+    return badRequest('Invalid JSON payload.');
+  }
+
+  const parseResult = CREATE_INVOICE_SCHEMA.safeParse(body);
+  if (!parseResult.success) {
+    const message = parseResult.error.errors.at(0)?.message ?? 'Invalid invoice payload.';
+    return badRequest(message);
+  }
+
+  const payload = parseResult.data;
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const total = payload.items.reduce((sum, item) => sum + item.amount, 0);
+  const splitScheduleTotal = (payload.splitPayments ?? []).reduce((sum, entry) => sum + entry.amount, 0);
+
+  if (payload.splitPayments && payload.splitPayments.length > 0) {
+    const roundedTotal = Number.parseFloat(total.toFixed(2));
+    const roundedSchedule = Number.parseFloat(splitScheduleTotal.toFixed(2));
+    if (Math.abs(roundedTotal - roundedSchedule) > 0.5) {
+      return badRequest('Split payment schedule total must match the invoice total.');
+    }
+  }
+
+  const firestore = getFirebaseAdminFirestore();
+  const invoiceRef = firestore.collection('clientInvoices').doc();
+
+  let stripePaymentUrl: string | null = null;
+  let stripePaymentLinkId: string | null = null;
+  if (payload.allowStripePayment) {
+    try {
+      const stripe = await getStripeClient();
+      if (stripe) {
+        const lineItems = payload.items
+          .filter((item) => item.amount > 0)
+          .map((item) => ({
+            price_data: {
+              currency: 'gbp',
+              product_data: { name: item.description },
+              unit_amount: Math.round(item.amount * 100),
+            },
+            quantity: 1,
+          }));
+        if (lineItems.length > 0) {
+          const paymentLink = await stripe.paymentLinks.create({
+            line_items: lineItems,
+            after_completion: { type: 'hosted_confirmation', custom_message: 'Thanks for your payment!' },
+            metadata: {
+              invoiceId: invoiceRef.id,
+              organisationName: payload.organisationName,
+              clientName: payload.clientName,
+            },
+          });
+          stripePaymentUrl = paymentLink.url;
+          stripePaymentLinkId = paymentLink.id;
+        }
+      }
+    } catch (error) {
+      console.error('Failed to create Stripe payment link for invoice', error);
+    }
+  }
+
+  const history: InvoiceHistoryEntry[] = [
+    {
+      event: 'created',
+      at: nowIso,
+      actor: { uid: context.uid, email: context.email },
+    },
+  ];
+
+  const invoiceData: Record<string, unknown> = {
+    orgId: payload.orgId,
+    organisationName: payload.organisationName,
+    crmRecordId: payload.crmRecordId,
+    clientId: payload.clientId,
+    clientName: payload.clientName,
+    clientEmail: payload.clientEmail,
+    clientStatus: payload.clientStatus,
+    billingEntityType: payload.billingEntityType,
+    projectId: payload.projectId,
+    dueDate: payload.dueDate,
+    items: payload.items,
+    total: Number.parseFloat(total.toFixed(2)),
+    outstandingBalance: Number.parseFloat(total.toFixed(2)),
+    paymentTerms: payload.paymentTerms,
+    termsUrl: payload.termsUrl,
+    allowStripePayment: payload.allowStripePayment,
+    splitPayments: payload.splitPayments,
+    splitPaymentsCount: payload.splitPayments?.length ?? 0,
+    status: 'draft',
+    portalPublished: false,
+    stripePaymentUrl,
+    stripePaymentLinkId,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    sentAt: null,
+    paidAt: null,
+    history,
+  };
+
+  try {
+    await invoiceRef.set(invoiceData);
+    const snapshot = await invoiceRef.get();
+    const invoice = serialiseInvoiceDoc(snapshot);
+    return NextResponse.json({ invoice }, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create invoice', error);
+    return NextResponse.json({ error: 'Failed to create invoice.' }, { status: 500 });
+  }
+}

--- a/apps/web/app/cart/page.tsx
+++ b/apps/web/app/cart/page.tsx
@@ -34,24 +34,24 @@ export default function CartPage() {
                 ? `Remove ${item.name} from cart`
                 : `Decrease quantity of ${item.name}`;
             const slot = item.campaignBooking;
+            const parseDateTime = (value: string | null | undefined) => {
+              if (!value) return null;
+              const normalised =
+                /^\d{4}-\d{2}-\d{2}$/.test(value)
+                  ? `${value}T00:00:00`
+                  : value;
+              const parsed = new Date(normalised);
+              return Number.isNaN(parsed.getTime()) ? null : parsed;
+            };
             const exhibitionDetails = (() => {
               const selection = item.exhibition;
               if (!selection) {
                 return null;
               }
-              const safeDate = (value: string | null | undefined) => {
-                if (!value) return null;
-                const normalised =
-                  /^\d{4}-\d{2}-\d{2}$/.test(value)
-                    ? `${value}T00:00:00`
-                    : value;
-                const parsed = new Date(normalised);
-                return Number.isNaN(parsed.getTime()) ? null : parsed;
-              };
-              const show = safeDate(selection.showDate ?? null);
+              const show = parseDateTime(selection.showDate ?? null);
               const setup =
                 selection.setupIncluded && selection.setupDate
-                  ? safeDate(selection.setupDate)
+                  ? parseDateTime(selection.setupDate)
                   : null;
               return {
                 showLabel: show ? show.toLocaleDateString() : null,
@@ -60,18 +60,9 @@ export default function CartPage() {
               };
             })();
             const dateLabel = (() => {
-              const safeDate = (value: string | null | undefined) => {
-                if (!value) return null;
-                const normalised =
-                  /^\d{4}-\d{2}-\d{2}$/.test(value)
-                    ? `${value}T00:00:00`
-                    : value;
-                const parsed = new Date(normalised);
-                return Number.isNaN(parsed.getTime()) ? null : parsed;
-              };
               if (slot) {
-                const start = safeDate(slot.slotStartAt);
-                const end = safeDate(slot.slotEndAt);
+                const start = parseDateTime(slot.slotStartAt);
+                const end = parseDateTime(slot.slotEndAt);
                 if (start && end) {
                   return `${start.toLocaleString("en-GB", {
                     dateStyle: "medium",
@@ -103,8 +94,8 @@ export default function CartPage() {
                 }
                 const parsed = item.kitItems
                   .map((entry) => ({
-                    start: safeDate(entry.start),
-                    end: safeDate(entry.end),
+                    start: parseDateTime(entry.start),
+                    end: parseDateTime(entry.end),
                   }))
                   .filter(
                     (entry): entry is { start: Date; end: Date } =>
@@ -128,11 +119,38 @@ export default function CartPage() {
                   ? startLabel
                   : `${startLabel} – ${endLabel}`;
               }
-              const fallback = safeDate(item.date);
+              const fallback = parseDateTime(item.date);
               if (fallback) {
                 return fallback.toLocaleDateString();
               }
               return "To be scheduled";
+            })();
+            const timeSlotDetails = (() => {
+              const slotSelection = item.timeSlot;
+              if (!slotSelection) {
+                return null;
+              }
+              if (slotSelection.label) {
+                return `Time: ${slotSelection.label}`;
+              }
+              const start = parseDateTime(slotSelection.start);
+              const end = parseDateTime(slotSelection.end);
+              if (start && end) {
+                const startLabel = start.toLocaleTimeString("en-GB", {
+                  timeStyle: "short",
+                });
+                const endLabel = end.toLocaleTimeString("en-GB", {
+                  timeStyle: "short",
+                });
+                return `Time: ${startLabel} – ${endLabel}`;
+              }
+              if (start) {
+                const startLabel = start.toLocaleTimeString("en-GB", {
+                  timeStyle: "short",
+                });
+                return `Time: ${startLabel}`;
+              }
+              return null;
             })();
 
             return (
@@ -152,6 +170,9 @@ export default function CartPage() {
                     <p className="text-xs text-gray-500">
                       Slot: {slot.slotLabel}
                     </p>
+                  )}
+                  {timeSlotDetails && (
+                    <p className="text-xs text-gray-500">{timeSlotDetails}</p>
                   )}
                   {item.variation && (
                     <p className="text-sm text-gray-600">{item.variation}</p>

--- a/apps/web/app/cart/page.tsx
+++ b/apps/web/app/cart/page.tsx
@@ -34,10 +34,39 @@ export default function CartPage() {
                 ? `Remove ${item.name} from cart`
                 : `Decrease quantity of ${item.name}`;
             const slot = item.campaignBooking;
+            const exhibitionDetails = (() => {
+              const selection = item.exhibition;
+              if (!selection) {
+                return null;
+              }
+              const safeDate = (value: string | null | undefined) => {
+                if (!value) return null;
+                const normalised =
+                  /^\d{4}-\d{2}-\d{2}$/.test(value)
+                    ? `${value}T00:00:00`
+                    : value;
+                const parsed = new Date(normalised);
+                return Number.isNaN(parsed.getTime()) ? null : parsed;
+              };
+              const show = safeDate(selection.showDate ?? null);
+              const setup =
+                selection.setupIncluded && selection.setupDate
+                  ? safeDate(selection.setupDate)
+                  : null;
+              return {
+                showLabel: show ? show.toLocaleDateString() : null,
+                setupLabel: setup ? setup.toLocaleDateString() : null,
+                setupIncluded: Boolean(selection.setupIncluded && setup),
+              };
+            })();
             const dateLabel = (() => {
               const safeDate = (value: string | null | undefined) => {
                 if (!value) return null;
-                const parsed = new Date(value);
+                const normalised =
+                  /^\d{4}-\d{2}-\d{2}$/.test(value)
+                    ? `${value}T00:00:00`
+                    : value;
+                const parsed = new Date(normalised);
                 return Number.isNaN(parsed.getTime()) ? null : parsed;
               };
               if (slot) {
@@ -65,6 +94,40 @@ export default function CartPage() {
                   })}`;
                 }
               }
+              if (exhibitionDetails?.showLabel) {
+                return exhibitionDetails.showLabel;
+              }
+              const kitRange = (() => {
+                if (!item.kitItems || item.kitItems.length === 0) {
+                  return null;
+                }
+                const parsed = item.kitItems
+                  .map((entry) => ({
+                    start: safeDate(entry.start),
+                    end: safeDate(entry.end),
+                  }))
+                  .filter(
+                    (entry): entry is { start: Date; end: Date } =>
+                      Boolean(entry.start) && Boolean(entry.end)
+                  );
+                if (parsed.length === 0) {
+                  return null;
+                }
+                const startDate = new Date(
+                  Math.min(...parsed.map((entry) => entry.start.getTime()))
+                );
+                const endDate = new Date(
+                  Math.max(...parsed.map((entry) => entry.end.getTime()))
+                );
+                return { startDate, endDate };
+              })();
+              if (kitRange) {
+                const startLabel = kitRange.startDate.toLocaleDateString();
+                const endLabel = kitRange.endDate.toLocaleDateString();
+                return startLabel === endLabel
+                  ? startLabel
+                  : `${startLabel} – ${endLabel}`;
+              }
               const fallback = safeDate(item.date);
               if (fallback) {
                 return fallback.toLocaleDateString();
@@ -80,6 +143,11 @@ export default function CartPage() {
                 <div className="min-w-[12rem] flex-1">
                   <p className="font-medium">{item.name}</p>
                   <p className="text-sm text-gray-600">{dateLabel}</p>
+                  {exhibitionDetails?.setupIncluded && exhibitionDetails.setupLabel && (
+                    <p className="text-xs text-gray-500">
+                      Setup day: {exhibitionDetails.setupLabel}
+                    </p>
+                  )}
                   {slot && (
                     <p className="text-xs text-gray-500">
                       Slot: {slot.slotLabel}

--- a/apps/web/app/checkout/CheckoutClient.tsx
+++ b/apps/web/app/checkout/CheckoutClient.tsx
@@ -106,6 +106,7 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
         date: item.date ?? null,
         location: item.location ?? null,
         postalCode: item.postalCode ?? null,
+        exhibition: item.exhibition ?? null,
         coverage: item.coverage ?? null,
         campaignBooking,
       };
@@ -173,6 +174,7 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
           location: item.location,
           postalCode: item.postalCode,
           coverage: item.coverage,
+          exhibition: item.exhibition ?? null,
           campaignBooking: item.campaignBooking,
         })),
         kitItems: orderInput.kitItems.map((kit) => ({

--- a/apps/web/app/checkout/CheckoutClient.tsx
+++ b/apps/web/app/checkout/CheckoutClient.tsx
@@ -107,6 +107,7 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
         location: item.location ?? null,
         postalCode: item.postalCode ?? null,
         exhibition: item.exhibition ?? null,
+        timeSlot: item.timeSlot ?? null,
         coverage: item.coverage ?? null,
         campaignBooking,
       };
@@ -174,6 +175,7 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
           location: item.location,
           postalCode: item.postalCode,
           coverage: item.coverage,
+          timeSlot: item.timeSlot ?? null,
           exhibition: item.exhibition ?? null,
           campaignBooking: item.campaignBooking,
         })),
@@ -605,6 +607,44 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
                 </span>
                 <span>£{(item.price * item.quantity).toFixed(2)}</span>
               </div>
+              {(() => {
+                const parseDateTime = (value: string | null | undefined) => {
+                  if (!value) return null;
+                  const normalised =
+                    /^\d{4}-\d{2}-\d{2}$/.test(value)
+                      ? `${value}T00:00:00`
+                      : value;
+                  const parsed = new Date(normalised);
+                  return Number.isNaN(parsed.getTime()) ? null : parsed;
+                };
+                const slot = item.timeSlot;
+                if (!slot) {
+                  return null;
+                }
+                if (slot.label) {
+                  return (
+                    <div className="text-xs text-gray-500">Time: {slot.label}</div>
+                  );
+                }
+                const start = parseDateTime(slot.start);
+                const end = parseDateTime(slot.end);
+                if (start && end) {
+                  return (
+                    <div className="text-xs text-gray-500">
+                      Time: {start.toLocaleTimeString("en-GB", { timeStyle: "short" })} – {" "}
+                      {end.toLocaleTimeString("en-GB", { timeStyle: "short" })}
+                    </div>
+                  );
+                }
+                if (start) {
+                  return (
+                    <div className="text-xs text-gray-500">
+                      Time: {start.toLocaleTimeString("en-GB", { timeStyle: "short" })}
+                    </div>
+                  );
+                }
+                return null;
+              })()}
               {item.rentalTotal ? (
                 <div className="flex justify-between text-xs text-gray-600">
                   <span>Rental</span>

--- a/apps/web/app/join-team/ClientPage.tsx
+++ b/apps/web/app/join-team/ClientPage.tsx
@@ -47,6 +47,23 @@ type CategoryOption = {
 
 const normalisePostalCodeValue = (value: string): string => value.trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
 
+const deriveOutcodeCandidates = (value: string): string[] => {
+  const normalised = normalisePostalCodeValue(value);
+  if (!normalised) {
+    return [];
+  }
+
+  const candidates = new Set<string>();
+  for (let length = Math.max(2, normalised.length - 3); length >= 2; length -= 1) {
+    const candidate = normalised.slice(0, length);
+    if (/^[A-Z]{1,2}\d[A-Z0-9]?$/.test(candidate) || candidate.length >= 3) {
+      candidates.add(candidate);
+    }
+  }
+
+  return Array.from(candidates);
+};
+
 const haversineDistanceKm = (lat1: number, lon1: number, lat2: number, lon2: number): number => {
   const toRad = (degrees: number) => (degrees * Math.PI) / 180;
   const dLat = toRad(lat2 - lat1);
@@ -148,13 +165,13 @@ export default function JoinTeamPage() {
         raw: string;
         normalised: string;
         resolved: string;
-        lat: number;
-        lng: number;
+        lat: number | null;
+        lng: number | null;
       }
     | null
   >(null);
   const [territorySuggestions, setTerritorySuggestions] = useState<Array<{ id: string; distanceKm: number | null }>>([]);
-  const postalCodeLocationCache = useRef(new Map<string, { lat: number; lng: number; resolved?: string }>());
+  const postalCodeLocationCache = useRef(new Map<string, { lat: number | null; lng: number | null; resolved?: string }>());
   const [marketerForm, setMarketerForm] = useState<MarketerFormState>(initialMarketerForm);
   const [marketerConsent, setMarketerConsent] = useState<MarketerConsentState>(initialMarketerConsent);
   const [marketerSubmitting, setMarketerSubmitting] = useState(false);
@@ -319,15 +336,9 @@ export default function JoinTeamPage() {
   }, [territoryMap]);
 
   const geocodePostalCode = useCallback(
-    async (postalCode: string): Promise<
-      | {
-          lat: number;
-          lng: number;
-          normalised: string;
-          resolved: string;
-        }
-      | null
-    > => {
+    async (
+      postalCode: string
+    ): Promise<{ lat: number | null; lng: number | null; normalised: string; resolved: string } | null> => {
       const normalised = normalisePostalCodeValue(postalCode);
       if (!normalised) {
         return null;
@@ -335,12 +346,13 @@ export default function JoinTeamPage() {
       const cached = postalCodeLocationCache.current.get(normalised);
       if (cached) {
         return {
-          lat: cached.lat,
-          lng: cached.lng,
+          lat: cached.lat ?? null,
+          lng: cached.lng ?? null,
           normalised,
           resolved: cached.resolved ?? normalised,
         };
       }
+
       const controller = new AbortController();
       const timeoutId = window.setTimeout(() => controller.abort(), 7000);
       try {
@@ -351,23 +363,20 @@ export default function JoinTeamPage() {
             signal: controller.signal,
           }
         );
-        if (response.status === 404) {
-          return null;
+        if (response.ok) {
+          const payload = (await response.json()) as {
+            result?: { latitude?: number; longitude?: number; postcode?: string } | null;
+          };
+          const latitude = typeof payload?.result?.latitude === 'number' ? payload.result.latitude : null;
+          const longitude = typeof payload?.result?.longitude === 'number' ? payload.result.longitude : null;
+          const resolved = typeof payload?.result?.postcode === 'string' ? payload.result.postcode : normalised;
+          postalCodeLocationCache.current.set(normalised, { lat: latitude, lng: longitude, resolved });
+          return { lat: latitude, lng: longitude, normalised, resolved };
         }
-        if (!response.ok) {
+
+        if (response.status !== 404) {
           throw new Error(`Lookup failed with status ${response.status}`);
         }
-        const payload = (await response.json()) as {
-          result?: { latitude?: number; longitude?: number; postcode?: string } | null;
-        };
-        const latitude = typeof payload?.result?.latitude === 'number' ? payload.result.latitude : null;
-        const longitude = typeof payload?.result?.longitude === 'number' ? payload.result.longitude : null;
-        if (latitude == null || longitude == null) {
-          return null;
-        }
-        const resolved = typeof payload?.result?.postcode === 'string' ? payload.result.postcode : normalised;
-        postalCodeLocationCache.current.set(normalised, { lat: latitude, lng: longitude, resolved });
-        return { lat: latitude, lng: longitude, normalised, resolved };
       } catch (error) {
         if ((error as Error)?.name === 'AbortError') {
           throw new Error('Lookup timed out');
@@ -376,6 +385,45 @@ export default function JoinTeamPage() {
       } finally {
         window.clearTimeout(timeoutId);
       }
+
+      const outcodeCandidates = deriveOutcodeCandidates(normalised);
+      for (const candidate of outcodeCandidates) {
+        const controller = new AbortController();
+        const timeoutId = window.setTimeout(() => controller.abort(), 7000);
+        try {
+          const response = await fetch(
+            `https://api.postcodes.io/outcodes/${encodeURIComponent(candidate)}`,
+            {
+              headers: { Accept: 'application/json' },
+              signal: controller.signal,
+            }
+          );
+          if (!response.ok) {
+            continue;
+          }
+          const payload = (await response.json()) as {
+            result?: { latitude?: number; longitude?: number; outcode?: string } | null;
+          };
+          const latitude = typeof payload?.result?.latitude === 'number' ? payload.result.latitude : null;
+          const longitude = typeof payload?.result?.longitude === 'number' ? payload.result.longitude : null;
+          const resolved = typeof payload?.result?.outcode === 'string' ? payload.result.outcode : candidate;
+          if (latitude != null && longitude != null) {
+            postalCodeLocationCache.current.set(normalised, { lat: latitude, lng: longitude, resolved });
+            return { lat: latitude, lng: longitude, normalised, resolved };
+          }
+        } catch (error) {
+          if ((error as Error)?.name === 'AbortError') {
+            throw new Error('Lookup timed out');
+          }
+          throw error;
+        } finally {
+          window.clearTimeout(timeoutId);
+        }
+      }
+
+      const resolved = outcodeCandidates.length > 0 ? outcodeCandidates[0] : normalised;
+      postalCodeLocationCache.current.set(normalised, { lat: null, lng: null, resolved });
+      return { lat: null, lng: null, normalised, resolved };
     },
     []
   );
@@ -383,9 +431,15 @@ export default function JoinTeamPage() {
   const computeTerritoryDistance = useCallback(
     async (
       option: TerritoryOption,
-      reference: { lat: number; lng: number; normalised: string }
+      reference: { lat: number | null; lng: number | null; normalised: string }
     ): Promise<number | null> => {
-      if (option.type === 'radius' && option.centerLat != null && option.centerLng != null) {
+      if (
+        reference.lat != null &&
+        reference.lng != null &&
+        option.type === 'radius' &&
+        option.centerLat != null &&
+        option.centerLng != null
+      ) {
         const distance = haversineDistanceKm(reference.lat, reference.lng, option.centerLat, option.centerLng);
         return Number.isFinite(distance) ? distance : null;
       }
@@ -407,9 +461,11 @@ export default function JoinTeamPage() {
           location = { lat: lookup.lat, lng: lookup.lng, resolved: lookup.resolved };
           postalCodeLocationCache.current.set(code, location);
         }
-        const distance = haversineDistanceKm(reference.lat, reference.lng, location.lat, location.lng);
-        if (Number.isFinite(distance)) {
-          bestDistance = bestDistance == null ? distance : Math.min(bestDistance, distance);
+        if (reference.lat != null && reference.lng != null && location.lat != null && location.lng != null) {
+          const distance = haversineDistanceKm(reference.lat, reference.lng, location.lat, location.lng);
+          if (Number.isFinite(distance)) {
+            bestDistance = bestDistance == null ? distance : Math.min(bestDistance, distance);
+          }
         }
       }
       if (bestDistance != null) {
@@ -446,9 +502,16 @@ export default function JoinTeamPage() {
     setPostcodeLookupStatus('loading');
     setPostcodeLookupError(null);
     try {
-      const lookup = await geocodePostalCode(trimmed);
-      if (!lookup) {
-        setPostcodeLookupStatus('notfound');
+      const lookup = (await geocodePostalCode(trimmed)) ?? {
+        lat: null,
+        lng: null,
+        normalised: normalisePostalCodeValue(trimmed),
+        resolved: normalisePostalCodeValue(trimmed),
+      };
+
+      if (!lookup.normalised) {
+        setPostcodeLookupStatus('error');
+        setPostcodeLookupError('Please enter a valid postcode to search for nearby territories.');
         setPostcodeLookupResult(null);
         setTerritorySuggestions([]);
         setSelectedTerritories([]);

--- a/apps/web/components/AddToCartWizard.tsx
+++ b/apps/web/components/AddToCartWizard.tsx
@@ -9,6 +9,8 @@ import {
   formatProductOnsiteDuration,
   getProductEventRangeLabel,
   getProductEventMonthKeys,
+  resolveProductOnsiteTiming,
+  type ProductOnsiteTiming,
 } from "@/lib/products";
 import { useCart } from "@/lib/cart";
 import { db, functions } from "@/lib/firebase";
@@ -342,6 +344,64 @@ const slotDateFormatter = new Intl.DateTimeFormat("en-GB", {
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
+interface WizardTimeSlot {
+  id: string;
+  startMinutes: number;
+  endMinutes: number;
+  label: string;
+}
+
+const formatTimeOfDay = (minutes: number): string => {
+  const hours = Math.floor(minutes / 60) % 24;
+  const mins = Math.round(minutes % 60);
+  return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
+};
+
+const buildTimeSlots = (
+  timing: ProductOnsiteTiming | null
+): WizardTimeSlot[] => {
+  if (!timing) {
+    return [];
+  }
+  const slots: WizardTimeSlot[] = [];
+  const span = Math.max(0, timing.totalMinutes);
+  if (span <= 0) {
+    return slots;
+  }
+  const start = timing.windowStartMinutes;
+  const end = Math.max(start + span, timing.windowEndMinutes);
+  const windowEnd = timing.windowEndMinutes <= start ? end : timing.windowEndMinutes;
+  const step = span <= 60 ? 15 : span <= 180 ? 30 : 60;
+  for (
+    let cursor = start;
+    cursor + span <= windowEnd + 0.01;
+    cursor += Math.max(step, 15)
+  ) {
+    const slotEnd = cursor + span;
+    if (slotEnd > windowEnd + 0.01) {
+      break;
+    }
+    const label = `${formatTimeOfDay(cursor)} – ${formatTimeOfDay(slotEnd)}`;
+    slots.push({
+      id: `${cursor}-${slotEnd}`,
+      startMinutes: cursor,
+      endMinutes: slotEnd,
+      label,
+    });
+  }
+  if (slots.length === 0) {
+    const slotEnd = start + span;
+    const label = `${formatTimeOfDay(start)} – ${formatTimeOfDay(slotEnd)}`;
+    slots.push({
+      id: `${start}-${slotEnd}`,
+      startMinutes: start,
+      endMinutes: slotEnd,
+      label,
+    });
+  }
+  return slots;
+};
+
 const toDateKeyFromDate = (date: Date): string => {
   const year = date.getUTCFullYear();
   const month = String(date.getUTCMonth() + 1).padStart(2, "0");
@@ -461,6 +521,14 @@ export default function AddToCartWizard({
   const onsiteBlockingDays = useMemo(
     () => Math.max(1, Math.ceil(onsiteDaysConfigured)),
     [onsiteDaysConfigured]
+  );
+  const onsiteTiming = useMemo(
+    () => resolveProductOnsiteTiming(product),
+    [product]
+  );
+  const timeSlotRequired = useMemo(
+    () => onsiteTiming !== null && onsiteBlockingDays <= 1,
+    [onsiteTiming, onsiteBlockingDays]
   );
   const onsiteSummary = useMemo(
     () => formatProductOnsiteDuration(product),
@@ -646,6 +714,16 @@ export default function AddToCartWizard({
     }
     return date;
   }, [date, exhibitionSetupOption, includeSetupDay, product.category]);
+  const slotDateKey = useMemo(() => {
+    if (product.category === "exhibition-videography") {
+      return normaliseDateKey(date);
+    }
+    return normaliseDateKey(reservationStartKey);
+  }, [date, product.category, reservationStartKey]);
+  const timeSlots = useMemo(
+    () => buildTimeSlots(timeSlotRequired ? onsiteTiming : null),
+    [onsiteTiming, timeSlotRequired]
+  );
   const selectedDateRange = useMemo(() => {
     if (!reservationStartKey) {
       return null;
@@ -659,6 +737,23 @@ export default function AddToCartWizard({
     const end = new Date(base.getTime() + (bookingSpan - 1) * DAY_IN_MS);
     return { start: base, end };
   }, [bookingSpan, reservationStartKey]);
+  const selectedTimeSlotRange = useMemo(() => {
+    if (!selectedTimeSlot || !slotDateKey) {
+      return null;
+    }
+    const base =
+      parseDateKey(slotDateKey) ?? new Date(`${slotDateKey}T00:00:00.000Z`);
+    if (Number.isNaN(base.getTime())) {
+      return null;
+    }
+    const start = new Date(
+      base.getTime() + selectedTimeSlot.startMinutes * 60 * 1000
+    );
+    const end = new Date(
+      base.getTime() + selectedTimeSlot.endMinutes * 60 * 1000
+    );
+    return { start, end };
+  }, [selectedTimeSlot, slotDateKey]);
   const [error, setError] = useState<string | null>(null);
   const [conflicts, setConflicts] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
@@ -673,6 +768,8 @@ export default function AddToCartWizard({
     useState<CampaignSlotStatus>("idle");
   const [campaignSlotError, setCampaignSlotError] = useState<string | null>(null);
   const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
+  const [selectedTimeSlot, setSelectedTimeSlot] =
+    useState<WizardTimeSlot | null>(null);
   const [availabilityOverrides, setAvailabilityOverrides] = useState<
     Record<string, ProductAvailabilityStatus>
   >({});
@@ -763,6 +860,7 @@ export default function AddToCartWizard({
     setDate(value);
     setConflicts([]);
     setError(null);
+    setSelectedTimeSlot(null);
     const startKey =
       product.category === "exhibition-videography" &&
       includeSetupDay &&
@@ -783,6 +881,25 @@ export default function AddToCartWizard({
     }
     announceSelection(reservationStartKey, bookingSpan);
   }, [announceSelection, bookingSpan, date, reservationStartKey]);
+
+  const handleTimeSlotSelect = useCallback(
+    (slot: WizardTimeSlot) => {
+      setSelectedTimeSlot(slot);
+      setError(null);
+      setLiveMessage(`Selected ${slot.label} filming window`);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!timeSlotRequired) {
+      setSelectedTimeSlot(null);
+    }
+  }, [timeSlotRequired]);
+
+  useEffect(() => {
+    setSelectedTimeSlot(null);
+  }, [slotDateKey]);
 
   useEffect(() => {
     async function load() {
@@ -1313,7 +1430,11 @@ export default function AddToCartWizard({
       product.category === "exhibition-videography"
         ? normaliseDateKey(reservationStartKey)
         : showDateKey;
+    if (!startDateKey) {
+      startDateKey = showDateKey;
+    }
     let requestDateIso: string | null = null;
+    let timeWindow: { start: string; end: string } | null = null;
     if (isCampaignProduct) {
       if (!slotSelection) {
         setError("Select an available slot to continue.");
@@ -1344,11 +1465,22 @@ export default function AddToCartWizard({
       if (!startDateKey) {
         startDateKey = showDateKey;
       }
-    } else if (!date || !startDateKey) {
-      setError("Select a production date to continue.");
-      setLiveMessage("Production date required before adding to cart");
-      return;
     } else {
+      if (!date || !startDateKey) {
+        setError("Select a production date to continue.");
+        setLiveMessage("Production date required before adding to cart");
+        return;
+      }
+      if (timeSlotRequired) {
+        if (!selectedTimeSlotRange) {
+          setError("Select a production time to continue.");
+          setLiveMessage("Production time required before adding to cart");
+          return;
+        }
+        const startIso = selectedTimeSlotRange.start.toISOString();
+        const endIso = selectedTimeSlotRange.end.toISOString();
+        timeWindow = { start: startIso, end: endIso };
+      }
       requestDateIso = `${startDateKey}T00:00:00.000Z`;
     }
     const affectedCalendarKeys =
@@ -1380,6 +1512,7 @@ export default function AddToCartWizard({
         productId: product.id,
         date: requestDateIso,
         spanOverride: bookingSpan,
+        timeWindow,
         coverage: coverage
           ? {
               type: coverage.type,
@@ -1498,6 +1631,18 @@ export default function AddToCartWizard({
         exhibition: exhibitionSelection,
         location: locationLabel.length > 0 ? locationLabel : null,
         postalCode: postalCodeLabel,
+        timeSlot:
+          timeSlotRequired && selectedTimeSlotRange
+            ? {
+                start: selectedTimeSlotRange.start.toISOString(),
+                end: selectedTimeSlotRange.end.toISOString(),
+                label: selectedTimeSlot?.label ?? null,
+                totalMinutes: onsiteTiming?.totalMinutes ?? null,
+                setupMinutes: onsiteTiming?.setupMinutes ?? null,
+                shootMinutes: onsiteTiming?.shootMinutes ?? null,
+                breakdownMinutes: onsiteTiming?.breakdownMinutes ?? null,
+              }
+            : null,
         coverage: {
           type: coverage.type,
           franchiseId: coverage.franchiseId,
@@ -1825,6 +1970,54 @@ export default function AddToCartWizard({
                   }
                   initialMonth={calendarInitialMonth}
                 />
+                {timeSlotRequired && (
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium">Select a filming window</p>
+                    {slotDateKey ? (
+                      timeSlots.length > 0 ? (
+                        <div className="grid gap-2 sm:grid-cols-2">
+                          {timeSlots.map((slot) => {
+                            const checked = selectedTimeSlot?.id === slot.id;
+                            return (
+                              <label
+                                key={slot.id}
+                                className={`flex items-center justify-between gap-3 rounded-md border p-3 text-sm transition focus-within:border-orange-400 focus-within:ring-1 focus-within:ring-orange ${
+                                  checked
+                                    ? "border-orange-400 bg-orange-50"
+                                    : "border-gray-200 bg-white hover:border-orange/60"
+                                }`}
+                              >
+                                <div className="flex items-center gap-3">
+                                  <input
+                                    type="radio"
+                                    name="onsite-slot"
+                                    className="mt-0.5"
+                                    checked={checked}
+                                    onChange={() => handleTimeSlotSelect(slot)}
+                                  />
+                                  <div className="flex flex-col">
+                                    <span className="font-medium">{slot.label}</span>
+                                  </div>
+                                </div>
+                              </label>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        <p className="text-xs text-gray-500">
+                          This product doesn’t have any bookable windows yet.
+                        </p>
+                      )
+                    ) : (
+                      <p className="text-xs text-gray-500">
+                        Choose a production date to see available times.
+                      </p>
+                    )}
+                    <p className="text-xs text-gray-500">
+                      Times shown in UK local time.
+                    </p>
+                  </div>
+                )}
                 {product.category === "exhibition-videography" && exhibitionSetupOption && (
                   <label
                     className={`flex items-start gap-3 rounded-md border px-3 py-2 text-sm transition focus-within:border-orange-400 focus-within:ring-1 focus-within:ring-orange ${
@@ -1872,6 +2065,9 @@ export default function AddToCartWizard({
             {(onsiteSummary || (selectedDateRange && bookingSpan > 1)) && (
               <div className="space-y-1 text-xs text-gray-600">
                 {onsiteSummary && <p>{onsiteSummary}</p>}
+                {timeSlotRequired && selectedTimeSlot && (
+                  <p>Preferred time: {selectedTimeSlot.label}</p>
+                )}
                 {selectedDateRange && bookingSpan > 1 && (
                   <p>
                     Crew reserved {" "}
@@ -1919,7 +2115,9 @@ export default function AddToCartWizard({
           {dateStep ? (
             <button
               className="btn btn-sm"
-              disabled={!date || submitting}
+              disabled={
+                !date || submitting || (timeSlotRequired && !selectedTimeSlotRange)
+              }
               onClick={handleFinish}
             >
               {submitting ? "Adding…" : "Add to Cart"}

--- a/apps/web/components/AddToCartWizard.tsx
+++ b/apps/web/components/AddToCartWizard.tsx
@@ -8,6 +8,7 @@ import { collection, doc, getDoc, getDocs } from "firebase/firestore";
 import { httpsCallable } from "firebase/functions";
 import ProductDatePicker, {
   type ProductAvailabilityScope,
+  type ProductAvailabilityStatus,
 } from "./ProductDatePicker";
 import {
   getPriceForTier,
@@ -364,6 +365,20 @@ const normaliseSlotDate = (value: string | null): string | null => {
   return parsed.toISOString();
 };
 
+const normaliseDateKey = (value: string | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  const year = parsed.getUTCFullYear();
+  const month = String(parsed.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(parsed.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
 type FunctionsError = {
   code: string;
   message: string;
@@ -407,6 +422,9 @@ export default function AddToCartWizard({
     useState<CampaignSlotStatus>("idle");
   const [campaignSlotError, setCampaignSlotError] = useState<string | null>(null);
   const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
+  const [availabilityOverrides, setAvailabilityOverrides] = useState<
+    Record<string, ProductAvailabilityStatus>
+  >({});
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   const territoriesRef = useRef<TerritoryRecord[] | null>(null);
@@ -573,6 +591,7 @@ export default function AddToCartWizard({
     setCampaignSlotStatus("idle");
     setCampaignSlotError(null);
     setSelectedSlotId(null);
+    setAvailabilityOverrides({});
   }, [locationInput, postcodeInput]);
 
   const loadTerritories = useCallback(async (): Promise<TerritoryRecord[]> => {
@@ -1034,6 +1053,19 @@ export default function AddToCartWizard({
       setLiveMessage("Production date required before adding to cart");
       return;
     }
+    const calendarKey =
+      normaliseDateKey(reservationDate) ?? normaliseDateKey(date) ?? null;
+    const updateCalendarStatus = (statusValue: ProductAvailabilityStatus) => {
+      if (!calendarKey) {
+        return;
+      }
+      setAvailabilityOverrides((prev) => {
+        if (prev[calendarKey] === statusValue) {
+          return prev;
+        }
+        return { ...prev, [calendarKey]: statusValue };
+      });
+    };
     setSubmitting(true);
     setLiveMessage("Checking equipment availability");
     try {
@@ -1041,6 +1073,14 @@ export default function AddToCartWizard({
       const res: any = await reserve({
         productId: product.id,
         date: reservationDate,
+        coverage: coverage
+          ? {
+              type: coverage.type,
+              franchiseId: coverage.franchiseId,
+              territoryId: coverage.territoryId,
+              label: coverage.label,
+            }
+          : null,
       });
       const {
         conflicts = [],
@@ -1048,6 +1088,7 @@ export default function AddToCartWizard({
         rentalTotal = 0,
         status,
         missingStandards = [],
+        provider: providerInfo = null,
       } = res.data || {};
       const reservationStatus = status === "pending" ? "pending" : "confirmed";
       if (reservationStatus === "confirmed" && conflicts.length > 0) {
@@ -1057,6 +1098,7 @@ export default function AddToCartWizard({
         setConflicts(conflictNames);
         setError("Some equipment is already reserved on the selected date.");
         setLiveMessage("Equipment conflicts found for the selected date");
+        updateCalendarStatus("unavailable");
         setSubmitting(false);
         return;
       }
@@ -1074,6 +1116,31 @@ export default function AddToCartWizard({
             `Missing required equipment standards: ${missingStandards.join(", ")}`
           );
         }
+        if (providerInfo && typeof providerInfo === "object") {
+          const providerLevel = String((providerInfo as any).level ?? "").toLowerCase();
+          const rawLabel = (providerInfo as any).label;
+          const providerLabel =
+            typeof rawLabel === "string" && rawLabel.trim().length > 0
+              ? rawLabel.trim()
+              : null;
+          if (providerLevel === "franchise_team") {
+            const message =
+              providerLabel
+                ? `${providerLabel} will confirm their availability and kit for this date.`
+                : "Local franchise freelancers and crew will confirm availability for this date.";
+            if (!warnings.includes(message)) {
+              warnings.push(message);
+            }
+          } else if (providerLevel === "hq") {
+            const message =
+              providerLabel
+                ? `${providerLabel} will confirm availability and secure the required kit.`
+                : "HQ operations will confirm availability and secure the required kit.";
+            if (!warnings.includes(message)) {
+              warnings.push(message);
+            }
+          }
+        }
         if (warnings.length === 0) {
           warnings.push("Kit availability will be confirmed manually by the operations team.");
         }
@@ -1085,6 +1152,9 @@ export default function AddToCartWizard({
           window.alert(message);
         }
       }
+      updateCalendarStatus(
+        reservationStatus === "pending" ? "pending" : "available"
+      );
       const locationLabel = locationInput.trim();
       const postalCodeLabel =
         coverage.postalCode ||
@@ -1132,6 +1202,7 @@ export default function AddToCartWizard({
       setSubmitting(false);
       onClose();
     } catch (err) {
+      updateCalendarStatus("pending");
       console.error(err);
       setSubmitting(false);
       if (isFunctionsError(err) && err.code === "failed-precondition") {
@@ -1405,6 +1476,7 @@ export default function AddToCartWizard({
                   selected={date}
                   onSelect={handleDateSelect}
                   scope={availabilityScope}
+                  overrides={availabilityOverrides}
                 />
               ) : (
                 <p className="text-sm text-gray-500">

--- a/apps/web/components/AddToCartWizard.tsx
+++ b/apps/web/components/AddToCartWizard.tsx
@@ -8,6 +8,7 @@ import {
   resolveProductOnsiteDays,
   formatProductOnsiteDuration,
   getProductEventRangeLabel,
+  getProductEventMonthKeys,
 } from "@/lib/products";
 import { useCart } from "@/lib/cart";
 import { db, functions } from "@/lib/firebase";
@@ -469,6 +470,10 @@ export default function AddToCartWizard({
     () => getProductEventRangeLabel(product),
     [product]
   );
+  const eventMonths = useMemo(
+    () => getProductEventMonthKeys(product),
+    [product]
+  );
   const exhibitionSchedule = useMemo(() => {
     if (product.category !== "exhibition-videography") {
       return {
@@ -532,6 +537,39 @@ export default function AddToCartWizard({
     }
     return exhibitionOptions[0]?.key ?? null;
   }, [exhibitionOptions, product.category]);
+  const exhibitionDayLabels = useMemo(() => {
+    if (product.category !== "exhibition-videography") {
+      return {} as Record<string, string>;
+    }
+    return exhibitionOptions.reduce<Record<string, string>>((acc, option) => {
+      const key = normaliseDateKey(option.key);
+      if (!key) {
+        return acc;
+      }
+      const prefix = option.label.includes(":")
+        ? option.label.split(":")[0]?.trim()
+        : option.label.trim();
+      acc[key] = prefix && prefix.length > 0 ? prefix : option.label;
+      return acc;
+    }, {});
+  }, [exhibitionOptions, product.category]);
+  const exhibitionHighlightDates = useMemo(() => {
+    if (!exhibitionSetupOption) {
+      return [] as string[];
+    }
+    return [exhibitionSetupOption.key];
+  }, [exhibitionSetupOption]);
+  const exhibitionCalendarMonth = useMemo(() => {
+    if (product.category !== "exhibition-videography") {
+      return null;
+    }
+    const first = exhibitionOptions[0]?.key;
+    if (!first) {
+      return null;
+    }
+    const normalised = normaliseDateKey(first);
+    return normalised ? normalised.slice(0, 7) : null;
+  }, [exhibitionOptions, product.category]);
   const [selected, setSelected] = useState<Record<string, string[]>>({});
   const [step, setStep] = useState(0);
   const [date, setDate] = useState<string | null>(() =>
@@ -560,6 +598,30 @@ export default function AddToCartWizard({
       setIncludeSetupDay(false);
     }
   }, [exhibitionSetupOption]);
+  const exhibitionAllowedDates = useMemo(() => {
+    if (product.category !== "exhibition-videography") {
+      return [] as string[];
+    }
+    return exhibitionOptions.map((option) => option.key);
+  }, [exhibitionOptions, product.category]);
+  const calendarInitialMonth = useMemo(() => {
+    const selectedMonth = normaliseDateKey(date)?.slice(0, 7) ?? null;
+    if (selectedMonth) {
+      return selectedMonth;
+    }
+    if (
+      product.category === "exhibition-videography" &&
+      exhibitionCalendarMonth
+    ) {
+      return exhibitionCalendarMonth;
+    }
+    return eventMonths[0] ?? null;
+  }, [
+    date,
+    eventMonths,
+    exhibitionCalendarMonth,
+    product.category,
+  ]);
   const bookingSpan = useMemo(() => {
     if (
       product.category === "exhibition-videography" &&
@@ -1464,7 +1526,7 @@ export default function AddToCartWizard({
       setSubmitting(false);
       onClose();
     } catch (err) {
-      updateCalendarStatus("pending");
+      updateCalendarStatus("available");
       console.error(err);
       setSubmitting(false);
       if (isFunctionsError(err) && err.code === "failed-precondition") {
@@ -1731,52 +1793,39 @@ export default function AddToCartWizard({
                   </div>
                 )}
               </div>
-            ) : product.category !== "exhibition-videography" ? (
-              coverageStatus === "success" && coverage ? (
+            ) : product.category === "exhibition-videography" && exhibitionOptions.length === 0 ? (
+              <p className="text-sm text-gray-500">Show dates coming soon.</p>
+            ) : coverageStatus === "success" && coverage ? (
+              <div className="space-y-3">
+                {product.category === "exhibition-videography" && eventRangeLabel && (
+                  <p className="text-sm text-gray-600">Show runs {eventRangeLabel}.</p>
+                )}
                 <ProductDatePicker
                   productId={product.id}
                   selected={date}
                   onSelect={handleDateSelect}
                   scope={availabilityScope}
                   overrides={availabilityOverrides}
+                  allowedDates={
+                    product.category === "exhibition-videography"
+                      ? exhibitionAllowedDates
+                      : undefined
+                  }
+                  allowedDateLabels={
+                    product.category === "exhibition-videography" &&
+                    Object.keys(exhibitionDayLabels).length > 0
+                      ? exhibitionDayLabels
+                      : undefined
+                  }
+                  highlightedDates={
+                    product.category === "exhibition-videography" &&
+                    exhibitionHighlightDates.length > 0
+                      ? exhibitionHighlightDates
+                      : undefined
+                  }
+                  initialMonth={calendarInitialMonth}
                 />
-              ) : (
-                <p className="text-sm text-gray-500">
-                  Confirm the filming address and postcode first to check availability.
-                </p>
-              )
-            ) : exhibitionOptions.length > 0 ? (
-              <div className="space-y-3">
-                {eventRangeLabel && (
-                  <p className="text-sm text-gray-600">Show runs {eventRangeLabel}.</p>
-                )}
-                <div
-                  className="grid gap-2"
-                  role="radiogroup"
-                  aria-label="Choose exhibition coverage day"
-                >
-                  {exhibitionOptions.map((option) => {
-                    const checked = date === option.key;
-                    return (
-                      <label
-                        key={option.key}
-                        className={`flex items-start gap-3 rounded-md border px-3 py-2 text-sm transition focus-within:border-orange-400 focus-within:ring-1 focus-within:ring-orange ${
-                          checked ? "border-orange-400 bg-orange-50" : "border-gray-200 bg-white"
-                        }`}
-                      >
-                        <input
-                          type="radio"
-                          name="exhibition-date"
-                          className="mt-1"
-                          checked={checked}
-                          onChange={() => handleDateSelect(option.key)}
-                        />
-                        <p className="text-sm font-semibold">{option.label}</p>
-                      </label>
-                    );
-                  })}
-                </div>
-                {exhibitionSetupOption && (
+                {product.category === "exhibition-videography" && exhibitionSetupOption && (
                   <label
                     className={`flex items-start gap-3 rounded-md border px-3 py-2 text-sm transition focus-within:border-orange-400 focus-within:ring-1 focus-within:ring-orange ${
                       includeSetupDay
@@ -1796,7 +1845,10 @@ export default function AddToCartWizard({
                           if (!next) {
                             announceSelection(date, onsiteBlockingDays);
                           } else {
-                            announceSelection(exhibitionSetupOption.key, onsiteBlockingDays + 1);
+                            announceSelection(
+                              exhibitionSetupOption.key,
+                              onsiteBlockingDays + 1
+                            );
                           }
                           return next;
                         });
@@ -1806,14 +1858,16 @@ export default function AddToCartWizard({
                       <p className="text-sm font-semibold">Include setup day coverage</p>
                       <p className="text-xs text-gray-500">
                         We’ll arrive on {exhibitionSetupOption.label} to capture stand build and
-                        pre-show content.
+                        pre-show content. The setup day is outlined on the calendar above.
                       </p>
                     </div>
                   </label>
                 )}
               </div>
             ) : (
-              <p className="text-sm text-gray-500">Show dates coming soon.</p>
+              <p className="text-sm text-gray-500">
+                Confirm the filming address and postcode first to check availability.
+              </p>
             )}
             {(onsiteSummary || (selectedDateRange && bookingSpan > 1)) && (
               <div className="space-y-1 text-xs text-gray-600">

--- a/apps/web/components/AddToCartWizard.tsx
+++ b/apps/web/components/AddToCartWizard.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Product, ProductModifierSelection } from "@/lib/products";
+import {
+  Product,
+  ProductModifierSelection,
+  getProductEventWindow,
+  resolveProductOnsiteDays,
+  formatProductOnsiteDuration,
+  getProductEventRangeLabel,
+} from "@/lib/products";
 import { useCart } from "@/lib/cart";
 import { db, functions } from "@/lib/firebase";
 import { collection, doc, getDoc, getDocs } from "firebase/firestore";
@@ -332,6 +339,48 @@ const slotDateFormatter = new Intl.DateTimeFormat("en-GB", {
   timeStyle: "short",
 });
 
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const toDateKeyFromDate = (date: Date): string => {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const parseDateKey = (value: string): Date | null => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const [year, month, day] = value.split("-").map((part) => Number.parseInt(part, 10));
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null;
+  }
+  return new Date(Date.UTC(year, month - 1, day));
+};
+
+const expandDateKeyRange = (key: string, span: number): string[] => {
+  const start = parseDateKey(key);
+  if (!start) {
+    return [];
+  }
+  const days = Math.max(1, Math.floor(span));
+  const keys: string[] = [];
+  for (let offset = 0; offset < days; offset += 1) {
+    const cursor = new Date(start.getTime() + offset * DAY_IN_MS);
+    keys.push(toDateKeyFromDate(cursor));
+  }
+  return keys;
+};
+
+const formatDateForSpeech = (date: Date): string =>
+  date.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
 const formatCampaignSlotWindow = (slot: CampaignSlotRecord): string => {
   const parse = (value: string | null): Date | null => {
     if (!value) {
@@ -403,11 +452,151 @@ export default function AddToCartWizard({
   }
   const { items, add } = useCart();
   const [groups, setGroups] = useState<ModifierGroup[]>([]);
+  const eventWindow = useMemo(() => getProductEventWindow(product), [product]);
+  const onsiteDaysConfigured = useMemo(
+    () => resolveProductOnsiteDays(product) ?? 1,
+    [product]
+  );
+  const onsiteBlockingDays = useMemo(
+    () => Math.max(1, Math.ceil(onsiteDaysConfigured)),
+    [onsiteDaysConfigured]
+  );
+  const onsiteSummary = useMemo(
+    () => formatProductOnsiteDuration(product),
+    [product]
+  );
+  const eventRangeLabel = useMemo(
+    () => getProductEventRangeLabel(product),
+    [product]
+  );
+  const exhibitionSchedule = useMemo(() => {
+    if (product.category !== "exhibition-videography") {
+      return {
+        showOptions: [] as Array<{ key: string; label: string }>,
+        setupOption: null as { key: string; label: string; helper?: string } | null,
+      };
+    }
+    const { start, end, setup } = eventWindow;
+    if (!start) {
+      return {
+        showOptions: [] as Array<{ key: string; label: string }>,
+        setupOption: null as { key: string; label: string; helper?: string } | null,
+      };
+    }
+    const resolvedEnd = end ?? start;
+    const showOptions: Array<{ key: string; label: string }> = [];
+    let setupOption: { key: string; label: string; helper?: string } | null = null;
+    const fallbackSetup = new Date(start.getTime() - DAY_IN_MS);
+    const setupCandidate = setup ?? fallbackSetup;
+    if (setupCandidate && !Number.isNaN(setupCandidate.getTime())) {
+      const key = toDateKeyFromDate(setupCandidate);
+      setupOption = {
+        key,
+        label: setupCandidate.toLocaleDateString(undefined, {
+          weekday: "long",
+          month: "long",
+          day: "numeric",
+        }),
+        helper: "Arrive a day early to capture stand build and pre-show content.",
+      };
+    }
+    const startCursor = parseDateKey(toDateKeyFromDate(start));
+    const endCursor = parseDateKey(toDateKeyFromDate(resolvedEnd));
+    if (!startCursor || !endCursor) {
+      return { showOptions, setupOption };
+    }
+    let dayIndex = 0;
+    for (
+      let cursor = startCursor;
+      cursor.getTime() <= endCursor.getTime();
+      cursor = new Date(cursor.getTime() + DAY_IN_MS)
+    ) {
+      dayIndex += 1;
+      const key = toDateKeyFromDate(cursor);
+      showOptions.push({
+        key,
+        label: `Day ${dayIndex}: ${cursor.toLocaleDateString(undefined, {
+          weekday: "long",
+          month: "long",
+          day: "numeric",
+        })}`,
+      });
+    }
+    return { showOptions, setupOption };
+  }, [eventWindow, product.category]);
+  const exhibitionOptions = exhibitionSchedule.showOptions;
+  const exhibitionSetupOption = exhibitionSchedule.setupOption;
+  const defaultExhibitionDate = useMemo(() => {
+    if (product.category !== "exhibition-videography") {
+      return null;
+    }
+    return exhibitionOptions[0]?.key ?? null;
+  }, [exhibitionOptions, product.category]);
   const [selected, setSelected] = useState<Record<string, string[]>>({});
   const [step, setStep] = useState(0);
-  const [date, setDate] = useState<string | null>(
-    product.category === "exhibition-videography" ? product.eventDate ?? null : null
+  const [date, setDate] = useState<string | null>(() =>
+    product.category === "exhibition-videography" ? defaultExhibitionDate : null
   );
+  const [includeSetupDay, setIncludeSetupDay] = useState(false);
+  useEffect(() => {
+    if (product.category !== "exhibition-videography") {
+      return;
+    }
+    if (exhibitionOptions.length === 0) {
+      setDate(null);
+      return;
+    }
+    setDate((current) => {
+      if (!current) {
+        return defaultExhibitionDate;
+      }
+      return exhibitionOptions.some((option) => option.key === current)
+        ? current
+        : defaultExhibitionDate;
+    });
+  }, [product.category, exhibitionOptions, defaultExhibitionDate]);
+  useEffect(() => {
+    if (!exhibitionSetupOption) {
+      setIncludeSetupDay(false);
+    }
+  }, [exhibitionSetupOption]);
+  const bookingSpan = useMemo(() => {
+    if (
+      product.category === "exhibition-videography" &&
+      includeSetupDay &&
+      exhibitionSetupOption
+    ) {
+      return onsiteBlockingDays + 1;
+    }
+    return onsiteBlockingDays;
+  }, [
+    exhibitionSetupOption,
+    includeSetupDay,
+    onsiteBlockingDays,
+    product.category,
+  ]);
+  const reservationStartKey = useMemo(() => {
+    if (product.category !== "exhibition-videography") {
+      return date;
+    }
+    if (includeSetupDay && exhibitionSetupOption) {
+      return exhibitionSetupOption.key;
+    }
+    return date;
+  }, [date, exhibitionSetupOption, includeSetupDay, product.category]);
+  const selectedDateRange = useMemo(() => {
+    if (!reservationStartKey) {
+      return null;
+    }
+    const base =
+      parseDateKey(reservationStartKey) ??
+      new Date(`${reservationStartKey}T00:00:00`);
+    if (Number.isNaN(base.getTime())) {
+      return null;
+    }
+    const end = new Date(base.getTime() + (bookingSpan - 1) * DAY_IN_MS);
+    return { start: base, end };
+  }, [bookingSpan, reservationStartKey]);
   const [error, setError] = useState<string | null>(null);
   const [conflicts, setConflicts] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
@@ -487,18 +676,51 @@ export default function AddToCartWizard({
     }
     return { type: "hq", organisationId: null } satisfies ProductAvailabilityScope;
   }, [coverage, coverageStatus]);
+  const announceSelection = useCallback(
+    (startKey: string | null, span: number) => {
+      if (!startKey) {
+        return;
+      }
+      const base = parseDateKey(startKey) ?? new Date(`${startKey}T00:00:00`);
+      if (Number.isNaN(base.getTime())) {
+        setLiveMessage(`Selected ${startKey} for production`);
+        return;
+      }
+      if (span > 1) {
+        const end = new Date(base.getTime() + (span - 1) * DAY_IN_MS);
+        setLiveMessage(
+          `Selected ${formatDateForSpeech(base)} – crew reserved until ${formatDateForSpeech(end)}.`
+        );
+      } else {
+        setLiveMessage(`Selected ${formatDateForSpeech(base)} for production`);
+      }
+    },
+    []
+  );
   const handleDateSelect = (value: string) => {
     setDate(value);
     setConflicts([]);
     setError(null);
-    const spokenDate = new Date(`${value}T00:00:00`).toLocaleDateString(undefined, {
-      weekday: "long",
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    });
-    setLiveMessage(`Selected ${spokenDate} for production`);
+    const startKey =
+      product.category === "exhibition-videography" &&
+      includeSetupDay &&
+      exhibitionSetupOption
+        ? exhibitionSetupOption.key
+        : value;
+    const span =
+      product.category === "exhibition-videography" &&
+      includeSetupDay &&
+      exhibitionSetupOption
+        ? onsiteBlockingDays + 1
+        : onsiteBlockingDays;
+    announceSelection(startKey, span);
   };
+  useEffect(() => {
+    if (!date) {
+      return;
+    }
+    announceSelection(reservationStartKey, bookingSpan);
+  }, [announceSelection, bookingSpan, date, reservationStartKey]);
 
   useEffect(() => {
     async function load() {
@@ -1024,7 +1246,12 @@ export default function AddToCartWizard({
       setLiveMessage("Filming location required before booking");
       return;
     }
-    let reservationDate = date;
+    const showDateKey = normaliseDateKey(date);
+    let startDateKey =
+      product.category === "exhibition-videography"
+        ? normaliseDateKey(reservationStartKey)
+        : showDateKey;
+    let requestDateIso: string | null = null;
     if (isCampaignProduct) {
       if (!slotSelection) {
         setError("Select an available slot to continue.");
@@ -1041,38 +1268,56 @@ export default function AddToCartWizard({
         setLiveMessage("Selected slot unavailable");
         return;
       }
-      reservationDate =
+      requestDateIso =
         normaliseSlotDate(slotSelection.startAt) ??
         normaliseSlotDate(slotSelection.endAt) ??
-        reservationDate;
-      if (!reservationDate) {
-        reservationDate = new Date().toISOString();
+        null;
+      startDateKey =
+        normaliseDateKey(slotSelection.startAt) ??
+        normaliseDateKey(slotSelection.endAt) ??
+        startDateKey;
+      if (!requestDateIso) {
+        requestDateIso = new Date().toISOString();
       }
-    } else if (!date) {
+      if (!startDateKey) {
+        startDateKey = showDateKey;
+      }
+    } else if (!date || !startDateKey) {
       setError("Select a production date to continue.");
       setLiveMessage("Production date required before adding to cart");
       return;
+    } else {
+      requestDateIso = `${startDateKey}T00:00:00.000Z`;
     }
-    const calendarKey =
-      normaliseDateKey(reservationDate) ?? normaliseDateKey(date) ?? null;
+    const affectedCalendarKeys =
+      startDateKey ? expandDateKeyRange(startDateKey, bookingSpan) : [];
     const updateCalendarStatus = (statusValue: ProductAvailabilityStatus) => {
-      if (!calendarKey) {
+      if (affectedCalendarKeys.length === 0) {
         return;
       }
       setAvailabilityOverrides((prev) => {
-        if (prev[calendarKey] === statusValue) {
-          return prev;
-        }
-        return { ...prev, [calendarKey]: statusValue };
+        let changed = false;
+        const next = { ...prev };
+        affectedCalendarKeys.forEach((key) => {
+          if (next[key] !== statusValue) {
+            next[key] = statusValue;
+            changed = true;
+          }
+        });
+        return changed ? next : prev;
       });
     };
+    if (!requestDateIso) {
+      requestDateIso = new Date().toISOString();
+    }
     setSubmitting(true);
     setLiveMessage("Checking equipment availability");
     try {
       const reserve = httpsCallable(functions, "reserveKit");
       const res: any = await reserve({
         productId: product.id,
-        date: reservationDate,
+        date: requestDateIso,
+        spanOverride: bookingSpan,
         coverage: coverage
           ? {
               type: coverage.type,
@@ -1161,17 +1406,34 @@ export default function AddToCartWizard({
         (postcodeInput.trim().length > 0
           ? postcodeInput.trim().toUpperCase()
           : null);
+      const exhibitionSelection =
+        product.category === "exhibition-videography"
+          ? {
+              showDate: showDateKey,
+              setupIncluded: includeSetupDay && Boolean(exhibitionSetupOption),
+              setupDate:
+                includeSetupDay && exhibitionSetupOption
+                  ? exhibitionSetupOption.key
+                  : null,
+            }
+          : null;
       add({
         id: product.id,
         name: product.name,
         price,
-        date: reservationDate || date || new Date().toISOString(),
+        date:
+          showDateKey ||
+          startDateKey ||
+          requestDateIso ||
+          date ||
+          new Date().toISOString(),
         variation: variationId,
         modifiers: selections,
         kitItems,
         rentalTotal,
         kitStatus: reservationStatus,
         kitWarnings: warnings,
+        exhibition: exhibitionSelection,
         location: locationLabel.length > 0 ? locationLabel : null,
         postalCode: postalCodeLabel,
         coverage: {
@@ -1483,12 +1745,92 @@ export default function AddToCartWizard({
                   Confirm the filming address and postcode first to check availability.
                 </p>
               )
-            ) : product.eventDate ? (
-              <p className="text-sm">
-                {new Date(product.eventDate).toLocaleDateString()}
-              </p>
+            ) : exhibitionOptions.length > 0 ? (
+              <div className="space-y-3">
+                {eventRangeLabel && (
+                  <p className="text-sm text-gray-600">Show runs {eventRangeLabel}.</p>
+                )}
+                <div
+                  className="grid gap-2"
+                  role="radiogroup"
+                  aria-label="Choose exhibition coverage day"
+                >
+                  {exhibitionOptions.map((option) => {
+                    const checked = date === option.key;
+                    return (
+                      <label
+                        key={option.key}
+                        className={`flex items-start gap-3 rounded-md border px-3 py-2 text-sm transition focus-within:border-orange-400 focus-within:ring-1 focus-within:ring-orange ${
+                          checked ? "border-orange-400 bg-orange-50" : "border-gray-200 bg-white"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="exhibition-date"
+                          className="mt-1"
+                          checked={checked}
+                          onChange={() => handleDateSelect(option.key)}
+                        />
+                        <p className="text-sm font-semibold">{option.label}</p>
+                      </label>
+                    );
+                  })}
+                </div>
+                {exhibitionSetupOption && (
+                  <label
+                    className={`flex items-start gap-3 rounded-md border px-3 py-2 text-sm transition focus-within:border-orange-400 focus-within:ring-1 focus-within:ring-orange ${
+                      includeSetupDay
+                        ? "border-orange-400 bg-orange-50"
+                        : "border-gray-200 bg-white"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      className="mt-1"
+                      checked={includeSetupDay}
+                      onChange={() => {
+                        setConflicts([]);
+                        setError(null);
+                        setIncludeSetupDay((prev) => {
+                          const next = !prev;
+                          if (!next) {
+                            announceSelection(date, onsiteBlockingDays);
+                          } else {
+                            announceSelection(exhibitionSetupOption.key, onsiteBlockingDays + 1);
+                          }
+                          return next;
+                        });
+                      }}
+                    />
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold">Include setup day coverage</p>
+                      <p className="text-xs text-gray-500">
+                        We’ll arrive on {exhibitionSetupOption.label} to capture stand build and
+                        pre-show content.
+                      </p>
+                    </div>
+                  </label>
+                )}
+              </div>
             ) : (
-              <p className="text-sm">To be confirmed</p>
+              <p className="text-sm text-gray-500">Show dates coming soon.</p>
+            )}
+            {(onsiteSummary || (selectedDateRange && bookingSpan > 1)) && (
+              <div className="space-y-1 text-xs text-gray-600">
+                {onsiteSummary && <p>{onsiteSummary}</p>}
+                {selectedDateRange && bookingSpan > 1 && (
+                  <p>
+                    Crew reserved {" "}
+                    {selectedDateRange.start.toLocaleDateString()} – {" "}
+                    {selectedDateRange.end.toLocaleDateString()}
+                  </p>
+                )}
+                {product.category === "exhibition-videography" &&
+                  includeSetupDay &&
+                  exhibitionSetupOption && (
+                    <p>Setup day coverage included.</p>
+                  )}
+              </div>
             )}
           </div>
         )}

--- a/apps/web/components/CRMRecordForm.tsx
+++ b/apps/web/components/CRMRecordForm.tsx
@@ -126,6 +126,13 @@ export default function CRMRecordForm({ status, onSave, onClose, products = [] }
               value={form.phone || ''}
               onChange={handleChange}
             />
+            <textarea
+              name="linkedinBio"
+              placeholder="LinkedIn bio"
+              className="border p-2"
+              value={form.linkedinBio || ''}
+              onChange={handleChange}
+            />
           </div>
 
           <div className={tab === 'branding' ? 'grid gap-2' : 'hidden'}>
@@ -198,6 +205,13 @@ export default function CRMRecordForm({ status, onSave, onClose, products = [] }
           </div>
 
           <div className={tab === 'log' ? 'grid gap-2' : 'hidden'}>
+            <input
+              name="origin"
+              placeholder="Origin (e.g. BARK)"
+              className="border p-2"
+              value={form.origin || ''}
+              onChange={handleChange}
+            />
             <textarea
               name="notes"
               placeholder="Contact notes"

--- a/apps/web/components/CategoryProductFilters.tsx
+++ b/apps/web/components/CategoryProductFilters.tsx
@@ -11,6 +11,7 @@ import type { ReactElement } from "react";
 import ProductCard from "./ProductCard";
 import ProductListRow from "./ProductListRow";
 import type { Product } from "@/lib/products";
+import { getProductEventWindow } from "@/lib/products";
 
 type SortOption =
   | "default"
@@ -46,11 +47,9 @@ function getStartingPrice(product: Product): number | null {
 }
 
 function getComparableTimestamp(product: Product): number {
-  if (product.eventDate) {
-    const eventTime = Date.parse(product.eventDate);
-    if (!Number.isNaN(eventTime)) {
-      return eventTime;
-    }
+  const { start } = getProductEventWindow(product);
+  if (start) {
+    return start.getTime();
   }
   const createdAt = (product as any)?.createdAt;
   if (!createdAt) return 0;

--- a/apps/web/components/ExhibitionProductList.tsx
+++ b/apps/web/components/ExhibitionProductList.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import ProductCard from "./ProductCard";
-import { Product } from "@/lib/products";
+import { Product, getProductEventMonthKeys } from "@/lib/products";
 
 export default function ExhibitionProductList({ products }: { products: Product[] }) {
   const [search, setSearch] = useState("");
@@ -20,7 +20,7 @@ export default function ExhibitionProductList({ products }: { products: Product[
   const months = useMemo(() => {
     const set = new Set<string>();
     products.forEach((p) => {
-      if (p.eventDate) set.add(p.eventDate.slice(0, 7));
+      getProductEventMonthKeys(p).forEach((key) => set.add(key));
     });
     return Array.from(set).sort();
   }, [products]);
@@ -33,7 +33,7 @@ export default function ExhibitionProductList({ products }: { products: Product[
       if (venue && p.venue !== venue) {
         return false;
       }
-      if (month && (!p.eventDate || !p.eventDate.startsWith(month))) {
+      if (month && !getProductEventMonthKeys(p).includes(month)) {
         return false;
       }
       return true;

--- a/apps/web/components/InvoicePDF.tsx
+++ b/apps/web/components/InvoicePDF.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
+
+interface InvoiceItem {
+  description: string;
+  amount: number;
+  productId?: string | null;
+}
+
+interface InvoicePDFProps {
+  invoice: {
+    id: string;
+    organisationName: string;
+    clientName?: string;
+    clientEmail?: string;
+    dueDate?: string | null;
+    items: InvoiceItem[];
+    total: number;
+    paymentTerms?: string;
+    notes?: string;
+  };
+}
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 32,
+    fontSize: 12,
+    fontFamily: "Helvetica",
+    color: "#111827",
+  },
+  header: {
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 700,
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 12,
+    color: "#6B7280",
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: 700,
+    marginTop: 24,
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 6,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: "#E5E7EB",
+    marginVertical: 12,
+  },
+  total: {
+    fontSize: 14,
+    fontWeight: 700,
+  },
+  notes: {
+    marginTop: 12,
+    fontSize: 11,
+    color: "#4B5563",
+  },
+});
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP", maximumFractionDigits: 2 }).format(value);
+
+export default function InvoicePDF({ invoice }: InvoicePDFProps) {
+  const dueLabel = invoice.dueDate
+    ? new Date(invoice.dueDate).toLocaleDateString()
+    : "Due on receipt";
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Invoice {invoice.id}</Text>
+          <Text style={styles.subtitle}>{invoice.organisationName}</Text>
+          {invoice.clientName ? <Text style={styles.subtitle}>Client: {invoice.clientName}</Text> : null}
+          {invoice.clientEmail ? <Text style={styles.subtitle}>Email: {invoice.clientEmail}</Text> : null}
+        </View>
+
+        <View>
+          <Text style={styles.sectionTitle}>Line items</Text>
+          {invoice.items.map((item, index) => (
+            <View key={index} style={styles.row}>
+              <View>
+                <Text>{item.description || `Item ${index + 1}`}</Text>
+                {item.productId ? <Text style={styles.subtitle}>Ref: {item.productId}</Text> : null}
+              </View>
+              <Text>{formatCurrency(item.amount)}</Text>
+            </View>
+          ))}
+          <View style={styles.divider} />
+          <View style={styles.row}>
+            <Text style={styles.total}>Total</Text>
+            <Text style={styles.total}>{formatCurrency(invoice.total)}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text>Due date</Text>
+            <Text>{dueLabel}</Text>
+          </View>
+        </View>
+
+        {invoice.paymentTerms ? (
+          <View>
+            <Text style={styles.sectionTitle}>Payment terms</Text>
+            <Text>{invoice.paymentTerms}</Text>
+          </View>
+        ) : null}
+
+        {invoice.notes ? (
+          <View>
+            <Text style={styles.sectionTitle}>Notes</Text>
+            <Text style={styles.notes}>{invoice.notes}</Text>
+          </View>
+        ) : null}
+      </Page>
+    </Document>
+  );
+}

--- a/apps/web/components/ProductCard.tsx
+++ b/apps/web/components/ProductCard.tsx
@@ -3,7 +3,11 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { Product } from "@/lib/products";
+import {
+  Product,
+  getProductEventRangeLabel,
+  formatProductOnsiteDuration,
+} from "@/lib/products";
 import {
   FiCalendar,
   FiMapPin,
@@ -40,13 +44,23 @@ export default function ProductCard({ product }: { product: Product }) {
       }),
     [activePrice, product]
   );
+  const eventRangeLabel = useMemo(
+    () => getProductEventRangeLabel(product),
+    [product]
+  );
+  const onsiteSummary = useMemo(
+    () => formatProductOnsiteDuration(product),
+    [product]
+  );
   const priceHeadline = priceDetails?.headline ?? "Pricing on request";
   const basePrice = activeVariation?.price ?? product.price;
   const img =
     product.imageUrl || "https://placehold.co/600x400?text=No+Image";
   const { visibleDeliverables, remainingDeliverableCount } =
     getDeliverableSummary(product);
-  const showSummary = Boolean(product.deliveryTime || visibleDeliverables.length > 0);
+  const showSummary = Boolean(
+    product.deliveryTime || visibleDeliverables.length > 0 || onsiteSummary
+  );
   const variationSelectId = `product-${product.id}-variation`;
 
   const handleQuickAdd = () => {
@@ -90,6 +104,12 @@ export default function ProductCard({ product }: { product: Product }) {
                 {product.deliveryTime}
               </span>
             )}
+            {onsiteSummary && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 font-medium">
+                <FiCalendar className="h-3 w-3" aria-hidden />
+                {onsiteSummary}
+              </span>
+            )}
             {visibleDeliverables.map((deliverable) => {
               const Icon =
                 (deliverable.type && deliverableIconMap[deliverable.type]) || FiCheckCircle;
@@ -112,10 +132,10 @@ export default function ProductCard({ product }: { product: Product }) {
         )}
         {product.category === "exhibition-videography" && (
           <>
-            {product.eventDate && (
+            {eventRangeLabel && (
               <div className="flex items-center gap-1 text-xs text-gray-600">
                 <FiCalendar className="w-3 h-3" />
-                {new Date(product.eventDate).toLocaleDateString()}
+                {eventRangeLabel}
               </div>
             )}
             {product.venue && (

--- a/apps/web/components/ProductDatePicker.tsx
+++ b/apps/web/components/ProductDatePicker.tsx
@@ -19,6 +19,7 @@ interface Props {
   selected: string | null;
   onSelect: (date: string) => void;
   scope?: ProductAvailabilityScope | null;
+  overrides?: Record<string, ProductAvailabilityStatus> | null;
 }
 
 export default function ProductDatePicker({
@@ -26,6 +27,7 @@ export default function ProductDatePicker({
   selected,
   onSelect,
   scope,
+  overrides,
 }: Props) {
   const today = new Date();
   const [view, setView] = useState(
@@ -161,7 +163,7 @@ export default function ProductDatePicker({
             2,
             "0"
           )}`;
-          const status = availability[date] ?? "available";
+          const status = overrides?.[date] ?? availability[date] ?? "available";
           const isDisabled = status === "booked" || status === "unavailable";
           const formattedDate = new Date(`${date}T00:00:00`).toLocaleDateString(
             undefined,

--- a/apps/web/components/ProductDatePicker.tsx
+++ b/apps/web/components/ProductDatePicker.tsx
@@ -116,7 +116,7 @@ export default function ProductDatePicker({
       }
     }
     return toMonthKey(today);
-  }, [allowedInfo.earliest, allowedInfo.signature, initialMonth, selected, today]);
+  }, [allowedInfo.earliest, initialMonth, selected, today]);
 
   const [view, setView] = useState(() =>
     monthKeyToDate(derivedMonthKey) ??

--- a/apps/web/components/ProductDatePicker.tsx
+++ b/apps/web/components/ProductDatePicker.tsx
@@ -20,6 +20,10 @@ interface Props {
   onSelect: (date: string) => void;
   scope?: ProductAvailabilityScope | null;
   overrides?: Record<string, ProductAvailabilityStatus> | null;
+  allowedDates?: string[] | null;
+  allowedDateLabels?: Record<string, string> | null;
+  highlightedDates?: string[] | null;
+  initialMonth?: string | null;
 }
 
 export default function ProductDatePicker({
@@ -28,17 +32,108 @@ export default function ProductDatePicker({
   onSelect,
   scope,
   overrides,
+  allowedDates,
+  allowedDateLabels,
+  highlightedDates,
+  initialMonth,
 }: Props) {
-  const today = new Date();
-  const [view, setView] = useState(
-    new Date(today.getFullYear(), today.getMonth(), 1)
-  );
+  const today = useMemo(() => new Date(), []);
   const [entries, setEntries] = useState<
     Array<{ id: string; data: Record<string, unknown> }>
   >([]);
   const [availability, setAvailability] = useState<
     Record<string, ProductAvailabilityStatus>
   >({});
+
+  const allowedInfo = useMemo(() => {
+    const allowedSet = new Set<string>();
+    const labelMap = new Map<string, string>();
+    if (Array.isArray(allowedDates)) {
+      allowedDates.forEach((value) => {
+        const key = normaliseDateKey(value);
+        if (key) {
+          allowedSet.add(key);
+        }
+      });
+    }
+    if (allowedDateLabels && typeof allowedDateLabels === "object") {
+      Object.entries(allowedDateLabels).forEach(([rawKey, rawLabel]) => {
+        const key = normaliseDateKey(rawKey);
+        if (!key) {
+          return;
+        }
+        const label = String(rawLabel ?? "").trim();
+        if (label.length > 0) {
+          labelMap.set(key, label);
+        }
+        allowedSet.add(key);
+      });
+    }
+    let earliest: string | null = null;
+    allowedSet.forEach((key) => {
+      if (!earliest || key < earliest) {
+        earliest = key;
+      }
+    });
+    const signature = Array.from(allowedSet)
+      .sort()
+      .join("|");
+    return {
+      hasAllowed: allowedSet.size > 0,
+      allowedSet,
+      labelMap,
+      earliest,
+      signature,
+    } as const;
+  }, [allowedDates, allowedDateLabels]);
+
+  const highlightSet = useMemo(() => {
+    const set = new Set<string>();
+    if (Array.isArray(highlightedDates)) {
+      highlightedDates.forEach((value) => {
+        const key = normaliseDateKey(value);
+        if (key) {
+          set.add(key);
+        }
+      });
+    }
+    return set;
+  }, [highlightedDates]);
+
+  const derivedMonthKey = useMemo(() => {
+    const selectedMonth = monthKeyFromDateKey(selected);
+    if (selectedMonth) {
+      return selectedMonth;
+    }
+    const initialMonthKey = normaliseMonthKey(initialMonth);
+    if (initialMonthKey) {
+      return initialMonthKey;
+    }
+    if (allowedInfo.earliest) {
+      const allowedMonth = monthKeyFromDateKey(allowedInfo.earliest);
+      if (allowedMonth) {
+        return allowedMonth;
+      }
+    }
+    return toMonthKey(today);
+  }, [allowedInfo.earliest, allowedInfo.signature, initialMonth, selected, today]);
+
+  const [view, setView] = useState(() =>
+    monthKeyToDate(derivedMonthKey) ??
+    new Date(today.getFullYear(), today.getMonth(), 1)
+  );
+
+  useEffect(() => {
+    setView((current) => {
+      const next = monthKeyToDate(derivedMonthKey);
+      if (!next) {
+        return current;
+      }
+      const currentKey = toMonthKey(current);
+      const nextKey = toMonthKey(next);
+      return currentKey === nextKey ? current : next;
+    });
+  }, [derivedMonthKey]);
 
   useEffect(() => {
     let cancelled = false;
@@ -47,7 +142,10 @@ export default function ProductDatePicker({
         const snap = await getDocs(
           collection(db, "productAvailability", productId, "dates")
         );
-        const docs = snap.docs.map((doc) => ({ id: doc.id, data: doc.data() as Record<string, unknown> }));
+        const docs = snap.docs.map((doc) => ({
+          id: doc.id,
+          data: doc.data() as Record<string, unknown>,
+        }));
         if (!cancelled) {
           setEntries(docs);
         }
@@ -102,35 +200,54 @@ export default function ProductDatePicker({
     unavailable: "Unavailable",
   };
 
-  const cellClasses = (status: ProductAvailabilityStatus, date: string) => {
-    const isDisabled = status === "booked" || status === "unavailable";
+  const indicatorPalette: Record<ProductAvailabilityStatus, string> = {
+    available: "bg-green-500",
+    pending: "bg-amber-500",
+    booked: "bg-red-500",
+    unavailable: "bg-gray-400",
+  };
+
+  const cellClasses = (
+    status: ProductAvailabilityStatus,
+    date: string,
+    options: { isAllowed: boolean; isHighlighted: boolean; isSelected: boolean }
+  ) => {
+    const isDisabled =
+      status === "booked" || status === "unavailable" || !options.isAllowed;
     const base =
-      "flex flex-col items-center justify-center rounded-md border px-2 py-1 text-xs transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange";
+      "relative flex min-h-[4.5rem] flex-col items-center justify-center rounded-md border px-2 py-2 text-xs transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange";
     const palette: Record<ProductAvailabilityStatus, string> = {
       available: "border-green-500 text-green-700 bg-green-50 hover:bg-green-100",
       pending: "border-amber-500 text-amber-700 bg-amber-50 hover:bg-amber-100",
       booked: "border-red-400 text-red-600 bg-red-50",
       unavailable: "border-gray-300 text-gray-500 bg-gray-100",
     };
+    const allowedClass = options.isAllowed ? palette[status] : palette.unavailable;
     const disabled = isDisabled ? " cursor-not-allowed opacity-70" : "";
-    const isSelected = selected === date ? " ring-2 ring-orange-500" : "";
-    return `${base} ${palette[status]}${disabled}${isSelected}`;
+    const highlight = options.isHighlighted ? " outline outline-1 outline-orange-300" : "";
+    const selectedClass = options.isSelected ? " ring-2 ring-orange-500" : "";
+    return `${base} ${allowedClass}${disabled}${highlight}${selectedClass}`;
   };
 
   const handleSelect = (date: string, status: ProductAvailabilityStatus) => {
+    const isAllowed = !allowedInfo.hasAllowed || allowedInfo.allowedSet.has(date);
+    if (!isAllowed) {
+      return;
+    }
     if (status === "available" || status === "pending") {
       onSelect(date);
     }
   };
 
   return (
-    <div className="max-w-xs text-xs" role="group" aria-label="Select a production date">
-      <div className="flex items-center justify-between mb-1">
+    <div className="max-w-sm text-xs" role="group" aria-label="Select a production date">
+      <div className="mb-1 flex items-center justify-between">
         <button
           className="btn btn-xs"
           onClick={() =>
             setView(new Date(view.getFullYear(), view.getMonth() - 1, 1))
           }
+          aria-label="Previous month"
         >
           ‹
         </button>
@@ -142,6 +259,7 @@ export default function ProductDatePicker({
           onClick={() =>
             setView(new Date(view.getFullYear(), view.getMonth() + 1, 1))
           }
+          aria-label="Next month"
         >
           ›
         </button>
@@ -156,33 +274,56 @@ export default function ProductDatePicker({
           </div>
         ))}
       </div>
-      <div className="grid grid-cols-7 gap-1 mt-1" role="presentation">
+      <div className="mt-1 grid grid-cols-7 gap-1" role="presentation">
         {days.map((d, i) => {
           if (!d) return <div key={i} />;
           const date = `${y}-${String(m + 1).padStart(2, "0")}-${String(d).padStart(
             2,
             "0"
           )}`;
-          const status = overrides?.[date] ?? availability[date] ?? "available";
-          const isDisabled = status === "booked" || status === "unavailable";
+          const isAllowed =
+            !allowedInfo.hasAllowed || allowedInfo.allowedSet.has(date);
+          const statusSource = overrides?.[date] ?? availability[date];
+          let status: ProductAvailabilityStatus = statusSource ?? "available";
+          let statusLabel = statusText[status];
+          if (!isAllowed) {
+            status = "unavailable";
+            statusLabel = "Not in schedule";
+          }
+          const isDisabled =
+            status === "booked" || status === "unavailable" || !isAllowed;
           const formattedDate = new Date(`${date}T00:00:00`).toLocaleDateString(
             undefined,
             { weekday: "long", month: "long", day: "numeric", year: "numeric" }
           );
+          const helperLabel = allowedInfo.labelMap.get(date) ?? null;
           return (
             <button
               key={date}
               type="button"
-              className={cellClasses(status, date)}
+              className={cellClasses(status, date, {
+                isAllowed,
+                isHighlighted: highlightSet.has(date),
+                isSelected: selected === date,
+              })}
               onClick={() => handleSelect(date, status)}
               aria-disabled={isDisabled}
               disabled={isDisabled}
               aria-pressed={selected === date ? true : undefined}
-              aria-label={`${formattedDate} – ${statusText[status]}`}
+              aria-label={`${formattedDate} – ${statusLabel}`}
             >
+              <span
+                aria-hidden
+                className={`absolute left-1 top-1 h-2 w-2 rounded-full ${indicatorPalette[status]}`}
+              />
               <span className="text-sm font-medium">{d}</span>
+              {helperLabel ? (
+                <span className="mt-0.5 text-[0.55rem] font-semibold text-gray-700">
+                  {helperLabel}
+                </span>
+              ) : null}
               <span className="mt-0.5 text-[0.6rem] font-semibold">
-                {statusText[status]}
+                {statusLabel}
               </span>
             </button>
           );
@@ -326,4 +467,63 @@ const evaluateScopeMatch = (
     return { match: true, priority: 5 };
   }
   return { match: appliesGlobally, priority: appliesGlobally ? 0 : -1 };
+};
+
+const normaliseDateKey = (value: string | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  const year = parsed.getFullYear();
+  const month = String(parsed.getMonth() + 1).padStart(2, "0");
+  const day = String(parsed.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const monthKeyFromDateKey = (value: string | null | undefined): string | null => {
+  const key = normaliseDateKey(value);
+  if (!key) {
+    return null;
+  }
+  return key.slice(0, 7);
+};
+
+const normaliseMonthKey = (value: string | null | undefined): string | null => {
+  if (!value || typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!/^\d{4}-\d{2}$/.test(trimmed)) {
+    return null;
+  }
+  const [yearStr, monthStr] = trimmed.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) {
+    return null;
+  }
+  if (month < 1 || month > 12) {
+    return null;
+  }
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}`;
+};
+
+const toMonthKey = (date: Date): string => {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+};
+
+const monthKeyToDate = (value: string | null): Date | null => {
+  if (!value || typeof value !== "string") {
+    return null;
+  }
+  const [yearStr, monthStr] = value.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) {
+    return null;
+  }
+  return new Date(year, month - 1, 1);
 };

--- a/apps/web/components/ProductDetail.tsx
+++ b/apps/web/components/ProductDetail.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Product, DeliverableType } from "@/lib/products";
+import {
+  Product,
+  DeliverableType,
+  getProductEventRangeLabel,
+  formatProductOnsiteDuration,
+} from "@/lib/products";
 import type { Venue } from "@/lib/venues";
 import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
@@ -195,6 +200,14 @@ export default function ProductDetail({
             : undefined,
       }),
     [product, basePrice]
+  );
+  const eventRangeLabel = useMemo(
+    () => getProductEventRangeLabel(product),
+    [product]
+  );
+  const onsiteSummary = useMemo(
+    () => formatProductOnsiteDuration(product),
+    [product]
   );
 
   const exampleVideos = useMemo<NormalizedVideo[]>(() => {
@@ -540,13 +553,14 @@ export default function ProductDetail({
               rangeNote={listingPriceDetails?.rangeNote}
             />
           </div>
-          {product.category === "exhibition-videography" && product.eventDate && (
-            <p className="text-sm text-gray-700">
-              Event Date: {new Date(product.eventDate).toLocaleDateString()}
-            </p>
+          {product.category === "exhibition-videography" && eventRangeLabel && (
+            <p className="text-sm text-gray-700">Event dates: {eventRangeLabel}</p>
           )}
           {product.category === "exhibition-videography" && venueName && (
             <p className="text-sm text-gray-700">Venue: {venueName}</p>
+          )}
+          {onsiteSummary && (
+            <p className="text-sm text-gray-700">On-site duration: {onsiteSummary}</p>
           )}
           {product.variations && product.variations.length > 0 && (
             <div className="grid gap-2">

--- a/apps/web/components/ProductDetail.tsx
+++ b/apps/web/components/ProductDetail.tsx
@@ -706,39 +706,6 @@ export default function ProductDetail({
         </section>
       )}
 
-      {exampleVideos.length > 0 && (
-        <section>
-          <h2 className="text-xl font-semibold mb-2">Example Videos</h2>
-          <div className="grid gap-6 md:grid-cols-2">
-            {exampleVideos.map((video, index) => {
-              const label = video.title || `Example video ${index + 1}`;
-              return (
-                <div
-                  key={`${video.url}-${index}`}
-                  className="space-y-3 rounded-lg border bg-white p-3 shadow-sm"
-                >
-                  <div className="relative aspect-video w-full overflow-hidden rounded-md bg-black">
-                    <VideoPlayer video={video} label={label} />
-                  </div>
-                  <div className="space-y-1">
-                    <p className="font-medium text-gray-900">{label}</p>
-                    <a
-                      href={video.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-sm font-medium text-orange hover:text-orange/80"
-                    >
-                      <FiExternalLink className="h-4 w-4" aria-hidden />
-                      Watch in new tab
-                    </a>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-      )}
-
       <ProductModifierSummary product={product} />
 
       <section className="text-center py-8">

--- a/apps/web/components/ProductListRow.tsx
+++ b/apps/web/components/ProductListRow.tsx
@@ -4,6 +4,10 @@ import Image from "next/image";
 import Link from "next/link";
 import type { Product } from "@/lib/products";
 import {
+  getProductEventRangeLabel,
+  formatProductOnsiteDuration,
+} from "@/lib/products";
+import {
   FiCalendar,
   FiClock,
   FiMapPin,
@@ -23,8 +27,11 @@ export default function ProductListRow({ product }: { product: Product }) {
   const priceHeadline = priceDetails?.headline ?? "Pricing on request";
   const { visibleDeliverables, remainingDeliverableCount } =
     getDeliverableSummary(product);
-  const showSummary = Boolean(product.deliveryTime || visibleDeliverables.length > 0);
-  const eventDate = product.eventDate ? new Date(product.eventDate) : null;
+  const onsiteSummary = formatProductOnsiteDuration(product);
+  const showSummary = Boolean(
+    product.deliveryTime || visibleDeliverables.length > 0 || onsiteSummary
+  );
+  const eventLabel = getProductEventRangeLabel(product);
 
   return (
     <article className="card p-4 text-sm shadow-sm">
@@ -53,6 +60,12 @@ export default function ProductListRow({ product }: { product: Product }) {
                   {product.deliveryTime}
                 </span>
               )}
+              {onsiteSummary && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 font-medium">
+                  <FiCalendar className="h-3 w-3" aria-hidden />
+                  {onsiteSummary}
+                </span>
+              )}
               {visibleDeliverables.map((deliverable) => {
                 const Icon =
                   (deliverable.type && deliverableIconMap[deliverable.type]) || FiCheckCircle;
@@ -73,12 +86,12 @@ export default function ProductListRow({ product }: { product: Product }) {
               )}
             </div>
           )}
-          {(eventDate || product.venue) && (
+          {(eventLabel || product.venue) && (
             <div className="flex flex-wrap items-center gap-4 text-xs text-gray-600">
-              {eventDate && (
+              {eventLabel && (
                 <span className="inline-flex items-center gap-1">
                   <FiCalendar className="h-3 w-3" aria-hidden />
-                  {eventDate.toLocaleDateString()}
+                  {eventLabel}
                 </span>
               )}
               {product.venue && (

--- a/apps/web/lib/cart.tsx
+++ b/apps/web/lib/cart.tsx
@@ -32,6 +32,11 @@ export interface CartItem {
   modifiers?: ProductModifierSelection[];
   location?: string | null;
   postalCode?: string | null;
+  exhibition?: {
+    showDate?: string | null;
+    setupDate?: string | null;
+    setupIncluded?: boolean;
+  } | null;
   coverage?: {
     type: "hq" | "franchise";
     franchiseId?: string | null;
@@ -61,6 +66,11 @@ interface ProductInput {
   modifiers?: ProductModifierSelection[];
   location?: string | null;
   postalCode?: string | null;
+  exhibition?: {
+    showDate?: string | null;
+    setupDate?: string | null;
+    setupIncluded?: boolean;
+  } | null;
   coverage?: {
     type: "hq" | "franchise";
     franchiseId?: string | null;
@@ -172,6 +182,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
             JSON.stringify(product.modifiers || []) &&
           (i.location || "") === (product.location || "") &&
           (i.postalCode || "") === (product.postalCode || "") &&
+          JSON.stringify(i.exhibition || null) ===
+            JSON.stringify(product.exhibition || null) &&
           JSON.stringify(i.coverage || null) ===
             JSON.stringify(product.coverage || null) &&
           JSON.stringify(i.campaignBooking || null) ===

--- a/apps/web/lib/cart.tsx
+++ b/apps/web/lib/cart.tsx
@@ -22,6 +22,16 @@ export interface CartCampaignBooking {
   priceAdjustment?: number;
 }
 
+export interface CartTimeSlot {
+  start: string;
+  end: string;
+  label?: string | null;
+  totalMinutes?: number | null;
+  setupMinutes?: number | null;
+  shootMinutes?: number | null;
+  breakdownMinutes?: number | null;
+}
+
 export interface CartItem {
   id: string;
   name: string;
@@ -37,6 +47,7 @@ export interface CartItem {
     setupDate?: string | null;
     setupIncluded?: boolean;
   } | null;
+  timeSlot?: CartTimeSlot | null;
   coverage?: {
     type: "hq" | "franchise";
     franchiseId?: string | null;
@@ -71,6 +82,7 @@ interface ProductInput {
     setupDate?: string | null;
     setupIncluded?: boolean;
   } | null;
+  timeSlot?: CartTimeSlot | null;
   coverage?: {
     type: "hq" | "franchise";
     franchiseId?: string | null;
@@ -184,6 +196,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
           (i.postalCode || "") === (product.postalCode || "") &&
           JSON.stringify(i.exhibition || null) ===
             JSON.stringify(product.exhibition || null) &&
+          JSON.stringify(i.timeSlot || null) ===
+            JSON.stringify(product.timeSlot || null) &&
           JSON.stringify(i.coverage || null) ===
             JSON.stringify(product.coverage || null) &&
           JSON.stringify(i.campaignBooking || null) ===

--- a/apps/web/lib/products.ts
+++ b/apps/web/lib/products.ts
@@ -277,9 +277,28 @@ export interface Product {
   defaultKitCost?: number;
   /** Number of days the crew is expected to be on-site. */
   onsiteDays?: number | null;
+  /** Minutes spent setting up on site before filming begins. */
+  onsiteSetupMinutes?: number | null;
+  /** Minutes allocated to the primary filming window. */
+  onsiteShootMinutes?: number | null;
+  /** Minutes required to wrap down and break down kit on site. */
+  onsiteBreakdownMinutes?: number | null;
+  /** Earliest customer bookable arrival time in HH:mm (24h). */
+  onsiteTimeWindowStart?: string | null;
+  /** Latest customer bookable finish time in HH:mm (24h). */
+  onsiteTimeWindowEnd?: string | null;
   budget?: ProductBudget;
   productSpec?: ProductSpec;
   crewRoles?: ProductCrewRole[];
+}
+
+export interface ProductOnsiteTiming {
+  setupMinutes: number;
+  shootMinutes: number;
+  breakdownMinutes: number;
+  totalMinutes: number;
+  windowStartMinutes: number;
+  windowEndMinutes: number;
 }
 
 export const DAY_IN_MS = 24 * 60 * 60 * 1000;
@@ -392,13 +411,156 @@ export const resolveProductOnsiteDays = (
     const parsed = Number(raw);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   }
+  const timing = resolveProductOnsiteTiming(product);
+  if (timing) {
+    const days = timing.totalMinutes / (24 * 60);
+    return days > 0 ? days : null;
+  }
   return null;
+};
+
+const parseMinutes = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Number(value));
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return 0;
+    }
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, parsed);
+    }
+  }
+  return 0;
+};
+
+const parseWindowTime = (value: unknown): number | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!/^\d{2}:\d{2}$/.test(trimmed)) {
+    return null;
+  }
+  const [hoursStr, minutesStr] = trimmed.split(":");
+  const hours = Number.parseInt(hoursStr, 10);
+  const minutes = Number.parseInt(minutesStr, 10);
+  if (
+    !Number.isFinite(hours) ||
+    !Number.isFinite(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+  return hours * 60 + minutes;
+};
+
+export const resolveProductOnsiteTiming = (
+  product: Product
+): ProductOnsiteTiming | null => {
+  const setup = parseMinutes((product as any)?.onsiteSetupMinutes);
+  const shoot = parseMinutes((product as any)?.onsiteShootMinutes);
+  const breakdown = parseMinutes((product as any)?.onsiteBreakdownMinutes);
+  const total = setup + shoot + breakdown;
+  if (total <= 0) {
+    return null;
+  }
+  const defaultStart = 8 * 60;
+  const defaultEnd = 18 * 60;
+  const startMinutes =
+    parseWindowTime((product as any)?.onsiteTimeWindowStart) ?? defaultStart;
+  let endMinutes =
+    parseWindowTime((product as any)?.onsiteTimeWindowEnd) ?? defaultEnd;
+  if (endMinutes <= startMinutes) {
+    endMinutes = startMinutes + total;
+  }
+  if (endMinutes - startMinutes < total) {
+    endMinutes = startMinutes + total;
+  }
+  return {
+    setupMinutes: setup,
+    shootMinutes: shoot,
+    breakdownMinutes: breakdown,
+    totalMinutes: total,
+    windowStartMinutes: startMinutes,
+    windowEndMinutes: endMinutes,
+  };
+};
+
+const formatMinutesSummary = (minutes: number, locale?: string): string => {
+  if (minutes <= 0) {
+    return "0 mins";
+  }
+  let hours = Math.floor(minutes / 60);
+  let remainder = Math.round(minutes - hours * 60);
+  if (remainder >= 60) {
+    hours += Math.floor(remainder / 60);
+    remainder %= 60;
+  }
+  if (remainder === 0 && hours > 0) {
+    const formatter = new Intl.NumberFormat(locale, {
+      maximumFractionDigits: 1,
+      minimumFractionDigits: 0,
+    });
+    const label = formatter.format(hours);
+    return `${label} ${hours === 1 ? "hour" : "hours"}`;
+  }
+  if (hours > 0) {
+    return `${hours} hour${hours === 1 ? "" : "s"} ${remainder} min${
+      remainder === 1 ? "" : "s"
+    }`;
+  }
+  return `${remainder} min${remainder === 1 ? "" : "s"}`;
+};
+
+const formatCompactMinutes = (minutes: number): string => {
+  if (minutes <= 0) {
+    return "0m";
+  }
+  let hours = Math.floor(minutes / 60);
+  let remainder = Math.round(minutes - hours * 60);
+  if (remainder >= 60) {
+    hours += Math.floor(remainder / 60);
+    remainder %= 60;
+  }
+  const parts: string[] = [];
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (remainder > 0 || parts.length === 0) {
+    parts.push(`${remainder}m`);
+  }
+  return parts.join(" ");
 };
 
 export const formatProductOnsiteDuration = (
   product: Product,
   locale?: string
 ): string | null => {
+  const timing = resolveProductOnsiteTiming(product);
+  if (timing) {
+    const totalLabel = formatMinutesSummary(timing.totalMinutes, locale);
+    const breakdownParts: string[] = [];
+    if (timing.setupMinutes > 0) {
+      breakdownParts.push(`Setup ${formatCompactMinutes(timing.setupMinutes)}`);
+    }
+    if (timing.shootMinutes > 0) {
+      breakdownParts.push(`Shoot ${formatCompactMinutes(timing.shootMinutes)}`);
+    }
+    if (timing.breakdownMinutes > 0) {
+      breakdownParts.push(
+        `Breakdown ${formatCompactMinutes(timing.breakdownMinutes)}`
+      );
+    }
+    const breakdown =
+      breakdownParts.length > 0 ? ` (${breakdownParts.join(" · ")})` : "";
+    return `${totalLabel} on site${breakdown}`;
+  }
   const days = resolveProductOnsiteDays(product);
   if (!days) {
     return null;

--- a/apps/web/lib/products.ts
+++ b/apps/web/lib/products.ts
@@ -66,8 +66,12 @@ async function fetchServerProducts(
     .map((r: any) => ({ id: r.document.name.split("/").pop()!, ...decodeFields(r.document.fields) }))
     .filter((p: any) => {
       if (p.category !== "exhibition-videography") return true;
-      if (!p.eventDate) return true;
-      return new Date(p.eventDate) >= now;
+      const end =
+        parseProductDate(p.eventEndDate) ||
+        parseProductDate(p.eventDate) ||
+        parseProductDate(p.eventStartDate);
+      if (!end) return true;
+      return end.getTime() >= now.getTime();
     });
 }
 
@@ -252,8 +256,14 @@ export interface Product {
   campaignSlug?: string | null;
   /** Optional booking configuration linked to a workflow booking template. */
   campaignBooking?: ProductCampaignBookingDetails | null;
-  /** Optional date for time-limited products such as Exhibition Videography */
+  /** Optional single date maintained for backwards compatibility. */
   eventDate?: string;
+  /** Start date for multi-day events such as exhibitions. */
+  eventStartDate?: string | null;
+  /** End date for multi-day events such as exhibitions. */
+  eventEndDate?: string | null;
+  /** Optional setup day offered before the show opens. */
+  eventSetupDate?: string | null;
   /** Venue name used for Exhibition Videography filtering */
   venue?: string;
   /** Linked venue reference for pulling travel details */
@@ -265,10 +275,146 @@ export interface Product {
   workflowId?: string;
   labourCost?: number;
   defaultKitCost?: number;
+  /** Number of days the crew is expected to be on-site. */
+  onsiteDays?: number | null;
   budget?: ProductBudget;
   productSpec?: ProductSpec;
   crewRoles?: ProductCrewRole[];
 }
+
+export const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const parseProductDate = (value: unknown): Date | null => {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as any).toDate === "function"
+  ) {
+    try {
+      const converted = (value as any).toDate();
+      if (converted instanceof Date && !Number.isNaN(converted.getTime())) {
+        return converted;
+      }
+    } catch {
+      return null;
+    }
+  }
+  return null;
+};
+
+const toDateKey = (date: Date): string => {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export interface ProductEventWindow {
+  start: Date | null;
+  end: Date | null;
+  setup: Date | null;
+}
+
+export const getProductEventWindow = (product: Product): ProductEventWindow => {
+  const start =
+    parseProductDate(product.eventStartDate) ||
+    parseProductDate(product.eventDate);
+  let end =
+    parseProductDate(product.eventEndDate) ||
+    parseProductDate(product.eventDate) ||
+    start;
+  if (start && end && end.getTime() < start.getTime()) {
+    end = start;
+  }
+  const setup = parseProductDate(product.eventSetupDate);
+  return { start: start ?? null, end: end ?? null, setup: setup ?? null };
+};
+
+export const getProductEventRangeLabel = (
+  product: Product,
+  locale?: string
+): string | null => {
+  const { start, end } = getProductEventWindow(product);
+  if (!start) {
+    return null;
+  }
+  const resolvedEnd = end ?? start;
+  const startLabel = start.toLocaleDateString(locale);
+  const endLabel = resolvedEnd.toLocaleDateString(locale);
+  if (start.getTime() === resolvedEnd.getTime()) {
+    return startLabel;
+  }
+  return `${startLabel} – ${endLabel}`;
+};
+
+export const getProductEventMonthKeys = (product: Product): string[] => {
+  const { start, end } = getProductEventWindow(product);
+  if (!start) {
+    return [];
+  }
+  const resolvedEnd = end ?? start;
+  const months = new Set<string>();
+  for (
+    let cursor = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate()));
+    cursor.getTime() <= resolvedEnd.getTime();
+    cursor = new Date(cursor.getTime() + DAY_IN_MS)
+  ) {
+    months.add(`${cursor.getUTCFullYear()}-${String(cursor.getUTCMonth() + 1).padStart(2, "0")}`);
+  }
+  if (months.size === 0) {
+    months.add(`${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, "0")}`);
+  }
+  return Array.from(months);
+};
+
+export const resolveProductOnsiteDays = (
+  product: Product
+): number | null => {
+  const raw = (product as any)?.onsiteDays;
+  if (typeof raw === "number") {
+    return Number.isFinite(raw) && raw > 0 ? raw : null;
+  }
+  if (typeof raw === "string") {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+  return null;
+};
+
+export const formatProductOnsiteDuration = (
+  product: Product,
+  locale?: string
+): string | null => {
+  const days = resolveProductOnsiteDays(product);
+  if (!days) {
+    return null;
+  }
+  if (Math.abs(days - 0.5) < 0.01) {
+    return "Half day on site";
+  }
+  if (Math.abs(days - 1) < 0.01) {
+    return "1 day on site";
+  }
+  const formatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: days % 1 === 0 ? 0 : 1,
+  });
+  return `${formatter.format(days)} days on site`;
+};
 
 // Fallback sample products if Firestore is unavailable
 const sampleProducts: Product[] = [
@@ -361,8 +507,12 @@ export async function getProducts(): Promise<Product[]> {
       .map((d) => ({ id: d.id, ...(d.data() as any) }))
       .filter((p) => {
         if (p.category !== "exhibition-videography") return true;
-        if (!p.eventDate) return true;
-        return new Date(p.eventDate) >= now;
+        const end =
+          parseProductDate(p.eventEndDate) ||
+          parseProductDate(p.eventDate) ||
+          parseProductDate(p.eventStartDate);
+        if (!end) return true;
+        return end.getTime() >= now.getTime();
       });
   } catch {
     return sampleProducts;
@@ -389,8 +539,12 @@ export async function getProductsByCategory(
       .map((d) => ({ id: d.id, ...(d.data() as any) }))
       .filter((p) => {
         if (p.category !== "exhibition-videography") return true;
-        if (!p.eventDate) return true;
-        return new Date(p.eventDate) >= now;
+        const end =
+          parseProductDate(p.eventEndDate) ||
+          parseProductDate(p.eventDate) ||
+          parseProductDate(p.eventStartDate);
+        if (!end) return true;
+        return end.getTime() >= now.getTime();
       });
   } catch {
     return sampleProducts.filter((p) => p.category === categoryId);

--- a/docs/order-availability.md
+++ b/docs/order-availability.md
@@ -1,0 +1,45 @@
+# Order Availability and Kit Reservation Flow
+
+This document summarises how the storefront determines production availability and assigns kit reservations when a customer adds a product to their cart.
+
+## 1. Coverage resolution
+
+1. The customer enters a filming address and postcode in the add-to-cart wizard.
+2. The postcode is matched against franchise territories to determine the primary operator:
+   - If a franchise owns the territory, the coverage assignment records the franchise ID and territory metadata.
+   - If no franchise is responsible, coverage defaults to HQ operations.
+3. The coverage metadata is passed to the `reserveKit` callable when the customer confirms their production date.
+
+## 2. Reservation attempts
+
+The `reserveKit` function evaluates availability in three stages, stopping as soon as a stage can cover the booking:
+
+1. **Franchise operations** – Kit owned by the franchise assigned to the territory. A successful match confirms kit immediately.
+2. **Franchise freelance/team network** – Kit registered to users within the same franchise. Success keeps the request in a *pending confirmation* state.
+3. **HQ operations** – Company-owned kit used as a final fallback. Success also remains pending until operations confirm.
+
+If the coverage assignment routes directly to HQ (because no franchise exists) only the HQ stage is evaluated.
+
+Each stage uses the same equipment IDs defined on the product. If a stage cannot supply an item—because the item belongs to another owner, is already booked, marked unavailable, or lacks the required compliance standard—the stage fails and the next fallback is tried.
+
+## 3. Equipment and standards checks
+
+For each required kit item the reservation flow:
+
+- Confirms the equipment document exists and belongs to the current stage owner.
+- Verifies the equipment is marked available and has no bookings overlapping the requested day.
+- Tracks which compliance standards the equipment meets and records any missing requirements.
+- Builds a list of kit items, including rental totals, for whichever stage succeeds.
+
+If no stage can supply the kit, the response lists the conflicts and missing standards so the UI can surface the exact issues.
+
+## 4. UI feedback and calendar state
+
+- The add-to-cart wizard surfaces warnings when availability falls back to the franchise team or HQ, or when conflicts/missing standards require manual confirmation.
+- The production date calendar caches availability overrides locally:
+  - **Confirmed** reservations mark the selected date as available.
+  - **Pending** reservations mark the date as pending confirmation.
+  - **Conflicts** that stop the booking mark the date as unavailable.
+- Catch-all errors during reservation also mark the date as pending so users know confirmation is outstanding.
+
+These steps ensure customers see the correct availability before checkout while operations receive clear visibility of which team needs to confirm the booking.

--- a/docs/order-availability.md
+++ b/docs/order-availability.md
@@ -45,3 +45,9 @@ If no stage can supply the kit, the response lists the conflicts and missing sta
 - Exhibition bookings can optionally extend the reservation by a setup day; the storefront passes an explicit span override so the reservation API locks both the setup and filming dates in one request.
 
 These steps ensure customers see the correct availability before checkout while operations receive clear visibility of which team needs to confirm the booking.
+
+## 5. Time windows for short sessions
+
+- Products can now capture on-site setup, filming, and breakdown minutes along with an optional booking window. When a product supplies any of these timings, the add-to-cart wizard presents a list of time slots after the customer picks a production date.
+- The selected slot is stored on the cart item and surfaced at checkout so operations know exactly when the crew is expected. Customers still see the day-level availability state, but the calendar requires a slot before the product can be added to the cart.
+- The `reserveKit` callable receives the time window alongside the usual start date. For single-day sessions it evaluates kit conflicts using the precise start/end times so multiple bookings can coexist on the same day. Multi-day reservations continue to block full days to cover setup and filming.

--- a/docs/order-availability.md
+++ b/docs/order-availability.md
@@ -41,5 +41,7 @@ If no stage can supply the kit, the response lists the conflicts and missing sta
   - **Pending** reservations mark the date as pending confirmation.
   - **Conflicts** that stop the booking mark the date as unavailable.
 - Catch-all errors during reservation also mark the date as pending so users know confirmation is outstanding.
+- Products declare how many days the crew will be on site via the `onsiteDays` field. The wizard blocks that many consecutive days on the availability calendar and shows the resulting range when the customer selects a start date.
+- Exhibition bookings can optionally extend the reservation by a setup day; the storefront passes an explicit span override so the reservation API locks both the setup and filming dates in one request.
 
 These steps ensure customers see the correct availability before checkout while operations receive clear visibility of which team needs to confirm the booking.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4489,111 +4489,407 @@ export const reserveKit = functions.https.onCall(async (data) => {
     new Set<string>(
       rawStandards
         .map((value: unknown) => (typeof value === 'string' ? value.trim() : ''))
-        .filter((value: string) => value.length > 0)
-    )
+        .filter((value: string) => value.length > 0),
+    ),
   );
   const standardsToEnforce = new Set(requiredStandards);
-  const standardMatches = new Map<string, Set<string>>();
-  requiredStandards.forEach((standard) => {
-    standardMatches.set(standard, new Set());
-  });
   const required = requiredKitRaw;
   const eqIds: string[] = required.flatMap((g: any) => g.items || []);
-  const conflicts: any[] = [];
-  const kitItems: any[] = [];
-  const missingStandards: string[] = [];
-  let rentalTotal = 0;
-  let reservationStatus: 'confirmed' | 'pending' = 'confirmed';
+
+  type ReservationStatus = 'confirmed' | 'pending';
+  type ProviderLevel = 'franchise_primary' | 'franchise_team' | 'hq';
+
+  interface ConflictRecord {
+    id: string;
+    name: string;
+    reason?: string;
+  }
+
+  interface KitReservationItem {
+    id: string;
+    name: string | null;
+    category: string | null;
+    start: string;
+    end: string;
+  }
+
+  interface ReservationProvider {
+    level: ProviderLevel;
+    status: ReservationStatus;
+    label: string;
+    franchiseId: string | null;
+    territoryId: string | null;
+  }
+
+  interface ReservationResponse {
+    conflicts: ConflictRecord[];
+    kitItems: KitReservationItem[];
+    rentalTotal: number;
+    status: ReservationStatus;
+    missingStandards: string[];
+    provider: ReservationProvider;
+  }
+
+  interface ReservationAttempt {
+    key: ProviderLevel;
+    ownerType: 'company' | 'franchise' | 'user';
+    initialStatus: ReservationStatus;
+    franchiseId: string | null;
+    label: string;
+  }
+
+  interface EquipmentRecord {
+    id: string;
+    name: string;
+    category: string | null;
+    ownerType: 'company' | 'franchise' | 'user';
+    ownerId: string | null;
+    franchiseId: string | null;
+    availableFlag: boolean;
+    booked: boolean;
+    meetsStandards: string[];
+    rentalPrice: number;
+    exists: boolean;
+  }
+
+  interface CoverageInfo {
+    type: 'franchise' | 'hq';
+    franchiseId: string | null;
+    territoryId: string | null;
+    label: string | null;
+  }
+
+  const normaliseCoverage = (raw: unknown): CoverageInfo => {
+    if (!raw || typeof raw !== 'object') {
+      return { type: 'hq', franchiseId: null, territoryId: null, label: null };
+    }
+    const rawType = (raw as any).type;
+    const type: 'franchise' | 'hq' = rawType === 'franchise' ? 'franchise' : 'hq';
+    const franchiseId =
+      typeof (raw as any).franchiseId === 'string' && (raw as any).franchiseId.trim().length > 0
+        ? (raw as any).franchiseId.trim()
+        : null;
+    const territoryId =
+      typeof (raw as any).territoryId === 'string' && (raw as any).territoryId.trim().length > 0
+        ? (raw as any).territoryId.trim()
+        : null;
+    const label =
+      typeof (raw as any).label === 'string' && (raw as any).label.trim().length > 0
+        ? (raw as any).label.trim()
+        : null;
+    if (type === 'franchise' && !franchiseId) {
+      return { type: 'hq', franchiseId: null, territoryId, label };
+    }
+    return { type, franchiseId, territoryId, label };
+  };
+
+  const coverageInfo = normaliseCoverage(data?.coverage);
+
+  const buildAttempts = (coverage: CoverageInfo): ReservationAttempt[] => {
+    const attempts: ReservationAttempt[] = [];
+    if (coverage.type === 'franchise' && coverage.franchiseId) {
+      const baseLabel = coverage.label ?? 'Franchise operations';
+      attempts.push({
+        key: 'franchise_primary',
+        ownerType: 'franchise',
+        initialStatus: 'confirmed',
+        franchiseId: coverage.franchiseId,
+        label: baseLabel,
+      });
+      attempts.push({
+        key: 'franchise_team',
+        ownerType: 'user',
+        initialStatus: 'pending',
+        franchiseId: coverage.franchiseId,
+        label: `${baseLabel} freelance team`,
+      });
+      attempts.push({
+        key: 'hq',
+        ownerType: 'company',
+        initialStatus: 'pending',
+        franchiseId: null,
+        label: 'HQ operations',
+      });
+    } else {
+      attempts.push({
+        key: 'hq',
+        ownerType: 'company',
+        initialStatus: 'confirmed',
+        franchiseId: null,
+        label: coverage.label ?? 'HQ operations',
+      });
+    }
+    return attempts;
+  };
+
+  const attempts = buildAttempts(coverageInfo);
+  if (attempts.length === 0) {
+    attempts.push({
+      key: 'hq',
+      ownerType: 'company',
+      initialStatus: 'confirmed',
+      franchiseId: null,
+      label: coverageInfo.label ?? 'HQ operations',
+    });
+  }
+
+  const deriveOwnerInfo = (eq: any): {
+    ownerType: 'company' | 'franchise' | 'user';
+    ownerId: string | null;
+    franchiseId: string | null;
+  } => {
+    const rawOwnerId =
+      typeof eq.ownerId === 'string' && eq.ownerId.trim().length > 0
+        ? eq.ownerId.trim()
+        : null;
+    const rawOwnerType =
+      typeof eq.ownerType === 'string' && eq.ownerType.trim().length > 0
+        ? eq.ownerType.trim().toLowerCase()
+        : '';
+    let ownerType: 'company' | 'franchise' | 'user';
+    if (rawOwnerType === 'company' || rawOwnerType === 'user' || rawOwnerType === 'franchise') {
+      ownerType = rawOwnerType;
+    } else if (rawOwnerId && rawOwnerId.startsWith('franchise:')) {
+      ownerType = 'franchise';
+    } else if (!rawOwnerId || rawOwnerId === 'company') {
+      ownerType = 'company';
+    } else {
+      ownerType = 'user';
+    }
+    let franchiseId: string | null = null;
+    if (typeof eq.franchiseId === 'string' && eq.franchiseId.trim().length > 0) {
+      franchiseId = eq.franchiseId.trim();
+    } else if (rawOwnerId && rawOwnerId.startsWith('franchise:')) {
+      franchiseId = rawOwnerId.slice('franchise:'.length);
+    }
+    return { ownerType, ownerId: rawOwnerId, franchiseId };
+  };
+
+  const equipmentRecords: EquipmentRecord[] = [];
   for (const id of eqIds) {
     const eqRef = db.collection('equipment').doc(id);
     const eqSnap = await eqRef.get();
-    if (!eqSnap.exists) continue;
-    const eq = eqSnap.data() as any;
-    const bookings = await eqRef
-      .collection('bookings')
-      .where('start', '<=', end)
-      .where('end', '>=', start)
-      .get();
-    if (!bookings.empty) {
-      conflicts.push({ id, name: eq.name || id });
-      reservationStatus = 'pending';
+    if (!eqSnap.exists) {
+      equipmentRecords.push({
+        id,
+        name: id,
+        category: null,
+        ownerType: 'company',
+        ownerId: null,
+        franchiseId: null,
+        availableFlag: false,
+        booked: false,
+        meetsStandards: [],
+        rentalPrice: 0,
+        exists: false,
+      });
       continue;
     }
-    if (standardsToEnforce.size > 0) {
-      const meets = Array.isArray(eq.meetsStandards)
-        ? (eq.meetsStandards as unknown[])
-            .map((value) => (typeof value === 'string' ? value.trim() : ''))
-            .filter((value): value is string => value.length > 0)
-        : [];
-      meets.forEach((standardId) => {
-        if (!standardsToEnforce.has(standardId)) return;
-        const record = standardMatches.get(standardId);
-        if (record) {
-          record.add(id);
-        }
-      });
-    }
-    const equipmentName =
-      typeof eq.name === 'string' && eq.name.trim().length > 0 ? eq.name.trim() : null;
-    const equipmentCategory =
+    const eq = eqSnap.data() as any;
+    const ownerInfo = deriveOwnerInfo(eq);
+    const category =
       typeof eq.category === 'string' && eq.category.trim().length > 0
         ? eq.category.trim()
         : typeof eq.type === 'string' && eq.type.trim().length > 0
           ? eq.type.trim()
           : null;
-    kitItems.push({
-      id,
+    const bookingsSnap = await eqRef
+      .collection('bookings')
+      .where('start', '<=', end)
+      .where('end', '>=', start)
+      .get();
+    const meetsStandards = Array.isArray(eq.meetsStandards)
+      ? (eq.meetsStandards as unknown[])
+          .map((value) => (typeof value === 'string' ? value.trim() : ''))
+          .filter((value): value is string => value.length > 0)
+      : [];
+    const equipmentName =
+      typeof eq.name === 'string' && eq.name.trim().length > 0 ? eq.name.trim() : eqSnap.id;
+    const rentalPrice =
+      typeof eq.rentalPrice === 'number' && Number.isFinite(eq.rentalPrice)
+        ? eq.rentalPrice
+        : 0;
+    equipmentRecords.push({
+      id: eqSnap.id,
       name: equipmentName,
-      category: equipmentCategory,
-      start: start.toISOString(),
-      end: end.toISOString(),
+      category,
+      ownerType: ownerInfo.ownerType,
+      ownerId: ownerInfo.ownerId,
+      franchiseId: ownerInfo.franchiseId,
+      availableFlag: eq.available !== false,
+      booked: !bookingsSnap.empty,
+      meetsStandards,
+      rentalPrice,
+      exists: true,
     });
-    rentalTotal += eq.rentalPrice || 0;
   }
-  if (conflicts.length > 0) {
-    return {
+
+  const matchesOwnerForAttempt = (
+    record: EquipmentRecord,
+    attempt: ReservationAttempt,
+  ): boolean => {
+    if (attempt.ownerType === 'company') {
+      return record.ownerType === 'company';
+    }
+    if (attempt.ownerType === 'franchise') {
+      return (
+        record.ownerType === 'franchise' &&
+        record.franchiseId !== null &&
+        record.franchiseId === attempt.franchiseId
+      );
+    }
+    return (
+      record.ownerType === 'user' &&
+      record.franchiseId !== null &&
+      attempt.franchiseId !== null &&
+      record.franchiseId === attempt.franchiseId
+    );
+  };
+
+  const evaluateAttempt = (
+    attempt: ReservationAttempt,
+  ): { success: boolean; response: ReservationResponse } => {
+    const conflicts: ConflictRecord[] = [];
+    const kitItems: KitReservationItem[] = [];
+    const missingStandards: string[] = [];
+    let rentalTotal = 0;
+    let reservationStatus: ReservationStatus = attempt.initialStatus;
+    const standardMatches = new Map<string, Set<string>>();
+    requiredStandards.forEach((standard) => {
+      standardMatches.set(standard, new Set());
+    });
+
+    for (const record of equipmentRecords) {
+      if (!record.exists) {
+        conflicts.push({ id: record.id, name: record.name, reason: 'missing' });
+        reservationStatus = 'pending';
+        continue;
+      }
+      if (!matchesOwnerForAttempt(record, attempt)) {
+        conflicts.push({
+          id: record.id,
+          name: record.name,
+          reason: 'owner_mismatch',
+        });
+        reservationStatus = 'pending';
+        continue;
+      }
+      if (!record.availableFlag) {
+        conflicts.push({
+          id: record.id,
+          name: record.name,
+          reason: 'unavailable',
+        });
+        reservationStatus = 'pending';
+        continue;
+      }
+      if (record.booked) {
+        conflicts.push({ id: record.id, name: record.name, reason: 'booked' });
+        reservationStatus = 'pending';
+        continue;
+      }
+      kitItems.push({
+        id: record.id,
+        name: record.name || record.id,
+        category: record.category,
+        start: start.toISOString(),
+        end: end.toISOString(),
+      });
+      rentalTotal += record.rentalPrice || 0;
+      record.meetsStandards.forEach((standardId) => {
+        if (!standardsToEnforce.has(standardId)) {
+          return;
+        }
+        const matches = standardMatches.get(standardId);
+        if (matches) {
+          matches.add(record.id);
+        }
+      });
+    }
+
+    if (standardsToEnforce.size > 0) {
+      requiredStandards.forEach((standard) => {
+        const matches = standardMatches.get(standard);
+        if (!matches || matches.size === 0) {
+          if (!missingStandards.includes(standard)) {
+            missingStandards.push(standard);
+          }
+        }
+      });
+      if (missingStandards.length > 0) {
+        reservationStatus = 'pending';
+      }
+    }
+
+    const success = conflicts.length === 0 && missingStandards.length === 0;
+    const response: ReservationResponse = {
       conflicts,
       kitItems,
       rentalTotal,
-      status: 'pending',
+      status: reservationStatus,
       missingStandards,
+      provider: {
+        level: attempt.key,
+        status: reservationStatus,
+        label: attempt.label,
+        franchiseId: attempt.franchiseId,
+        territoryId: coverageInfo.territoryId,
+      },
     };
-  }
-  if (standardsToEnforce.size > 0) {
-    const missingStandardsList = requiredStandards.filter((standard) => {
-      const matches = standardMatches.get(standard);
-      return !matches || matches.size === 0;
-    });
-    if (missingStandardsList.length > 0) {
-      missingStandardsList.forEach((standard) => {
-        if (!standard) return;
-        if (!missingStandards.includes(standard)) {
-          missingStandards.push(standard);
+
+    return { success, response };
+  };
+
+  let fallbackResponse: ReservationResponse | null = null;
+
+  for (const attempt of attempts) {
+    const { success, response } = evaluateAttempt(attempt);
+    if (success) {
+      if (response.status === 'confirmed' && response.kitItems.length > 0) {
+        const batch = db.batch();
+        for (const item of response.kitItems) {
+          const eqRef = db.collection('equipment').doc(item.id);
+          batch.set(eqRef.collection('bookings').doc(), {
+            start: admin.firestore.Timestamp.fromDate(start),
+            end: admin.firestore.Timestamp.fromDate(end),
+            projectId: null,
+          });
         }
-      });
-      reservationStatus = 'pending';
+        await batch.commit();
+      }
+      return response;
     }
+    fallbackResponse = response;
   }
-  if (reservationStatus === 'confirmed') {
-    const batch = db.batch();
-    for (const item of kitItems) {
-      const eqRef = db.collection('equipment').doc(item.id);
-      batch.set(eqRef.collection('bookings').doc(), {
-        start: admin.firestore.Timestamp.fromDate(start),
-        end: admin.firestore.Timestamp.fromDate(end),
-        projectId: null,
-      });
-    }
-    await batch.commit();
+
+  if (fallbackResponse) {
+    return fallbackResponse;
   }
+
+  const defaultAttempt = attempts[0] ?? {
+    key: 'hq' as ProviderLevel,
+    ownerType: 'company' as const,
+    initialStatus: 'pending' as ReservationStatus,
+    franchiseId: null,
+    label: coverageInfo.label ?? 'HQ operations',
+  };
+
   return {
     conflicts: [],
-    kitItems,
-    rentalTotal,
-    status: reservationStatus,
-    missingStandards,
+    kitItems: [],
+    rentalTotal: 0,
+    status: defaultAttempt.initialStatus,
+    missingStandards: requiredStandards,
+    provider: {
+      level: defaultAttempt.key,
+      status: defaultAttempt.initialStatus,
+      label: defaultAttempt.label,
+      franchiseId: defaultAttempt.franchiseId,
+      territoryId: coverageInfo.territoryId,
+    },
   };
 });
+
 
 type NormalisedRoles = Record<string, boolean>;
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4473,12 +4473,41 @@ export const reserveKit = functions.https.onCall(async (data) => {
     throw new functions.https.HttpsError('invalid-argument', 'productId and date required');
   }
   const start = new Date(date);
-  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  if (Number.isNaN(start.getTime())) {
+    throw new functions.https.HttpsError("invalid-argument", "Invalid reservation date");
+  }
   const prodSnap = await db.collection('products').doc(productId).get();
   if (!prodSnap.exists) {
     throw new functions.https.HttpsError('not-found', 'product not found');
   }
   const productData = prodSnap.data() as any;
+  const rawOnsiteDays =
+    typeof productData?.onsiteDays === 'number'
+      ? productData.onsiteDays
+      : typeof productData?.onsiteDays === 'string'
+        ? Number(productData.onsiteDays)
+        : null;
+  const onsiteDaysValue =
+    typeof rawOnsiteDays === 'number' && Number.isFinite(rawOnsiteDays) && rawOnsiteDays > 0
+      ? rawOnsiteDays
+      : 1;
+  const spanOverrideRaw =
+    typeof data?.spanOverride === 'number'
+      ? data.spanOverride
+      : typeof data?.spanOverride === 'string'
+        ? Number(data.spanOverride)
+        : null;
+  const spanOverride =
+    typeof spanOverrideRaw === 'number' &&
+    Number.isFinite(spanOverrideRaw) &&
+    spanOverrideRaw > 0
+      ? Math.min(spanOverrideRaw, 14)
+      : null;
+  const onsiteDayBlocks = Math.max(
+    1,
+    Math.ceil(spanOverride !== null ? spanOverride : onsiteDaysValue),
+  );
+  const end = new Date(start.getTime() + onsiteDayBlocks * 24 * 60 * 60 * 1000);
   const requiredKitRaw = Array.isArray(productData?.requiredKit)
     ? productData.requiredKit
     : [];
@@ -8133,6 +8162,25 @@ export const createOrder = functions.https.onCall(async (data, context) => {
     if (campaignBooking && typeof campaignBooking.priceAdjustment === 'number') {
       price += campaignBooking.priceAdjustment;
     }
+    const rawExhibition = items[idx]?.exhibition;
+    const exhibitionDetails =
+      rawExhibition && typeof rawExhibition === 'object'
+        ? (() => {
+            const showDate =
+              typeof rawExhibition.showDate === 'string' && rawExhibition.showDate.trim().length > 0
+                ? rawExhibition.showDate.trim()
+                : null;
+            const setupDate =
+              typeof rawExhibition.setupDate === 'string' && rawExhibition.setupDate.trim().length > 0
+                ? rawExhibition.setupDate.trim()
+                : null;
+            const setupIncluded = rawExhibition.setupIncluded === true;
+            if (!showDate && !setupDate && !setupIncluded) {
+              return null;
+            }
+            return { showDate, setupDate, setupIncluded };
+          })()
+        : null;
     const budget = (prod as any).budget || {};
     const labourFilming = parseOptional(budget.labourFilming);
     const labourEditing = parseOptional(budget.labourEditing);
@@ -8176,6 +8224,7 @@ export const createOrder = functions.https.onCall(async (data, context) => {
       date: itemDate,
       location: itemLocation,
       postalCode: itemPostalCode,
+      exhibition: exhibitionDetails,
       coverage: coveragePayload,
       campaignBooking,
       budget: {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4472,9 +4472,28 @@ export const reserveKit = functions.https.onCall(async (data) => {
   if (!productId || !date) {
     throw new functions.https.HttpsError('invalid-argument', 'productId and date required');
   }
-  const start = new Date(date);
-  if (Number.isNaN(start.getTime())) {
+  const baseStart = new Date(date);
+  if (Number.isNaN(baseStart.getTime())) {
     throw new functions.https.HttpsError("invalid-argument", "Invalid reservation date");
+  }
+  let start = baseStart;
+  let end: Date | null = null;
+  const rawWindow = data?.timeWindow;
+  if (rawWindow && typeof rawWindow === 'object') {
+    const windowStartRaw = (rawWindow as any).start;
+    const windowEndRaw = (rawWindow as any).end;
+    if (typeof windowStartRaw === 'string' && typeof windowEndRaw === 'string') {
+      const windowStart = new Date(windowStartRaw);
+      const windowEnd = new Date(windowEndRaw);
+      if (
+        !Number.isNaN(windowStart.getTime()) &&
+        !Number.isNaN(windowEnd.getTime()) &&
+        windowEnd.getTime() > windowStart.getTime()
+      ) {
+        start = windowStart;
+        end = windowEnd;
+      }
+    }
   }
   const prodSnap = await db.collection('products').doc(productId).get();
   if (!prodSnap.exists) {
@@ -4507,7 +4526,18 @@ export const reserveKit = functions.https.onCall(async (data) => {
     1,
     Math.ceil(spanOverride !== null ? spanOverride : onsiteDaysValue),
   );
-  const end = new Date(start.getTime() + onsiteDayBlocks * 24 * 60 * 60 * 1000);
+  if (onsiteDayBlocks > 1) {
+    if (baseStart.getTime() < start.getTime()) {
+      start = baseStart;
+    }
+    const blockEnd = new Date(baseStart.getTime() + onsiteDayBlocks * 24 * 60 * 60 * 1000);
+    if (!end || blockEnd.getTime() > end.getTime()) {
+      end = blockEnd;
+    }
+  }
+  if (!end) {
+    end = new Date(start.getTime() + onsiteDayBlocks * 24 * 60 * 60 * 1000);
+  }
   const requiredKitRaw = Array.isArray(productData?.requiredKit)
     ? productData.requiredKit
     : [];
@@ -8181,6 +8211,52 @@ export const createOrder = functions.https.onCall(async (data, context) => {
             return { showDate, setupDate, setupIncluded };
           })()
         : null;
+    const rawTimeSlot = items[idx]?.timeSlot;
+    const timeSlotDetails =
+      rawTimeSlot && typeof rawTimeSlot === 'object'
+        ? (() => {
+            const slotStart =
+              typeof rawTimeSlot.start === 'string' && rawTimeSlot.start.trim().length > 0
+                ? rawTimeSlot.start.trim()
+                : null;
+            const slotEnd =
+              typeof rawTimeSlot.end === 'string' && rawTimeSlot.end.trim().length > 0
+                ? rawTimeSlot.end.trim()
+                : null;
+            if (!slotStart || !slotEnd) {
+              return null;
+            }
+            const slotLabel =
+              typeof rawTimeSlot.label === 'string' && rawTimeSlot.label.trim().length > 0
+                ? rawTimeSlot.label.trim()
+                : null;
+            const totalMinutes =
+              typeof rawTimeSlot.totalMinutes === 'number' && Number.isFinite(rawTimeSlot.totalMinutes)
+                ? rawTimeSlot.totalMinutes
+                : null;
+            const setupMinutes =
+              typeof rawTimeSlot.setupMinutes === 'number' && Number.isFinite(rawTimeSlot.setupMinutes)
+                ? rawTimeSlot.setupMinutes
+                : null;
+            const shootMinutes =
+              typeof rawTimeSlot.shootMinutes === 'number' && Number.isFinite(rawTimeSlot.shootMinutes)
+                ? rawTimeSlot.shootMinutes
+                : null;
+            const breakdownMinutes =
+              typeof rawTimeSlot.breakdownMinutes === 'number' && Number.isFinite(rawTimeSlot.breakdownMinutes)
+                ? rawTimeSlot.breakdownMinutes
+                : null;
+            return {
+              start: slotStart,
+              end: slotEnd,
+              label: slotLabel,
+              totalMinutes,
+              setupMinutes,
+              shootMinutes,
+              breakdownMinutes,
+            };
+          })()
+        : null;
     const budget = (prod as any).budget || {};
     const labourFilming = parseOptional(budget.labourFilming);
     const labourEditing = parseOptional(budget.labourEditing);
@@ -8226,6 +8302,7 @@ export const createOrder = functions.https.onCall(async (data, context) => {
       postalCode: itemPostalCode,
       exhibition: exhibitionDetails,
       coverage: coveragePayload,
+      timeSlot: timeSlotDetails,
       campaignBooking,
       budget: {
         perUnit: {


### PR DESCRIPTION
## Summary
- expand the cart wizard to pass coverage context, surface fallback warnings, and mirror reservation results on the calendar
- allow the product date picker to honour in-session availability overrides
- overhaul the reserveKit callable to evaluate franchise, freelancer, and HQ kit availability with provider metadata
- document the reservation and availability flow for future reference

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df6ca84b9c83238e946edb8fbaa341