### PR TITLE
Add guidance for customer brand tasks

### DIFF
--- a/apps/web/app/admin/ClientPage.tsx
+++ b/apps/web/app/admin/ClientPage.tsx
@@ -70,6 +70,11 @@ export default function AdminPage() {
       href: '/admin/email-templates',
     },
     {
+      label: 'HQ social manager',
+      description: 'Connect Pineapple-owned channels and monitor OAuth health.',
+      href: '/admin/social-manager',
+    },
+    {
       label: 'QR code generator',
       description: 'Create scannable links for campaign assets.',
       href: '/admin/tools/qr-code-generator',

--- a/apps/web/app/admin/availability/ClientPage.tsx
+++ b/apps/web/app/admin/availability/ClientPage.tsx
@@ -26,7 +26,13 @@ import {
 } from "firebase/firestore";
 import { adminListUsers } from "@/lib/admin";
 import { useRoleGate } from "@/hooks/useRoleGate";
-import { ROLE_LABELS, extractUserRoles, type RoleKey, type UserRoles } from "@/lib/roles";
+import {
+  ROLE_LABELS,
+  extractUserRoles,
+  isGodAdmin,
+  type RoleKey,
+  type UserRoles,
+} from "@/lib/roles";
 
 interface RawMember {
   id: string;
@@ -479,7 +485,7 @@ interface BookingSummary {
   projectId: string | null;
 }
 
-type MemberType = "franchisee" | "team";
+type MemberType = "franchisee" | "hq" | "team";
 
 interface ConflictWarning {
   date: string;
@@ -528,6 +534,9 @@ function describeTeamPosition(member: Member): string | null {
   }
   if (member.isStaff) {
     return "Staff";
+  }
+  if (resolveMemberType(member) === "hq") {
+    return "HQ operations";
   }
   return null;
 }
@@ -619,7 +628,40 @@ const AvailabilityConflictNotice = ({
   const { date, bookings, member, memberType } = warning;
   const friendlyDate = formatDisplayDate(date);
   const label = resolveTeamMemberLabel(member);
-  const summary = buildConflictSummary(label, friendlyDate, bookings);
+  const summary = buildConflictSummary(label, friendlyDate, bookings, memberType);
+
+  const conflictMessage = (() => {
+    switch (memberType) {
+      case "franchisee":
+        return "This date already has a confirmed booking you are responsible for. Please either keep cover in place or offer it to HQ/another franchise before rescheduling with the client.";
+      case "hq":
+        return "This date already has a confirmed HQ booking. Loop in the operations desk so cover is arranged before you release the slot.";
+      default:
+        return "This date already has a confirmed booking. Please coordinate with your franchise owner or HQ so they can arrange cover before you step away.";
+    }
+  })();
+
+  const copyButtonLabel = (() => {
+    switch (memberType) {
+      case "franchisee":
+        return "Copy coverage request details";
+      case "hq":
+        return "Copy HQ handover summary";
+      default:
+        return "Copy handover summary";
+    }
+  })();
+
+  const tipCopy = (() => {
+    switch (memberType) {
+      case "franchisee":
+        return "Tip: Share this summary with HQ or neighbouring franchises to request cover before contacting the client.";
+      case "hq":
+        return "Tip: Share this summary with the wider HQ operations team so they can reassign cover or escalate if needed.";
+      default:
+        return "Tip: Send this summary to your franchise owner or HQ so they can coordinate a replacement.";
+    }
+  })();
 
   const handleCopy = async () => {
     try {
@@ -641,11 +683,7 @@ const AvailabilityConflictNotice = ({
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h2 className="text-base font-semibold text-amber-900">Existing booking on {friendlyDate}</h2>
-          <p className="mt-1 text-sm text-amber-900">
-            {memberType === "franchisee"
-              ? "This date already has a confirmed booking you are responsible for. Please either keep cover in place or offer it to HQ/another franchise before rescheduling with the client."
-              : "This date already has a confirmed booking. Please coordinate with your franchise owner or HQ so they can arrange cover before you step away."}
-          </p>
+          <p className="mt-1 text-sm text-amber-900">{conflictMessage}</p>
         </div>
         <button
           type="button"
@@ -690,18 +728,10 @@ const AvailabilityConflictNotice = ({
           onClick={handleCopy}
           className="inline-flex items-center justify-center rounded-md bg-amber-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-700"
         >
-          {memberType === "franchisee" ? "Copy coverage request details" : "Copy handover summary"}
+          {copyButtonLabel}
         </button>
         {copied && <span className="text-xs text-amber-800">Copied. Share this with your support contact.</span>}
-        {memberType === "franchisee" ? (
-          <p className="text-xs text-amber-800">
-            Tip: Share this summary with HQ or neighbouring franchises to request cover before contacting the client.
-          </p>
-        ) : (
-          <p className="text-xs text-amber-800">
-            Tip: Send this summary to your franchise owner or HQ so they can coordinate a replacement.
-          </p>
-        )}
+        <p className="text-xs text-amber-800">{tipCopy}</p>
       </div>
     </section>
   );
@@ -864,9 +894,14 @@ const formatDisplayDate = (input: string) => {
 const buildConflictSummary = (
   memberLabel: string,
   dateLabel: string,
-  bookings: BookingSummary[]
+  bookings: BookingSummary[],
+  memberType: MemberType
 ) => {
-  const lines = [`Availability change for ${memberLabel} on ${dateLabel}`, "Conflicting bookings:"];
+  const intro =
+    memberType === "hq"
+      ? `HQ availability change for ${memberLabel} on ${dateLabel}`
+      : `Availability change for ${memberLabel} on ${dateLabel}`;
+  const lines = [intro, "Conflicting bookings:"];
   bookings.forEach((booking, index) => {
     const title = booking.title ?? "Booking";
     const schedule = formatDateRange(booking.start, booking.end);
@@ -897,11 +932,22 @@ const resolveMemberType = (member: Member | null): MemberType => {
   if (!member) {
     return "team";
   }
-  if (member.isStaff) {
-    return "team";
+  if (isGodAdmin(member) || member.isStaff) {
+    return "hq";
   }
   if (member.franchiseIds.length > 0) {
     return "franchisee";
+  }
+  const roles = member.roles ?? {};
+  const hasHqRole =
+    roles.admin ||
+    roles.operations ||
+    roles.projects ||
+    roles.sales ||
+    roles.marketing ||
+    roles.finance;
+  if (hasHqRole) {
+    return "hq";
   }
   return "team";
 };

--- a/apps/web/app/admin/brand-guidelines/ClientPage.tsx
+++ b/apps/web/app/admin/brand-guidelines/ClientPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import NextImage from "next/image";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import { deleteObject, getDownloadURL, ref, uploadBytes } from "firebase/storage";
@@ -8,11 +8,33 @@ import { deleteObject, getDownloadURL, ref, uploadBytes } from "firebase/storage
 import { useRoleGate } from "@/hooks/useRoleGate";
 import { ensureFirebase } from "@/lib/firebase";
 import {
+  BrandGuidelineLogoAsset,
   BrandGuidelinesState,
   DEFAULT_BRAND_GUIDELINES,
   parseBrandGuidelines,
   sanitiseBrandGuidelines,
 } from "@/lib/brand-guidelines";
+
+const createLogoId = (): string =>
+  typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `logo-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+const readBlobAsDataUrl = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
+    reader.onerror = () => reject(reader.error || new Error("Failed to read file"));
+    reader.readAsDataURL(blob);
+  });
+
+const loadImageElement = (src: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = document.createElement("img");
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("Unable to load logo preview"));
+    image.src = src;
+  });
 
 type FeedbackState = { message: string; tone: "success" | "error" } | null;
 
@@ -24,6 +46,15 @@ export default function BrandGuidelinesPage() {
   const [uploadingLogo, setUploadingLogo] = useState(false);
   const [removingLogo, setRemovingLogo] = useState(false);
   const [guidelines, setGuidelines] = useState<BrandGuidelinesState>(DEFAULT_BRAND_GUIDELINES);
+  const [secondaryLogoFile, setSecondaryLogoFile] = useState<File | null>(null);
+  const [secondaryLogoName, setSecondaryLogoName] = useState("");
+  const [secondaryLogoNotes, setSecondaryLogoNotes] = useState("");
+  const [uploadingSecondaryLogo, setUploadingSecondaryLogo] = useState(false);
+  const [removingSecondaryLogoId, setRemovingSecondaryLogoId] = useState<string | null>(null);
+  const [monochromeSourceFile, setMonochromeSourceFile] = useState<File | null>(null);
+  const [monochromeGenerating, setMonochromeGenerating] = useState(false);
+  const [monochromeVariants, setMonochromeVariants] = useState<{ white?: string; black?: string }>({});
+  const [monochromeError, setMonochromeError] = useState<string | null>(null);
   const [savingGuidelines, setSavingGuidelines] = useState(false);
   const [feedback, setFeedback] = useState<FeedbackState>(null);
 
@@ -51,6 +82,86 @@ export default function BrandGuidelinesPage() {
       }
     })();
   }, [allowed, guardLoading]);
+
+  const handleSecondaryLogoFileChange = (file: File | null) => {
+    setSecondaryLogoFile(file);
+    if (file && !secondaryLogoName.trim()) {
+      const defaultName = file.name.replace(/\.[^/.]+$/, "");
+      setSecondaryLogoName(defaultName);
+    }
+  };
+
+  const persistGuidelinesSnapshot = async (next: BrandGuidelinesState) => {
+    const { db } = await ensureFirebase();
+    await setDoc(doc(db, "settings", "branding"), { brandGuidelines: sanitiseBrandGuidelines(next) }, { merge: true });
+  };
+
+  const convertImageToVariant = (image: HTMLImageElement, variant: "white" | "black"): string => {
+    const width = image.naturalWidth || image.width;
+    const height = image.naturalHeight || image.height;
+    if (!width || !height) {
+      throw new Error("Logo must have a valid width and height.");
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Unable to process logo. Try a different browser.");
+    }
+    context.clearRect(0, 0, width, height);
+    context.drawImage(image, 0, 0, width, height);
+    const imageData = context.getImageData(0, 0, width, height);
+    const { data } = imageData;
+    for (let index = 0; index < data.length; index += 4) {
+      const alpha = data[index + 3];
+      if (alpha === 0) {
+        continue;
+      }
+      if (variant === "white") {
+        data[index] = 255;
+        data[index + 1] = 255;
+        data[index + 2] = 255;
+      } else {
+        data[index] = 0;
+        data[index + 1] = 0;
+        data[index + 2] = 0;
+      }
+    }
+    context.putImageData(imageData, 0, 0);
+    return canvas.toDataURL("image/png");
+  };
+
+  const generateMonochromeVariants = async (source: { file?: File | null; url?: string }) => {
+    try {
+      setMonochromeGenerating(true);
+      setMonochromeError(null);
+      setMonochromeVariants({});
+      let dataUrl: string | null = null;
+      if (source.file) {
+        dataUrl = await readBlobAsDataUrl(source.file);
+      } else if (source.url) {
+        const response = await fetch(source.url);
+        if (!response.ok) {
+          throw new Error("Could not download the logo. Try uploading a file instead.");
+        }
+        const blob = await response.blob();
+        dataUrl = await readBlobAsDataUrl(blob);
+      }
+      if (!dataUrl) {
+        throw new Error("Select a logo file or upload a primary logo first.");
+      }
+      const image = await loadImageElement(dataUrl);
+      const whiteVariant = convertImageToVariant(image, "white");
+      const blackVariant = convertImageToVariant(image, "black");
+      setMonochromeVariants({ white: whiteVariant, black: blackVariant });
+    } catch (error: any) {
+      console.error("Failed to generate monochrome logos", error);
+      setMonochromeError(error?.message || "Unable to generate variants. Try a different file.");
+    } finally {
+      setMonochromeGenerating(false);
+    }
+  };
 
   const colorPreview = useMemo(
     () => [
@@ -112,17 +223,109 @@ export default function BrandGuidelinesPage() {
     }
   };
 
+  const handleSecondaryLogoUpload = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!secondaryLogoFile) return;
+    try {
+      setUploadingSecondaryLogo(true);
+      setFeedback(null);
+      const { db, storage } = await ensureFirebase();
+      const key = `site/brand/secondary/logo-${Date.now()}-${encodeURIComponent(secondaryLogoFile.name)}`;
+      const storageRef = ref(storage, key);
+      await uploadBytes(storageRef, secondaryLogoFile, {
+        contentType: secondaryLogoFile.type || "image/png",
+      });
+      const url = await getDownloadURL(storageRef);
+      const newLogo: BrandGuidelineLogoAsset = {
+        id: createLogoId(),
+        name: secondaryLogoName.trim() || secondaryLogoFile.name,
+        notes: secondaryLogoNotes.trim(),
+        url,
+        storagePath: key,
+      };
+      const nextGuidelines: BrandGuidelinesState = {
+        ...guidelines,
+        assets: {
+          ...guidelines.assets,
+          secondaryLogos: [...guidelines.assets.secondaryLogos, newLogo],
+        },
+      };
+      setGuidelines(nextGuidelines);
+      await persistGuidelinesSnapshot(nextGuidelines);
+      setSecondaryLogoFile(null);
+      setSecondaryLogoName("");
+      setSecondaryLogoNotes("");
+      setFeedback({ message: "Secondary logo uploaded.", tone: "success" });
+    } catch (error: any) {
+      console.error("Failed to upload secondary logo", error);
+      setFeedback({ message: error?.message || "Failed to upload secondary logo.", tone: "error" });
+    } finally {
+      setUploadingSecondaryLogo(false);
+    }
+  };
+
+  const handleSecondaryLogoRemove = async (logo: BrandGuidelineLogoAsset) => {
+    if (!confirm("Remove this secondary logo?")) return;
+    try {
+      setRemovingSecondaryLogoId(logo.id);
+      setFeedback(null);
+      const { db, storage } = await ensureFirebase();
+      if (logo.storagePath) {
+        try {
+          await deleteObject(ref(storage, logo.storagePath));
+        } catch (error) {
+          console.warn("Could not remove secondary logo from storage", error);
+        }
+      } else if (logo.url) {
+        try {
+          const url = new URL(logo.url);
+          const path = decodeURIComponent(url.pathname.replace(/^\//, ""));
+          await deleteObject(ref(storage, path));
+        } catch (error) {
+          console.warn("Could not resolve storage path for secondary logo", error);
+        }
+      }
+      const nextGuidelines: BrandGuidelinesState = {
+        ...guidelines,
+        assets: {
+          ...guidelines.assets,
+          secondaryLogos: guidelines.assets.secondaryLogos.filter((item) => item.id !== logo.id),
+        },
+      };
+      setGuidelines(nextGuidelines);
+      await persistGuidelinesSnapshot(nextGuidelines);
+      setFeedback({ message: "Secondary logo removed.", tone: "success" });
+    } catch (error: any) {
+      console.error("Failed to remove secondary logo", error);
+      setFeedback({ message: error?.message || "Failed to remove secondary logo.", tone: "error" });
+    } finally {
+      setRemovingSecondaryLogoId(null);
+    }
+  };
+
+  const handleMonochromeSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!monochromeSourceFile) {
+      setMonochromeError("Choose a logo file to convert.");
+      return;
+    }
+    await generateMonochromeVariants({ file: monochromeSourceFile });
+  };
+
+  const handleMonochromeFromPrimary = async () => {
+    if (!logoUrl) {
+      setMonochromeError("Upload your primary logo first or choose a file to convert.");
+      return;
+    }
+    await generateMonochromeVariants({ url: logoUrl });
+  };
+
   const saveGuidelines = async (event: FormEvent) => {
     event.preventDefault();
     try {
       setSavingGuidelines(true);
       setFeedback(null);
-      const { db } = await ensureFirebase();
-      await setDoc(
-        doc(db, "settings", "branding"),
-        { brandGuidelines: sanitiseBrandGuidelines(guidelines) },
-        { merge: true },
-      );
+      await persistGuidelinesSnapshot(guidelines);
       setFeedback({ message: "Brand guidelines saved.", tone: "success" });
     } catch (error: any) {
       console.error("Failed to save brand guidelines", error);
@@ -165,12 +368,14 @@ export default function BrandGuidelinesPage() {
       <section className="card grid gap-4 p-5">
         <div>
           <h2 className="text-lg font-semibold text-gray-900">Brand assets</h2>
-          <p className="text-sm text-gray-600">Upload your primary logo for use across the portal.</p>
+          <p className="text-sm text-gray-600">
+            Upload your primary logo, catalogue alternate versions, and instantly generate monochrome overlays for marketing and production teams.
+          </p>
         </div>
         <form onSubmit={handleLogoUpload} className="grid gap-4 sm:grid-cols-[auto_1fr] sm:items-center">
           <div className="flex items-center gap-4">
             {logoUrl ? (
-              <Image
+              <NextImage
                 src={logoUrl}
                 alt="Brand logo"
                 width={96}
@@ -210,6 +415,203 @@ export default function BrandGuidelinesPage() {
             </div>
           </div>
         </form>
+        <div className="grid gap-4 rounded-lg border border-gray-200/80 bg-gray-50/70 p-4">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Secondary logos</h3>
+            <p className="mt-1 text-sm text-gray-600">
+              Save monochrome icons, stacked versions, or campaign-specific marks with guidance for when to use them.
+            </p>
+          </div>
+          {guidelines.assets.secondaryLogos.length ? (
+            <ul className="grid gap-3">
+              {guidelines.assets.secondaryLogos.map((asset) => (
+                <li
+                  key={asset.id}
+                  className="grid gap-3 rounded-lg border border-gray-200 bg-white p-4 sm:grid-cols-[auto_1fr_auto] sm:items-center"
+                >
+                  <div className="flex items-center justify-center">
+                    <NextImage
+                      src={asset.url}
+                      alt={asset.name || "Secondary logo"}
+                      width={88}
+                      height={88}
+                      className="h-20 w-20 rounded-lg border border-gray-200 object-contain p-2"
+                    />
+                  </div>
+                  <div className="space-y-2 text-sm text-gray-700">
+                    <div>
+                      <p className="font-semibold text-gray-900">{asset.name || "Secondary logo"}</p>
+                      <p className="mt-1 text-xs text-gray-500">
+                        {asset.notes || "Add notes so teams know when this variation should be used."}
+                      </p>
+                    </div>
+                    <a
+                      href={asset.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      download
+                      className="inline-flex text-xs font-semibold uppercase tracking-wide text-gray-500 underline decoration-gray-300 decoration-2 underline-offset-4"
+                    >
+                      Download PNG
+                    </a>
+                  </div>
+                  <button
+                    type="button"
+                    className="btn-outline btn-sm"
+                    onClick={() => handleSecondaryLogoRemove(asset)}
+                    disabled={removingSecondaryLogoId === asset.id}
+                  >
+                    {removingSecondaryLogoId === asset.id ? "Removing…" : "Remove"}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-600">
+              No alternate logos yet. Upload additional marks below to keep campaign assets consistent.
+            </p>
+          )}
+          <form onSubmit={handleSecondaryLogoUpload} className="grid gap-3">
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] md:items-start">
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Logo file
+                <input
+                  className="mt-1"
+                  type="file"
+                  accept="image/*"
+                  onChange={(event) => handleSecondaryLogoFileChange(event.target.files?.[0] || null)}
+                />
+              </label>
+              <div className="grid gap-3">
+                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Display name
+                  <input
+                    className="input mt-1"
+                    value={secondaryLogoName}
+                    onChange={(event) => setSecondaryLogoName(event.target.value)}
+                    placeholder="e.g. White icon"
+                  />
+                </label>
+                <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Usage notes
+                  <textarea
+                    className="input mt-1"
+                    rows={3}
+                    value={secondaryLogoNotes}
+                    onChange={(event) => setSecondaryLogoNotes(event.target.value)}
+                    placeholder="When to use this version, background considerations, animation notes…"
+                  />
+                </label>
+              </div>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <button type="submit" className="btn btn-sm" disabled={!secondaryLogoFile || uploadingSecondaryLogo}>
+                {uploadingSecondaryLogo ? "Uploading…" : "Upload secondary logo"}
+              </button>
+              {secondaryLogoFile ? (
+                <button
+                  type="button"
+                  className="btn-outline btn-sm"
+                  onClick={() => {
+                    handleSecondaryLogoFileChange(null);
+                    setSecondaryLogoName("");
+                    setSecondaryLogoNotes("");
+                  }}
+                  disabled={uploadingSecondaryLogo}
+                >
+                  Clear
+                </button>
+              ) : null}
+            </div>
+          </form>
+        </div>
+        <div className="grid gap-4 rounded-lg border border-gray-200/80 bg-gray-50/70 p-4">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Monochrome logo generator</h3>
+            <p className="mt-1 text-sm text-gray-600">
+              Create transparent all-white and all-black PNGs for video overlays and merchandise with one click.
+            </p>
+          </div>
+          {monochromeError ? (
+            <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-xs text-rose-900">{monochromeError}</div>
+          ) : null}
+          <form onSubmit={handleMonochromeSubmit} className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+            <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Choose logo file
+              <input
+                className="mt-1"
+                type="file"
+                accept="image/*"
+                onChange={(event) => {
+                  setMonochromeVariants({});
+                  setMonochromeError(null);
+                  setMonochromeSourceFile(event.target.files?.[0] || null);
+                }}
+              />
+            </label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <button type="submit" className="btn btn-sm" disabled={!monochromeSourceFile || monochromeGenerating}>
+                {monochromeGenerating ? "Generating…" : "Generate variants"}
+              </button>
+              <button
+                type="button"
+                className="btn-outline btn-sm"
+                onClick={handleMonochromeFromPrimary}
+                disabled={monochromeGenerating || !logoUrl}
+              >
+                Use saved primary logo
+              </button>
+            </div>
+          </form>
+          {monochromeVariants.white || monochromeVariants.black ? (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {monochromeVariants.white ? (
+                <div className="grid gap-2 rounded-lg border border-gray-200 bg-white p-3 text-center">
+                  <div className="flex h-28 items-center justify-center rounded-md bg-gray-900">
+                    <NextImage
+                      src={monochromeVariants.white}
+                      alt="White logo preview"
+                      width={220}
+                      height={110}
+                      unoptimized
+                      className="max-h-20 w-auto object-contain"
+                    />
+                  </div>
+                  <a
+                    href={monochromeVariants.white}
+                    download={`brand-white-logo.png`}
+                    className="text-xs font-semibold uppercase tracking-wide text-gray-500 underline decoration-gray-300 decoration-2 underline-offset-4"
+                  >
+                    Download white PNG
+                  </a>
+                </div>
+              ) : null}
+              {monochromeVariants.black ? (
+                <div className="grid gap-2 rounded-lg border border-gray-200 bg-white p-3 text-center">
+                  <div className="flex h-28 items-center justify-center rounded-md bg-gray-100">
+                    <NextImage
+                      src={monochromeVariants.black}
+                      alt="Black logo preview"
+                      width={220}
+                      height={110}
+                      unoptimized
+                      className="max-h-20 w-auto object-contain"
+                    />
+                  </div>
+                  <a
+                    href={monochromeVariants.black}
+                    download={`brand-black-logo.png`}
+                    className="text-xs font-semibold uppercase tracking-wide text-gray-500 underline decoration-gray-300 decoration-2 underline-offset-4"
+                  >
+                    Download black PNG
+                  </a>
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-600">Upload a logo file or reuse the saved primary mark to create monochrome variants in seconds.</p>
+          )}
+        </div>
       </section>
 
       <form onSubmit={saveGuidelines} className="card grid gap-6 p-5">

--- a/apps/web/app/admin/proposals/new/ClientPage.tsx
+++ b/apps/web/app/admin/proposals/new/ClientPage.tsx
@@ -133,6 +133,8 @@ export default function NewProposalPage() {
   const [agreementIds, setAgreementIds] = useState<string[]>([]);
   const [sectionIds, setSectionIds] = useState<string[]>([]);
   const [customText, setCustomText] = useState("");
+  const [brandColor, setBrandColor] = useState("");
+  const [logoUrl, setLogoUrl] = useState("");
   const [setupPlan, setSetupPlan] = useState<ProposalSetupPlan>({
     layout: "conference",
     notes: "",
@@ -240,6 +242,19 @@ export default function NewProposalPage() {
       setItems(tpl.items || []);
       setAgreementIds(tpl.agreementIds || []);
       setSectionIds(tpl.sectionIds || []);
+    }
+  }, [templateId, templates]);
+
+  useEffect(() => {
+    if (!templateId) {
+      setBrandColor("");
+      setLogoUrl("");
+      return;
+    }
+    const tpl = templates.find((t) => t.id === templateId);
+    if (tpl) {
+      setBrandColor(typeof tpl.brandColor === "string" ? tpl.brandColor : "");
+      setLogoUrl(typeof tpl.logoUrl === "string" ? tpl.logoUrl : "");
     }
   }, [templateId, templates]);
 
@@ -512,6 +527,8 @@ export default function NewProposalPage() {
         templateId: templateId || undefined,
         customText,
         setupPlan,
+        brandColor: brandColor || undefined,
+        logoUrl: logoUrl || undefined,
       });
       router.push("/admin/proposals");
     } catch (err: any) {
@@ -780,6 +797,25 @@ export default function NewProposalPage() {
           {sectionIds.length > 0 && <p>Sections: {sectionIds.length}</p>}
           {agreementIds.length > 0 && (
             <p>Agreements: {agreementIds.length}</p>
+          )}
+          {(brandColor || logoUrl) && (
+            <div className="grid gap-1">
+              <p className="font-medium">Branding</p>
+              {logoUrl ? (
+                <p className="text-sm text-gray-600">Logo attached from template.</p>
+              ) : null}
+              {brandColor ? (
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <span>Primary colour</span>
+                  <span
+                    aria-hidden
+                    className="inline-block h-4 w-4 rounded-full border border-gray-200"
+                    style={{ backgroundColor: brandColor }}
+                  />
+                  <span className="font-mono text-xs text-gray-500">{brandColor}</span>
+                </div>
+              ) : null}
+            </div>
           )}
           <div className="flex justify-between mt-2">
             <button className="btn-outline" onClick={() => setStep(4)}>Back</button>

--- a/apps/web/app/admin/social-manager/ClientPage.tsx
+++ b/apps/web/app/admin/social-manager/ClientPage.tsx
@@ -202,7 +202,7 @@ export default function SocialManagerClientPage() {
               platform: normaliseText(data.platform) ?? "unknown",
               displayName: normaliseText(data.displayName) ?? `Account ${docSnap.id}`,
               organisationName:
-                normaliseText(data.organisationName) ?? normaliseText(data.organisationId) ?? "Pineapple Tapped HQ",
+                normaliseText(data.organisationName) ?? normaliseText(data.organisationId) ?? null,
               scopes,
               connection: {
                 status: connectionStatus,

--- a/apps/web/app/admin/social-manager/ClientPage.tsx
+++ b/apps/web/app/admin/social-manager/ClientPage.tsx
@@ -1,0 +1,609 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  collection,
+  deleteDoc,
+  doc,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  updateDoc,
+  type DocumentData,
+  type Firestore,
+  type QueryDocumentSnapshot,
+} from "firebase/firestore";
+
+import PortalHero from "@/components/PortalHero";
+import { formatDateTime } from "@/lib/datetime";
+import { ensureFirebase, loadAuthModule } from "@/lib/firebase";
+import { useRoleGate } from "@/hooks/useRoleGate";
+
+interface HqAccount {
+  id: string;
+  platform: string;
+  displayName: string;
+  organisationName: string | null;
+  scopes: { publish: boolean; analytics: boolean };
+  connection: {
+    status: string | null;
+    requiresReauth: boolean;
+    reauthRecommended: boolean;
+    expiresAt: Date | null;
+    lastAuthorizedAt: Date | null;
+  };
+  providerAccountName: string | null;
+  providerAccountUrl: string | null;
+  updatedAt: Date | null;
+  createdAt: Date | null;
+}
+
+interface HqAccountFormState {
+  organisationName: string;
+  displayName: string;
+  publishEnabled: boolean;
+  analyticsEnabled: boolean;
+}
+
+const PLATFORM_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "youtube", label: "YouTube" },
+  { value: "linkedin", label: "LinkedIn" },
+  { value: "instagram", label: "Instagram" },
+  { value: "facebook", label: "Facebook Pages" },
+  { value: "tiktok", label: "TikTok" },
+  { value: "twitter", label: "X (Twitter)" },
+  { value: "vimeo", label: "Vimeo" },
+];
+
+const PLATFORM_LABELS = PLATFORM_OPTIONS.reduce<Record<string, string>>((acc, option) => {
+  acc[option.value] = option.label;
+  return acc;
+}, {});
+
+function normaliseText(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function toDate(value: unknown): Date | null {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? new Date(value) : null;
+  }
+  if (typeof value === "object" && typeof (value as { toDate?: () => Date }).toDate === "function") {
+    try {
+      const result = (value as { toDate: () => Date }).toDate();
+      return Number.isNaN(result.getTime()) ? null : result;
+    } catch (error) {
+      return null;
+    }
+  }
+  return null;
+}
+
+export default function SocialManagerClientPage() {
+  const { allowed, loading: roleLoading } = useRoleGate("admin");
+  const [dbRef, setDbRef] = useState<Firestore | null>(null);
+
+  const [accounts, setAccounts] = useState<HqAccount[]>([]);
+  const [accountsLoading, setAccountsLoading] = useState(true);
+  const [accountError, setAccountError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const [accountForm, setAccountForm] = useState<HqAccountFormState>({
+    organisationName: "Pineapple Tapped HQ",
+    displayName: "",
+    publishEnabled: true,
+    analyticsEnabled: true,
+  });
+
+  const [platformSearch, setPlatformSearch] = useState("");
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const current = new URL(window.location.href);
+    const status = current.searchParams.get("socialConnection");
+    if (!status) {
+      return;
+    }
+    const message = current.searchParams.get("message");
+    if (status === "success") {
+      setFeedback(message || "Social account connected.");
+      setAccountError(null);
+      setAccountForm((prev) => ({ ...prev, displayName: "" }));
+    } else {
+      setAccountError(message || "Unable to connect the social account.");
+      setFeedback(null);
+    }
+    ["socialConnection", "message", "accountId", "platform", "reauth", "expiresAt"].forEach((param) =>
+      current.searchParams.delete(param)
+    );
+    window.history.replaceState({}, "", `${current.pathname}${current.search}${current.hash}`);
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+    let unsubscribeAuth: (() => void) | null = null;
+    (async () => {
+      try {
+        const { auth, db } = await ensureFirebase();
+        if (!mounted) return;
+        setDbRef(db as Firestore);
+        const authMod = await loadAuthModule();
+        if (!mounted) return;
+        unsubscribeAuth = authMod.onAuthStateChanged(auth, () => undefined);
+      } catch (error) {
+        console.error("Failed to initialise Firebase", error);
+        if (!mounted) return;
+        setDbRef(null);
+      }
+    })();
+    return () => {
+      mounted = false;
+      if (unsubscribeAuth) {
+        unsubscribeAuth();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!dbRef) {
+      return;
+    }
+    setAccountsLoading(true);
+    const q = query(collection(dbRef, "socialAccounts"), orderBy("createdAt", "desc"), limit(100));
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        const mapped = snapshot.docs
+          .map((docSnap: QueryDocumentSnapshot<DocumentData>) => {
+            const data = docSnap.data() as Record<string, unknown>;
+            const hqManaged = data.hqManaged === true || (!data.organisationId && !data.organisationName);
+            if (!hqManaged) {
+              return null;
+            }
+            const connectionData = (data.connection ?? {}) as Record<string, unknown>;
+            const connectionStatus =
+              normaliseText(connectionData.status) ?? normaliseText(data.status) ?? "active";
+            const connectionExpiresAt = toDate(connectionData.expiresAt ?? connectionData.expiry ?? null);
+            const requiresReauth =
+              connectionStatus === "requires_reauth" || Boolean(connectionData.requiresReauth ?? connectionData.reauthRequired);
+            const reauthRecommended =
+              requiresReauth ||
+              Boolean(
+                connectionData.reauthRecommended ??
+                  connectionData.reauthSoon ??
+                  connectionData.requiresReauthSoon
+              ) ||
+              (connectionExpiresAt ? connectionExpiresAt.getTime() - Date.now() < 48 * 60 * 60 * 1000 : false);
+            const scopesRaw = (data.scopes ?? {}) as Record<string, unknown>;
+            const scopes = {
+              publish: scopesRaw.publish === true,
+              analytics: scopesRaw.analytics === true || scopesRaw.insights === true,
+            } satisfies HqAccount["scopes"];
+            return {
+              id: docSnap.id,
+              platform: normaliseText(data.platform) ?? "unknown",
+              displayName: normaliseText(data.displayName) ?? `Account ${docSnap.id}`,
+              organisationName:
+                normaliseText(data.organisationName) ?? normaliseText(data.organisationId) ?? "Pineapple Tapped HQ",
+              scopes,
+              connection: {
+                status: connectionStatus,
+                requiresReauth,
+                reauthRecommended,
+                expiresAt: connectionExpiresAt,
+                lastAuthorizedAt: toDate(
+                  connectionData.lastAuthorizedAt ??
+                    connectionData.authorizedAt ??
+                    connectionData.lastLinkedAt ??
+                    data.lastAuthorizedAt ??
+                    data.lastLinkedAt ??
+                    null
+                ),
+              },
+              providerAccountName:
+                normaliseText(
+                  (data.provider as Record<string, unknown> | undefined)?.accountName ??
+                    (data.provider as Record<string, unknown> | undefined)?.name ??
+                    data.accountName
+                ) ?? null,
+              providerAccountUrl:
+                normaliseText(
+                  (data.provider as Record<string, unknown> | undefined)?.accountUrl ??
+                    data.accountUrl ??
+                    data.channelUrl
+                ) ?? null,
+              updatedAt: toDate(data.updatedAt),
+              createdAt: toDate(data.createdAt),
+            } satisfies HqAccount;
+          })
+          .filter((entry): entry is HqAccount => entry !== null);
+        setAccounts(mapped);
+        setAccountsLoading(false);
+        setAccountError(null);
+      },
+      (error) => {
+        console.error("Failed to subscribe to HQ social accounts", error);
+        setAccountError(error?.message || "Unable to load social accounts");
+        setAccountsLoading(false);
+      }
+    );
+    return () => unsubscribe();
+  }, [dbRef]);
+
+  const filteredPlatforms = useMemo(() => {
+    if (!platformSearch.trim()) {
+      return PLATFORM_OPTIONS;
+    }
+    const term = platformSearch.trim().toLowerCase();
+    return PLATFORM_OPTIONS.filter((option) => option.label.toLowerCase().includes(term));
+  }, [platformSearch]);
+
+  const summary = useMemo(() => {
+    const totals = { active: 0, reauth: 0, total: accounts.length };
+    accounts.forEach((account) => {
+      if (account.connection.requiresReauth) {
+        totals.reauth += 1;
+      } else {
+        totals.active += 1;
+      }
+    });
+    return totals;
+  }, [accounts]);
+
+  const startOAuthFlow = useCallback(
+    (platformKey: string, account?: HqAccount | null) => {
+      if (typeof window === "undefined") {
+        return;
+      }
+      const target = PLATFORM_OPTIONS.find((option) => option.value === platformKey);
+      if (!target) {
+        setAccountError("Unsupported platform selected.");
+        return;
+      }
+      const origin = window.location.origin;
+      const redirectUrl = new URL("/admin/social-manager", origin);
+      redirectUrl.searchParams.set("tab", "accounts");
+
+      const authUrl = new URL(`/api/social-accounts/${platformKey}`, origin);
+      const organisationName =
+        account?.organisationName ??
+        (accountForm.organisationName.trim() || "Pineapple Tapped HQ");
+      authUrl.searchParams.set("organisationName", organisationName);
+      authUrl.searchParams.set("displayName", account?.displayName || accountForm.displayName || organisationName);
+      const requestedScopes: string[] = [];
+      const publishEnabled = account ? account.scopes.publish : accountForm.publishEnabled;
+      const analyticsEnabled = account ? account.scopes.analytics : accountForm.analyticsEnabled;
+      if (publishEnabled) requestedScopes.push("publish");
+      if (analyticsEnabled) requestedScopes.push("analytics");
+      if (requestedScopes.length > 0) {
+        authUrl.searchParams.set("scopes", requestedScopes.join(","));
+      }
+      authUrl.searchParams.set("redirect", redirectUrl.toString());
+      authUrl.searchParams.set("hqManaged", "true");
+      if (account?.id) {
+        authUrl.searchParams.set("accountId", account.id);
+      }
+      setAccountError(null);
+      setFeedback(null);
+      window.location.href = authUrl.toString();
+    },
+    [accountForm]
+  );
+
+  const handleUpdateAccount = useCallback(
+    async (accountId: string, updates: Partial<HqAccount>) => {
+      if (!dbRef) return;
+      try {
+        const payload: Record<string, unknown> = { updatedAt: serverTimestamp() };
+        if (updates.scopes) {
+          payload.scopes = {
+            publish: updates.scopes.publish,
+            analytics: updates.scopes.analytics,
+          };
+        }
+        if (updates.connection?.status) {
+          payload.status = updates.connection.status;
+        }
+        await updateDoc(doc(dbRef, "socialAccounts", accountId), payload);
+        setFeedback("Account updated.");
+      } catch (error) {
+        console.error("Failed to update HQ social account", error);
+        setAccountError(error?.message || "Unable to update the account");
+      }
+    },
+    [dbRef]
+  );
+
+  const handleDeleteAccount = useCallback(
+    async (accountId: string) => {
+      if (!dbRef) return;
+      try {
+        await deleteDoc(doc(dbRef, "socialAccounts", accountId));
+        setFeedback("Account removed.");
+      } catch (error) {
+        console.error("Failed to remove HQ social account", error);
+        setAccountError(error?.message || "Unable to remove the account");
+      }
+    },
+    [dbRef]
+  );
+
+  const heroMetrics = [
+    { label: "Active", value: summary.active },
+    { label: "Needs re-auth", value: summary.reauth },
+    { label: "Total", value: summary.total },
+  ];
+
+  if (roleLoading) {
+    return <div className="p-6 text-sm text-gray-600">Checking permissions…</div>;
+  }
+
+  if (!allowed) {
+    return <div className="p-6 text-sm text-gray-600">You do not have access to manage HQ social accounts.</div>;
+  }
+
+  return (
+    <div className="grid gap-6">
+      <PortalHero
+        title="HQ Social Manager"
+        subtitle="Link Pineapple's owned channels, monitor token health, and refresh permissions before scheduled campaigns."
+        metrics={heroMetrics}
+        actions={[]}
+      />
+
+      <section className="grid gap-4 rounded border bg-white p-6 shadow-sm">
+        <header className="space-y-1">
+          <h2 className="text-lg font-semibold text-gray-900">Connect an HQ social profile</h2>
+          <p className="text-sm text-gray-600">
+            Use this launcher to connect Pineapple-owned accounts. Tokens are stored securely and marked as HQ-managed so client
+            schedulers stay separate.
+          </p>
+        </header>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="text-sm">
+            <span className="font-medium">Organisation label</span>
+            <input
+              type="text"
+              value={accountForm.organisationName}
+              onChange={(event) => setAccountForm((prev) => ({ ...prev, organisationName: event.target.value }))}
+              className="mt-1 w-full rounded border px-3 py-2"
+              placeholder="Pineapple Tapped HQ"
+            />
+          </label>
+          <label className="text-sm">
+            <span className="font-medium">Display name</span>
+            <input
+              type="text"
+              value={accountForm.displayName}
+              onChange={(event) => setAccountForm((prev) => ({ ...prev, displayName: event.target.value }))}
+              className="mt-1 w-full rounded border px-3 py-2"
+              placeholder="Shown in connection lists"
+            />
+          </label>
+        </div>
+
+        <div className="flex flex-wrap gap-6 text-sm">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={accountForm.publishEnabled}
+              onChange={(event) =>
+                setAccountForm((prev) => ({ ...prev, publishEnabled: event.target.checked }))
+              }
+            />
+            Allow scheduling / publishing permissions
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={accountForm.analyticsEnabled}
+              onChange={(event) =>
+                setAccountForm((prev) => ({ ...prev, analyticsEnabled: event.target.checked }))
+              }
+            />
+            Allow analytics insights
+          </label>
+        </div>
+
+        <div className="grid gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-xs text-gray-500">
+              Choose a platform to launch the OAuth flow. We’ll mark the resulting account as HQ-managed automatically.
+            </p>
+            <input
+              type="search"
+              value={platformSearch}
+              onChange={(event) => setPlatformSearch(event.target.value)}
+              className="w-full rounded border px-3 py-2 text-sm md:w-64"
+              placeholder="Filter platforms"
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {filteredPlatforms.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => startOAuthFlow(option.value)}
+                className="rounded bg-orange px-3 py-2 text-sm font-semibold text-white shadow hover:bg-orange/90"
+              >
+                Connect {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {feedback ? <p className="text-sm text-emerald-600">{feedback}</p> : null}
+        {accountError ? <p className="text-sm text-red-600">{accountError}</p> : null}
+      </section>
+
+      <section className="grid gap-4 rounded border bg-white p-6 shadow-sm">
+        <header className="space-y-1">
+          <h2 className="text-lg font-semibold text-gray-900">HQ account connections</h2>
+          <p className="text-sm text-gray-600">
+            Tokens listed here are flagged as HQ managed. Refresh or revoke access before expiry to keep the scheduler running smoothly.
+          </p>
+        </header>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
+              <tr>
+                <th className="p-2">Platform</th>
+                <th className="p-2">Display name</th>
+                <th className="p-2">Status</th>
+                <th className="p-2">Permissions</th>
+                <th className="p-2">Last updated</th>
+                <th className="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {accountsLoading ? (
+                <tr>
+                  <td colSpan={6} className="p-4 text-center text-gray-500">
+                    Loading HQ accounts…
+                  </td>
+                </tr>
+              ) : accounts.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="p-4 text-center text-gray-500">
+                    No HQ connections captured yet.
+                  </td>
+                </tr>
+              ) : (
+                accounts.map((account) => (
+                  <tr key={account.id} className="border-b last:border-0">
+                    <td className="p-2 align-top">
+                      <div className="font-medium text-gray-900">
+                        {PLATFORM_LABELS[account.platform] ?? account.platform}
+                      </div>
+                      {account.providerAccountName ? (
+                        <div className="text-xs text-gray-500">{account.providerAccountName}</div>
+                      ) : null}
+                      {account.providerAccountUrl ? (
+                        <div className="text-xs">
+                          <a
+                            href={account.providerAccountUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-slate-500 underline"
+                          >
+                            View profile
+                          </a>
+                        </div>
+                      ) : null}
+                    </td>
+                    <td className="p-2 align-top text-sm text-gray-700">
+                      <div className="font-semibold text-gray-900">{account.displayName}</div>
+                      <div className="text-xs text-gray-500">{account.organisationName ?? "Pineapple Tapped HQ"}</div>
+                    </td>
+                    <td className="p-2 align-top text-xs">
+                      <div
+                        className={`font-semibold ${
+                          account.connection.requiresReauth
+                            ? "text-red-600"
+                            : account.connection.reauthRecommended
+                            ? "text-amber-600"
+                            : "text-emerald-600"
+                        }`}
+                      >
+                        {account.connection.requiresReauth
+                          ? "Re-auth required"
+                          : account.connection.reauthRecommended
+                          ? "Re-auth soon"
+                          : account.connection.status?.replace(/_/g, " ") ?? "Active"}
+                      </div>
+                      <div className="text-gray-500">
+                        {account.connection.expiresAt
+                          ? `Expires ${formatDateTime(account.connection.expiresAt)}`
+                          : "No expiry provided"}
+                      </div>
+                      {account.connection.lastAuthorizedAt ? (
+                        <div className="text-gray-400">
+                          Linked {formatDateTime(account.connection.lastAuthorizedAt)}
+                        </div>
+                      ) : null}
+                    </td>
+                    <td className="p-2 align-top text-xs text-gray-600">
+                      <div>{account.scopes.publish ? "Publishing enabled" : "Scheduling blocked"}</div>
+                      <div>{account.scopes.analytics ? "Analytics enabled" : "Analytics hidden"}</div>
+                    </td>
+                    <td className="p-2 align-top text-xs text-gray-500">
+                      {account.updatedAt ? formatDateTime(account.updatedAt) : "—"}
+                    </td>
+                    <td className="p-2 align-top text-xs">
+                      <div className="flex flex-col gap-2">
+                        <button
+                          type="button"
+                          onClick={() => startOAuthFlow(account.platform, account)}
+                          className="rounded bg-slate-800 px-3 py-1 font-semibold text-white shadow hover:bg-slate-900"
+                        >
+                          Refresh token
+                        </button>
+                        <label className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            checked={account.scopes.publish}
+                            onChange={(event) =>
+                              handleUpdateAccount(account.id, {
+                                scopes: {
+                                  publish: event.target.checked,
+                                  analytics: account.scopes.analytics,
+                                },
+                              })
+                            }
+                          />
+                          <span>Allow publishing</span>
+                        </label>
+                        <label className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            checked={account.scopes.analytics}
+                            onChange={(event) =>
+                              handleUpdateAccount(account.id, {
+                                scopes: {
+                                  publish: account.scopes.publish,
+                                  analytics: event.target.checked,
+                                },
+                              })
+                            }
+                          />
+                          <span>Allow analytics</span>
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteAccount(account.id)}
+                          className="rounded border border-red-600 px-3 py-1 font-semibold text-red-600 hover:bg-red-50"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/admin/social-manager/ClientPage.tsx
+++ b/apps/web/app/admin/social-manager/ClientPage.tsx
@@ -171,70 +171,70 @@ export default function SocialManagerClientPage() {
     const unsubscribe = onSnapshot(
       q,
       (snapshot) => {
-        const mapped = snapshot.docs
-          .map((docSnap: QueryDocumentSnapshot<DocumentData>) => {
-            const data = docSnap.data() as Record<string, unknown>;
-            const hqManaged = data.hqManaged === true || (!data.organisationId && !data.organisationName);
-            if (!hqManaged) {
-              return null;
-            }
-            const connectionData = (data.connection ?? {}) as Record<string, unknown>;
-            const connectionStatus =
-              normaliseText(connectionData.status) ?? normaliseText(data.status) ?? "active";
-            const connectionExpiresAt = toDate(connectionData.expiresAt ?? connectionData.expiry ?? null);
-            const requiresReauth =
-              connectionStatus === "requires_reauth" || Boolean(connectionData.requiresReauth ?? connectionData.reauthRequired);
-            const reauthRecommended =
-              requiresReauth ||
-              Boolean(
-                connectionData.reauthRecommended ??
-                  connectionData.reauthSoon ??
-                  connectionData.requiresReauthSoon
-              ) ||
-              (connectionExpiresAt ? connectionExpiresAt.getTime() - Date.now() < 48 * 60 * 60 * 1000 : false);
-            const scopesRaw = (data.scopes ?? {}) as Record<string, unknown>;
-            const scopes = {
-              publish: scopesRaw.publish === true,
-              analytics: scopesRaw.analytics === true || scopesRaw.insights === true,
-            } satisfies HqAccount["scopes"];
-            return {
-              id: docSnap.id,
-              platform: normaliseText(data.platform) ?? "unknown",
-              displayName: normaliseText(data.displayName) ?? `Account ${docSnap.id}`,
-              organisationName:
-                normaliseText(data.organisationName) ?? normaliseText(data.organisationId) ?? null,
-              scopes,
-              connection: {
-                status: connectionStatus,
-                requiresReauth,
-                reauthRecommended,
-                expiresAt: connectionExpiresAt,
-                lastAuthorizedAt: toDate(
-                  connectionData.lastAuthorizedAt ??
-                    connectionData.authorizedAt ??
-                    connectionData.lastLinkedAt ??
-                    data.lastAuthorizedAt ??
-                    data.lastLinkedAt ??
-                    null
-                ),
-              },
-              providerAccountName:
-                normaliseText(
-                  (data.provider as Record<string, unknown> | undefined)?.accountName ??
-                    (data.provider as Record<string, unknown> | undefined)?.name ??
-                    data.accountName
-                ) ?? null,
-              providerAccountUrl:
-                normaliseText(
-                  (data.provider as Record<string, unknown> | undefined)?.accountUrl ??
-                    data.accountUrl ??
-                    data.channelUrl
-                ) ?? null,
-              updatedAt: toDate(data.updatedAt),
-              createdAt: toDate(data.createdAt),
-            } satisfies HqAccount;
-          })
-          .filter((entry): entry is HqAccount => entry !== null);
+        const mapped = snapshot.docs.reduce<HqAccount[]>((acc, docSnap: QueryDocumentSnapshot<DocumentData>) => {
+          const data = docSnap.data() as Record<string, unknown>;
+          const hqManaged = data.hqManaged === true || (!data.organisationId && !data.organisationName);
+          if (!hqManaged) {
+            return acc;
+          }
+          const connectionData = (data.connection ?? {}) as Record<string, unknown>;
+          const connectionStatus: string | null =
+            normaliseText(connectionData.status) ?? normaliseText(data.status) ?? "active";
+          const connectionExpiresAt = toDate(connectionData.expiresAt ?? connectionData.expiry ?? null);
+          const requiresReauth =
+            connectionStatus === "requires_reauth" || Boolean(connectionData.requiresReauth ?? connectionData.reauthRequired);
+          const reauthRecommended =
+            requiresReauth ||
+            Boolean(
+              connectionData.reauthRecommended ??
+                connectionData.reauthSoon ??
+                connectionData.requiresReauthSoon
+            ) ||
+            (connectionExpiresAt ? connectionExpiresAt.getTime() - Date.now() < 48 * 60 * 60 * 1000 : false);
+          const scopesRaw = (data.scopes ?? {}) as Record<string, unknown>;
+          const scopes: HqAccount["scopes"] = {
+            publish: scopesRaw.publish === true,
+            analytics: scopesRaw.analytics === true || scopesRaw.insights === true,
+          };
+          const account: HqAccount = {
+            id: docSnap.id,
+            platform: normaliseText(data.platform) ?? "unknown",
+            displayName: normaliseText(data.displayName) ?? `Account ${docSnap.id}`,
+            organisationName:
+              normaliseText(data.organisationName) ?? normaliseText(data.organisationId) ?? null,
+            scopes,
+            connection: {
+              status: connectionStatus,
+              requiresReauth,
+              reauthRecommended,
+              expiresAt: connectionExpiresAt,
+              lastAuthorizedAt: toDate(
+                connectionData.lastAuthorizedAt ??
+                  connectionData.authorizedAt ??
+                  connectionData.lastLinkedAt ??
+                  data.lastAuthorizedAt ??
+                  data.lastLinkedAt ??
+                  null
+              ),
+            },
+            providerAccountName:
+              normaliseText(
+                (data.provider as Record<string, unknown> | undefined)?.accountName ??
+                  (data.provider as Record<string, unknown> | undefined)?.name ??
+                  data.accountName
+              ) ?? null,
+            providerAccountUrl:
+              normaliseText(
+                (data.provider as Record<string, unknown> | undefined)?.accountUrl ??
+                  data.accountUrl ??
+                  data.channelUrl
+              ) ?? null,
+            updatedAt: toDate(data.updatedAt),
+            createdAt: toDate(data.createdAt),
+          };
+          acc.push(account);
+          return acc;
+        }, []);
         setAccounts(mapped);
         setAccountsLoading(false);
         setAccountError(null);

--- a/apps/web/app/admin/social-manager/ClientPage.tsx
+++ b/apps/web/app/admin/social-manager/ClientPage.tsx
@@ -326,7 +326,13 @@ export default function SocialManagerClientPage() {
         setFeedback("Account updated.");
       } catch (error) {
         console.error("Failed to update HQ social account", error);
-        setAccountError(error?.message || "Unable to update the account");
+        const message =
+          error instanceof Error
+            ? error.message
+            : typeof error === "string"
+            ? error
+            : "Unable to update the account";
+        setAccountError(message);
       }
     },
     [dbRef]
@@ -340,7 +346,13 @@ export default function SocialManagerClientPage() {
         setFeedback("Account removed.");
       } catch (error) {
         console.error("Failed to remove HQ social account", error);
-        setAccountError(error?.message || "Unable to remove the account");
+        const message =
+          error instanceof Error
+            ? error.message
+            : typeof error === "string"
+            ? error
+            : "Unable to remove the account";
+        setAccountError(message);
       }
     },
     [dbRef]

--- a/apps/web/app/admin/social-manager/page.tsx
+++ b/apps/web/app/admin/social-manager/page.tsx
@@ -1,0 +1,7 @@
+import ClientPage from "./ClientPage";
+
+export const metadata = { title: "HQ Social Manager | Pineapple Tapped" };
+
+export default function Page() {
+  return <ClientPage />;
+}

--- a/apps/web/app/admin/users/ClientPage.tsx
+++ b/apps/web/app/admin/users/ClientPage.tsx
@@ -7,14 +7,17 @@ import {
   collection,
   collectionGroup,
   doc,
+  getDoc,
   getDocs,
   limit,
   onSnapshot,
   orderBy,
   query,
+  serverTimestamp,
+  setDoc,
   updateDoc,
   where,
-  serverTimestamp,
+  type Firestore,
 } from 'firebase/firestore';
 
 import CRMRecordForm from '@/components/CRMRecordForm';
@@ -79,6 +82,182 @@ interface FranchiseSummary {
   id: string;
   name: string;
   code: string | null;
+}
+
+interface OrganisationSummary {
+  id: string;
+  name: string;
+}
+
+async function findOrganisationByName(db: Firestore, name: string): Promise<OrganisationSummary | null> {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const normalised = trimmed.toLowerCase();
+
+  try {
+    const lowerSnap = await getDocs(
+      query(collection(db, 'orgs'), where('nameLower', '==', normalised), limit(1))
+    );
+    if (!lowerSnap.empty) {
+      const docSnap = lowerSnap.docs[0];
+      const data = docSnap.data() as Record<string, any>;
+      const resolvedName = typeof data?.name === 'string' && data.name.trim().length > 0 ? data.name : trimmed;
+      return { id: docSnap.id, name: resolvedName };
+    }
+  } catch (error) {
+    console.warn('Failed to query organisation by nameLower', { name }, error);
+  }
+
+  try {
+    const rangeSnap = await getDocs(
+      query(collection(db, 'orgs'), where('name', '>=', trimmed), where('name', '<=', `${trimmed}\uf8ff`), limit(5))
+    );
+    if (!rangeSnap.empty) {
+      for (const docSnap of rangeSnap.docs) {
+        const data = docSnap.data() as Record<string, any>;
+        const candidateName = typeof data?.name === 'string' ? data.name : '';
+        if (candidateName.trim().toLowerCase() === normalised) {
+          const resolvedName = candidateName.trim().length > 0 ? candidateName : trimmed;
+          return { id: docSnap.id, name: resolvedName };
+        }
+      }
+      const firstMatch = rangeSnap.docs[0];
+      const firstData = firstMatch.data() as Record<string, any>;
+      const fallbackName =
+        typeof firstData?.name === 'string' && firstData.name.trim().length > 0 ? firstData.name : trimmed;
+      return { id: firstMatch.id, name: fallbackName };
+    }
+  } catch (error) {
+    console.warn('Failed to search organisation by range', { name }, error);
+  }
+
+  return null;
+}
+
+async function createOrganisationFromCrm(
+  db: Firestore,
+  name: string,
+  context: {
+    contactId: string;
+    contactEmail: string;
+    contactName?: string | null;
+    website?: string | null;
+    location?: string | null;
+    address?: string | null;
+    socials?: string | null;
+    actorUid?: string | null;
+  }
+): Promise<OrganisationSummary> {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error('Organisation name is required.');
+  }
+
+  const orgRef = doc(collection(db, 'orgs'));
+  const payload: Record<string, unknown> = {
+    name: trimmed,
+    nameLower: trimmed.toLowerCase(),
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    createdBy: context.actorUid ?? null,
+    source: 'crm',
+    primaryContactId: context.contactId,
+    primaryContactEmail: context.contactEmail,
+    primaryContactLinkedAt: serverTimestamp(),
+  };
+
+  if (context.contactName && context.contactName.trim()) {
+    payload.primaryContactName = context.contactName.trim();
+  }
+  if (context.website && context.website.trim()) {
+    payload.website = context.website.trim();
+  }
+  if (context.location && context.location.trim()) {
+    payload.location = context.location.trim();
+  }
+  if (context.address && context.address.trim()) {
+    payload.address = context.address.trim();
+  }
+  if (context.socials && context.socials.trim()) {
+    payload.socials = context.socials.trim();
+  }
+
+  await setDoc(orgRef, payload);
+
+  return { id: orgRef.id, name: trimmed };
+}
+
+async function maybeUpdateOrganisationDetails(
+  db: Firestore,
+  orgId: string,
+  details: { website?: string | null; location?: string | null; address?: string | null; socials?: string | null }
+) {
+  const orgRef = doc(db, 'orgs', orgId);
+  try {
+    const orgSnap = await getDoc(orgRef);
+    if (!orgSnap.exists()) {
+      return;
+    }
+    const data = (orgSnap.data() as Record<string, any>) || {};
+    const updates: Record<string, unknown> = {};
+
+    if (details.website && details.website.trim() && !data.website) {
+      updates.website = details.website.trim();
+    }
+    if (details.location && details.location.trim() && !data.location) {
+      updates.location = details.location.trim();
+    }
+    if (details.address && details.address.trim() && !data.address) {
+      updates.address = details.address.trim();
+    }
+    if (details.socials && details.socials.trim() && !data.socials) {
+      updates.socials = details.socials.trim();
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return;
+    }
+
+    updates.updatedAt = serverTimestamp();
+    await updateDoc(orgRef, updates);
+  } catch (error) {
+    console.warn('Failed to enrich existing organisation with CRM details', { orgId }, error);
+  }
+}
+
+async function ensureOrganisationMembership(
+  db: Firestore,
+  orgId: string,
+  userId: string,
+  actorUid: string | null
+): Promise<string> {
+  const membershipRef = doc(db, 'memberships', `${orgId}_${userId}`);
+  const snap = await getDoc(membershipRef);
+  const defaultRole = 'client_admin';
+  const existingData = snap.exists ? ((snap.data() as Record<string, any>) ?? {}) : {};
+  const role =
+    typeof existingData.role === 'string' && existingData.role.trim().length > 0 ? existingData.role : defaultRole;
+
+  const payload: Record<string, unknown> = {
+    orgId,
+    userId,
+    role,
+    updatedAt: serverTimestamp(),
+  };
+
+  if (!snap.exists) {
+    payload.createdAt = serverTimestamp();
+    payload.addedBy = actorUid ?? null;
+  } else if (!existingData.addedBy && actorUid) {
+    payload.addedBy = actorUid;
+  }
+
+  await setDoc(membershipRef, payload, { merge: true });
+
+  return role;
 }
 
 interface CrmAuditLogEntry {
@@ -1022,8 +1201,56 @@ export default function AdminUsersPage() {
       sanitised.createdAt = timestampIso;
       sanitised.updatedAt = timestampIso;
 
+      const { db, storage, auth: firebaseAuth } = await ensureFirebase();
+      if (!db) {
+        throw new Error('Firestore is unavailable.');
+      }
+
+      type OrganisationOutcome = (OrganisationSummary & { mode: 'existing' | 'created' }) | null;
+      let organisationOutcome: OrganisationOutcome = null;
+
+      const organisationInput =
+        typeof sanitised.organisation === 'string' && sanitised.organisation.trim().length > 0
+          ? sanitised.organisation.trim()
+          : '';
+
+      if (organisationInput) {
+        const existing = await findOrganisationByName(db, organisationInput);
+        if (existing) {
+          const confirmationMessage = `An organisation named “${existing.name}” already exists. Connect this contact to the existing organisation?`;
+          const useExisting = typeof window !== 'undefined' ? window.confirm(confirmationMessage) : true;
+          if (useExisting) {
+            organisationOutcome = { ...existing, mode: 'existing' };
+          }
+        }
+
+        if (organisationOutcome?.mode === 'existing') {
+          await maybeUpdateOrganisationDetails(db, organisationOutcome.id, {
+            website: typeof sanitised.website === 'string' ? sanitised.website : null,
+            location: typeof sanitised.location === 'string' ? sanitised.location : null,
+            address: typeof sanitised.address === 'string' ? sanitised.address : null,
+            socials: typeof sanitised.socials === 'string' ? sanitised.socials : null,
+          });
+          sanitised.organisation = organisationOutcome.name;
+          sanitised.organisationId = organisationOutcome.id;
+        } else {
+          const created = await createOrganisationFromCrm(db, organisationInput, {
+            contactId: id,
+            contactEmail: emailValue,
+            contactName: typeof sanitised.fullName === 'string' ? sanitised.fullName : null,
+            website: typeof sanitised.website === 'string' ? sanitised.website : null,
+            location: typeof sanitised.location === 'string' ? sanitised.location : null,
+            address: typeof sanitised.address === 'string' ? sanitised.address : null,
+            socials: typeof sanitised.socials === 'string' ? sanitised.socials : null,
+            actorUid: firebaseAuth?.currentUser?.uid ?? null,
+          });
+          organisationOutcome = { ...created, mode: 'created' };
+          sanitised.organisation = created.name;
+          sanitised.organisationId = created.id;
+        }
+      }
+
       if (fileEntries.length > 0) {
-        const { storage } = await ensureFirebase();
         if (!storage || (storage as any).__isPlaceholder) {
           throw new Error('Firebase storage is unavailable.');
         }
@@ -1043,12 +1270,34 @@ export default function AdminUsersPage() {
 
       await adminUpdateUser({ userId: id, updates: sanitised });
 
+      let membershipRole: string | null = null;
+      if (organisationOutcome) {
+        membershipRole = await ensureOrganisationMembership(
+          db,
+          organisationOutcome.id,
+          id,
+          firebaseAuth?.currentUser?.uid ?? null
+        );
+      }
+
       const newRecord: AdminUser = {
         id,
         email: emailValue,
         ...(sanitised as Partial<AdminUser>),
         crmStatus: defaultStage,
       };
+
+      if (organisationOutcome) {
+        const membershipEntry = {
+          orgId: organisationOutcome.id,
+          orgName: organisationOutcome.name,
+          role: membershipRole,
+        };
+        newRecord.organisation = organisationOutcome.name;
+        newRecord.memberships = Array.isArray(newRecord.memberships)
+          ? [...newRecord.memberships, membershipEntry]
+          : [membershipEntry];
+      }
 
       setUsers((prev) => [...prev, newRecord]);
       void recordCrmAuditEvent(newRecord, {
@@ -1057,6 +1306,20 @@ export default function AdminUsersPage() {
         before: null,
         after: defaultStage,
       });
+
+      if (organisationOutcome) {
+        void recordCrmAuditEvent(newRecord, {
+          action: 'field_update',
+          field: 'organisation',
+          before: null,
+          after: organisationOutcome.name,
+          note:
+            organisationOutcome.mode === 'existing'
+              ? `Linked to existing organisation (${organisationOutcome.id}) during CRM record creation.`
+              : `Created new organisation (${organisationOutcome.id}) during CRM record creation.`,
+        });
+      }
+
       setShowForm(false);
     } catch (err: any) {
       console.error(err);

--- a/apps/web/app/api/social-accounts/[platform]/route.ts
+++ b/apps/web/app/api/social-accounts/[platform]/route.ts
@@ -44,6 +44,7 @@ interface AuthStateDoc {
   displayName: string | null;
   redirectUri: string;
   scopes?: RequestedScopes;
+  hqManaged?: boolean | null;
   createdAt?: Timestamp | Date | FieldValue | null;
   createdBy?: string | null;
   accountId?: string | null;
@@ -62,6 +63,7 @@ interface StoreCredentialPayload {
   organisationName: string | null;
   displayName: string | null;
   scopes: RequestedScopes;
+  hqManaged: boolean;
   tokens: {
     accessToken: string;
     refreshToken: string | null;
@@ -116,6 +118,14 @@ function parseScopesParam(value: string | null): RequestedScopes {
     publish: entries.includes('publish'),
     analytics: entries.includes('analytics'),
   };
+}
+
+function parseBooleanFlag(value: string | null): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalised = value.trim().toLowerCase();
+  return normalised === 'true' || normalised === '1' || normalised === 'yes';
 }
 
 function sanitiseRedirect(origin: string, candidate: string | null): string {
@@ -243,6 +253,7 @@ async function handleInitiation(request: NextRequest, platform: SocialPlatform) 
   const redirectCandidate = parseString(params.get('redirect'));
   const accountId = parseString(params.get('accountId'));
   const scopes = parseScopesParam(params.get('scopes'));
+  const hqManaged = parseBooleanFlag(params.get('hqManaged'));
 
   if (!organisationId && !organisationName) {
     return NextResponse.json(
@@ -265,6 +276,7 @@ async function handleInitiation(request: NextRequest, platform: SocialPlatform) 
       displayName: displayName ?? organisationName ?? null,
       redirectUri,
       scopes,
+      hqManaged,
       createdAt: FieldValue.serverTimestamp(),
       createdBy: user.uid,
       accountId: accountId ?? null,
@@ -412,6 +424,7 @@ async function handleCallback(request: NextRequest, platform: SocialPlatform) {
       organisationName: stateData.organisationName ?? null,
       displayName: stateData.displayName ?? stateData.organisationName ?? null,
       scopes: stateData.scopes ?? { publish: true, analytics: true },
+      hqManaged: stateData.hqManaged === true,
       tokens: {
         accessToken: tokenResult.accessToken,
         refreshToken: tokenResult.refreshToken,

--- a/apps/web/app/crm/proposals/page.tsx
+++ b/apps/web/app/crm/proposals/page.tsx
@@ -1,9 +1,38 @@
 "use client";
-import { useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import type { User } from 'firebase/auth';
 import { httpsCallable } from 'firebase/functions';
 import { ensureFirebase, loadAuthModule } from '@/lib/firebase';
 import { fetchOrgDocs, fetchUserOrgIds } from '@/lib/crm';
+
+const SETUP_LAYOUT_LABELS: Record<string, string> = {
+  conference: 'Conference stage',
+  panel: 'Panel / fireside',
+  interview: 'Interview setup',
+  custom: 'Custom layout',
+};
+
+const SETUP_ZONE_LABELS: Record<string, string> = {
+  'stage-front': 'Stage front',
+  'stage-rear': 'Stage rear',
+  audience: 'Audience',
+  lighting: 'Lighting rig',
+  control: 'Control / steering',
+  support: 'Support areas',
+};
+
+const normaliseRichText = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value
+    .replace(/<br\s*\/?>(?=\s*<)/gi, '\n')
+    .replace(/<\/(p|div|li|h[1-6])>/gi, '\n')
+    .replace(/<li>/gi, '• ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+};
 
 /**
  * Lists proposals in the CRM pipeline. Staff can accept a proposal to
@@ -15,6 +44,7 @@ export default function ProposalsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const orgIdsRef = useRef<string[]>([]);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
@@ -96,6 +126,15 @@ export default function ProposalsPage() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!expandedId) {
+      return;
+    }
+    if (!proposals.some((proposal) => proposal.id === expandedId)) {
+      setExpandedId(null);
+    }
+  }, [expandedId, proposals]);
+
   const accept = async (id: string) => {
     if (!confirm('Accepting will create an order and may trigger task creation after payment. Continue?')) return;
 
@@ -112,6 +151,158 @@ export default function ProposalsPage() {
       console.error('Failed to accept proposal', err);
       alert(err?.message || 'Error accepting proposal');
     }
+  };
+
+  const renderSetupPlan = (plan: any) => {
+    if (!plan || typeof plan !== 'object') {
+      return null;
+    }
+    const placements = Array.isArray(plan.placements) ? plan.placements : [];
+    const hasNotes = typeof plan.notes === 'string' && plan.notes.trim().length > 0;
+    if (placements.length === 0 && !hasNotes) {
+      return null;
+    }
+    const layoutLabel = SETUP_LAYOUT_LABELS[plan.layout] || plan.layout || 'Custom layout';
+    return (
+      <div className="grid gap-1">
+        <p className="font-medium">Setup plan</p>
+        <p className="text-sm text-gray-600">Layout: {layoutLabel}</p>
+        {placements.length > 0 ? (
+          <ul className="list-disc pl-5 text-sm text-gray-600">
+            {placements.map((placement: any) => (
+              <li key={placement.id || `${placement.itemId}-${placement.zone}`}>
+                <span className="font-medium text-gray-700">{placement.itemName}</span> ×
+                {placement.quantity || 1} →{' '}
+                {SETUP_ZONE_LABELS[placement.zone] || placement.zone || 'Zone'}
+                {placement.notes ? ` (${placement.notes})` : ''}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        {hasNotes ? (
+          <p className="whitespace-pre-wrap text-sm text-gray-600">{plan.notes.trim()}</p>
+        ) : null}
+      </div>
+    );
+  };
+
+  const renderSections = (sections: any[]) => {
+    if (!Array.isArray(sections) || sections.length === 0) {
+      return null;
+    }
+    return (
+      <div className="grid gap-2">
+        <p className="font-medium">Included sections</p>
+        {sections.map((section) => {
+          const content = normaliseRichText(section?.content);
+          const summary = typeof section?.summary === 'string' ? section.summary.trim() : '';
+          return (
+            <div key={section?.id || section?.title} className="rounded-lg border border-gray-200 bg-white p-3">
+              <p className="text-sm font-semibold text-gray-800">{section?.title || section?.id}</p>
+              {summary ? (
+                <p className="text-xs uppercase tracking-wide text-gray-500">{summary}</p>
+              ) : null}
+              {content ? (
+                <p className="mt-1 whitespace-pre-wrap text-sm text-gray-600">{content}</p>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderAgreements = (agreements: any[]) => {
+    if (!Array.isArray(agreements) || agreements.length === 0) {
+      return null;
+    }
+    return (
+      <div className="grid gap-2">
+        <p className="font-medium">Agreements</p>
+        {agreements.map((agreement) => {
+          const content = normaliseRichText(agreement?.content);
+          return (
+            <div key={agreement?.id || agreement?.title} className="rounded-lg border border-gray-200 bg-white p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm font-semibold text-gray-800">{agreement?.title || agreement?.id}</p>
+                {agreement?.category ? (
+                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                    {agreement.category}
+                  </span>
+                ) : null}
+                {agreement?.requireSign ? (
+                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">
+                    Signature required
+                  </span>
+                ) : null}
+              </div>
+              {content ? (
+                <p className="mt-1 whitespace-pre-wrap text-sm text-gray-600">{content}</p>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderBranding = (proposal: any) => {
+    const color = typeof proposal?.brandColor === 'string' ? proposal.brandColor.trim() : '';
+    const logo = typeof proposal?.logoUrl === 'string' ? proposal.logoUrl : '';
+    if (!color && !logo) {
+      return null;
+    }
+    return (
+      <div className="grid gap-2">
+        <p className="font-medium">Branding</p>
+        <div className="flex flex-wrap items-center gap-3">
+          {logo ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={logo} alt="Proposal logo" className="h-12 w-12 rounded-lg border border-gray-200 object-contain" />
+          ) : null}
+          {color ? (
+            <div className="flex items-center gap-2 text-sm text-gray-600">
+              <span className="font-medium text-gray-700">Primary colour</span>
+              <span
+                aria-hidden
+                className="inline-block h-5 w-5 rounded-full border border-gray-200"
+                style={{ backgroundColor: color }}
+              />
+              <span className="font-mono text-xs text-gray-500">{color}</span>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
+  const renderDetails = (proposal: any) => {
+    const setup = renderSetupPlan(proposal?.setupPlan);
+    const sections = renderSections(proposal?.sections);
+    const agreements = renderAgreements(proposal?.agreements);
+    const branding = renderBranding(proposal);
+    const customText = typeof proposal?.customText === 'string' && proposal.customText.trim().length > 0
+      ? proposal.customText.trim()
+      : '';
+
+    if (!setup && !sections && !agreements && !branding && !customText) {
+      return <p className="text-sm text-gray-500">No additional details recorded for this proposal.</p>;
+    }
+
+    return (
+      <div className="grid gap-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
+        {customText ? (
+          <div className="grid gap-1">
+            <p className="font-medium">Intro / notes</p>
+            <p className="whitespace-pre-wrap text-sm text-gray-600">{customText}</p>
+          </div>
+        ) : null}
+        {branding}
+        {setup}
+        {sections}
+        {agreements}
+      </div>
+    );
   };
 
   if (loading) return <p>Loading…</p>;
@@ -136,20 +327,36 @@ export default function ProposalsPage() {
             </tr>
           </thead>
           <tbody>
-            {proposals.map((p) => (
-              <tr key={p.id} className="border-t">
-                <td>{p.id.substring(0, 6)}</td>
-                <td>{p.clientEmail}</td>
-                <td>{p.status}</td>
-                <td>
-                  {p.status === 'sent' && (
-                    <button className="link" onClick={() => accept(p.id)}>
-                      Accept
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
+            {proposals.map((p) => {
+              const isExpanded = expandedId === p.id;
+              return (
+                <Fragment key={p.id}>
+                  <tr className="border-t">
+                    <td>{p.id.substring(0, 6)}</td>
+                    <td>{p.clientEmail}</td>
+                    <td>{p.status}</td>
+                    <td className="flex gap-2">
+                      {p.status === 'sent' && (
+                        <button className="link" onClick={() => accept(p.id)}>
+                          Accept
+                        </button>
+                      )}
+                      <button
+                        className="link text-gray-600"
+                        onClick={() => setExpandedId(isExpanded ? null : p.id)}
+                      >
+                        {isExpanded ? 'Hide details' : 'Details'}
+                      </button>
+                    </td>
+                  </tr>
+                  {isExpanded ? (
+                    <tr>
+                      <td colSpan={4}>{renderDetails(p)}</td>
+                    </tr>
+                  ) : null}
+                </Fragment>
+              );
+            })}
           </tbody>
         </table>
       )}

--- a/apps/web/app/orgs/[orgId]/brand-guidelines/page.tsx
+++ b/apps/web/app/orgs/[orgId]/brand-guidelines/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import NextImage from "next/image";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { deleteObject, getDownloadURL, ref, uploadBytes } from "firebase/storage";
@@ -12,11 +12,33 @@ import { auth, db, ensureFirebase, storage } from "@/lib/firebase";
 import { extractUserRoles, hasRole } from "@/lib/roles";
 import {
   BrandGuidelineColors,
+  BrandGuidelineLogoAsset,
   BrandGuidelinesState,
   DEFAULT_BRAND_GUIDELINES,
   parseBrandGuidelines,
   sanitiseBrandGuidelines,
 } from "@/lib/brand-guidelines";
+
+const createLogoId = (): string =>
+  typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `logo-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+const readBlobAsDataUrl = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
+    reader.onerror = () => reject(reader.error || new Error("Failed to read file"));
+    reader.readAsDataURL(blob);
+  });
+
+const loadImageElement = (src: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = document.createElement("img");
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("Unable to load logo preview"));
+    image.src = src;
+  });
 
 interface FeedbackState {
   message: string;
@@ -35,6 +57,15 @@ export default function OrgBrandGuidelinesPage() {
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [uploadingLogo, setUploadingLogo] = useState(false);
   const [removingLogo, setRemovingLogo] = useState(false);
+  const [secondaryLogoFile, setSecondaryLogoFile] = useState<File | null>(null);
+  const [secondaryLogoName, setSecondaryLogoName] = useState("");
+  const [secondaryLogoNotes, setSecondaryLogoNotes] = useState("");
+  const [uploadingSecondaryLogo, setUploadingSecondaryLogo] = useState(false);
+  const [removingSecondaryLogoId, setRemovingSecondaryLogoId] = useState<string | null>(null);
+  const [monochromeSourceFile, setMonochromeSourceFile] = useState<File | null>(null);
+  const [monochromeGenerating, setMonochromeGenerating] = useState(false);
+  const [monochromeVariants, setMonochromeVariants] = useState<{ white?: string; black?: string }>({});
+  const [monochromeError, setMonochromeError] = useState<string | null>(null);
   const [savingGuidelines, setSavingGuidelines] = useState(false);
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [canEdit, setCanEdit] = useState(false);
@@ -101,6 +132,84 @@ export default function OrgBrandGuidelinesPage() {
       active = false;
     };
   }, [orgId]);
+
+  const persistGuidelinesSnapshot = async (next: BrandGuidelinesState) => {
+    if (!orgId) return;
+    await ensureFirebase();
+    await setDoc(
+      doc(db, "orgs", orgId),
+      { brandGuidelines: sanitiseBrandGuidelines(next), brandGuidelinesUpdatedAt: serverTimestamp() },
+      { merge: true },
+    );
+    setBrandUpdatedAt(new Date());
+  };
+
+  const convertImageToVariant = (image: HTMLImageElement, variant: "white" | "black"): string => {
+    const width = image.naturalWidth || image.width;
+    const height = image.naturalHeight || image.height;
+    if (!width || !height) {
+      throw new Error("Logo must have a valid width and height.");
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Unable to process logo. Try a different browser.");
+    }
+    context.clearRect(0, 0, width, height);
+    context.drawImage(image, 0, 0, width, height);
+    const imageData = context.getImageData(0, 0, width, height);
+    const { data } = imageData;
+    for (let index = 0; index < data.length; index += 4) {
+      const alpha = data[index + 3];
+      if (alpha === 0) {
+        continue;
+      }
+      if (variant === "white") {
+        data[index] = 255;
+        data[index + 1] = 255;
+        data[index + 2] = 255;
+      } else {
+        data[index] = 0;
+        data[index + 1] = 0;
+        data[index + 2] = 0;
+      }
+    }
+    context.putImageData(imageData, 0, 0);
+    return canvas.toDataURL("image/png");
+  };
+
+  const generateMonochromeVariants = async (source: { file?: File | null; url?: string }) => {
+    try {
+      setMonochromeGenerating(true);
+      setMonochromeError(null);
+      setMonochromeVariants({});
+      let dataUrl: string | null = null;
+      if (source.file) {
+        dataUrl = await readBlobAsDataUrl(source.file);
+      } else if (source.url) {
+        const response = await fetch(source.url);
+        if (!response.ok) {
+          throw new Error("Could not download the logo. Try uploading a file instead.");
+        }
+        const blob = await response.blob();
+        dataUrl = await readBlobAsDataUrl(blob);
+      }
+      if (!dataUrl) {
+        throw new Error("Select a logo file or upload a primary logo first.");
+      }
+      const image = await loadImageElement(dataUrl);
+      const whiteVariant = convertImageToVariant(image, "white");
+      const blackVariant = convertImageToVariant(image, "black");
+      setMonochromeVariants({ white: whiteVariant, black: blackVariant });
+    } catch (error: any) {
+      console.error("Failed to generate monochrome logos", error);
+      setMonochromeError(error?.message || "Unable to generate variants. Try a different file.");
+    } finally {
+      setMonochromeGenerating(false);
+    }
+  };
 
   const heroMetrics = useMemo(
     () => [
@@ -191,18 +300,120 @@ export default function OrgBrandGuidelinesPage() {
     }
   };
 
+  const handleSecondaryLogoFileChange = (file: File | null) => {
+    setSecondaryLogoFile(file);
+    if (file && !secondaryLogoName.trim()) {
+      const defaultName = file.name.replace(/\.[^/.]+$/, "");
+      setSecondaryLogoName(defaultName);
+    }
+  };
+
+  const handleSecondaryLogoUpload = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!orgId || !canEdit || !secondaryLogoFile) return;
+    try {
+      setUploadingSecondaryLogo(true);
+      setFeedback(null);
+      const fileName = secondaryLogoFile.name;
+      const key = `orgs/${orgId}/brand-guidelines/secondary/logo-${Date.now()}-${encodeURIComponent(fileName)}`;
+      const storageRef = ref(storage, key);
+      await uploadBytes(storageRef, secondaryLogoFile, {
+        contentType: secondaryLogoFile.type || "image/png",
+      });
+      const url = await getDownloadURL(storageRef);
+      const newLogo: BrandGuidelineLogoAsset = {
+        id: createLogoId(),
+        name: secondaryLogoName.trim() || fileName,
+        notes: secondaryLogoNotes.trim(),
+        url,
+        storagePath: key,
+      };
+      const nextGuidelines: BrandGuidelinesState = {
+        ...guidelines,
+        assets: {
+          ...guidelines.assets,
+          secondaryLogos: [...guidelines.assets.secondaryLogos, newLogo],
+        },
+      };
+      setGuidelines(nextGuidelines);
+      await persistGuidelinesSnapshot(nextGuidelines);
+      setSecondaryLogoFile(null);
+      setSecondaryLogoName("");
+      setSecondaryLogoNotes("");
+      setFeedback({ message: "Secondary logo uploaded.", tone: "success" });
+    } catch (error: any) {
+      console.error("Failed to upload secondary logo", error);
+      setFeedback({ message: error?.message || "Failed to upload secondary logo.", tone: "error" });
+    } finally {
+      setUploadingSecondaryLogo(false);
+    }
+  };
+
+  const handleSecondaryLogoRemove = async (logo: BrandGuidelineLogoAsset) => {
+    if (!orgId || !canEdit) return;
+    if (typeof window !== "undefined" && !window.confirm("Remove this secondary logo?")) {
+      return;
+    }
+    try {
+      setRemovingSecondaryLogoId(logo.id);
+      setFeedback(null);
+      if (logo.storagePath) {
+        try {
+          await deleteObject(ref(storage, logo.storagePath));
+        } catch (error) {
+          console.warn("Could not remove secondary logo from storage", error);
+        }
+      } else if (logo.url) {
+        try {
+          const url = new URL(logo.url);
+          const path = decodeURIComponent(url.pathname.replace(/^\//, ""));
+          await deleteObject(ref(storage, path));
+        } catch (error) {
+          console.warn("Could not resolve storage path for secondary logo", error);
+        }
+      }
+      const nextGuidelines: BrandGuidelinesState = {
+        ...guidelines,
+        assets: {
+          ...guidelines.assets,
+          secondaryLogos: guidelines.assets.secondaryLogos.filter((item) => item.id !== logo.id),
+        },
+      };
+      setGuidelines(nextGuidelines);
+      await persistGuidelinesSnapshot(nextGuidelines);
+      setFeedback({ message: "Secondary logo removed.", tone: "success" });
+    } catch (error: any) {
+      console.error("Failed to remove secondary logo", error);
+      setFeedback({ message: error?.message || "Failed to remove secondary logo.", tone: "error" });
+    } finally {
+      setRemovingSecondaryLogoId(null);
+    }
+  };
+
+  const handleMonochromeSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!monochromeSourceFile) {
+      setMonochromeError("Choose a logo file to convert.");
+      return;
+    }
+    await generateMonochromeVariants({ file: monochromeSourceFile });
+  };
+
+  const handleMonochromeFromPrimary = async () => {
+    if (!logoUrl) {
+      setMonochromeError("Upload your primary logo first or choose a file to convert.");
+      return;
+    }
+    await generateMonochromeVariants({ url: logoUrl });
+  };
+
   const saveGuidelines = async (event: FormEvent) => {
     event.preventDefault();
     if (!orgId || !canEdit) return;
     try {
       setSavingGuidelines(true);
       setFeedback(null);
-      await setDoc(
-        doc(db, "orgs", orgId),
-        { brandGuidelines: sanitiseBrandGuidelines(guidelines), brandGuidelinesUpdatedAt: serverTimestamp() },
-        { merge: true },
-      );
-      setBrandUpdatedAt(new Date());
+      await persistGuidelinesSnapshot(guidelines);
       setFeedback({ message: "Brand guidelines saved.", tone: "success" });
     } catch (error: any) {
       console.error("Failed to save brand guidelines", error);
@@ -271,13 +482,15 @@ export default function OrgBrandGuidelinesPage() {
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <h2 className="text-lg font-semibold text-slate-900">Brand assets</h2>
-                <p className="text-sm text-slate-500">Upload the primary logo your team should reference across projects.</p>
+                <p className="text-sm text-slate-500">
+                  Upload your primary logo, store alternate marks, and generate ready-to-use monochrome versions for overlays.
+                </p>
               </div>
             </div>
             <form onSubmit={handleLogoUpload} className="grid gap-4 lg:grid-cols-[auto_1fr] lg:items-center">
               <div className="flex items-center justify-center">
                 {logoUrl ? (
-                  <Image
+                  <NextImage
                     src={logoUrl}
                     alt="Brand logo"
                     width={120}
@@ -318,6 +531,218 @@ export default function OrgBrandGuidelinesPage() {
                 </div>
               </div>
             </form>
+            <div className="grid gap-4 rounded-2xl border border-slate-200/70 bg-slate-50/70 p-4">
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-900">Secondary logos</h3>
+                  <p className="text-sm text-slate-500">
+                    Store alternate marks, monochrome icons, or vertical layouts with usage notes for the team.
+                  </p>
+                </div>
+              </div>
+              {guidelines.assets.secondaryLogos.length ? (
+                <ul className="grid gap-3">
+                  {guidelines.assets.secondaryLogos.map((asset) => (
+                    <li
+                      key={asset.id}
+                      className="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 sm:grid-cols-[auto_1fr_auto] sm:items-center"
+                    >
+                      <div className="flex items-center justify-center">
+                        <NextImage
+                          src={asset.url}
+                          alt={asset.name || "Secondary logo"}
+                          width={96}
+                          height={96}
+                          className="h-20 w-20 rounded-xl border border-slate-200 object-contain p-2"
+                        />
+                      </div>
+                      <div className="space-y-2 text-sm text-slate-700">
+                        <div>
+                          <p className="font-semibold text-slate-900">{asset.name || "Secondary logo"}</p>
+                          <p className="mt-1 text-xs text-slate-500">
+                            {asset.notes || "Add usage notes so production knows when to pick this version."}
+                          </p>
+                        </div>
+                        <a
+                          href={asset.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          download
+                          className="inline-flex text-xs font-semibold uppercase tracking-wide text-slate-500 underline decoration-slate-300 decoration-2 underline-offset-4"
+                        >
+                          Download PNG
+                        </a>
+                      </div>
+                      {canEdit ? (
+                        <button
+                          type="button"
+                          className="btn-outline btn-sm"
+                          onClick={() => handleSecondaryLogoRemove(asset)}
+                          disabled={removingSecondaryLogoId === asset.id}
+                        >
+                          {removingSecondaryLogoId === asset.id ? "Removing…" : "Remove"}
+                        </button>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-slate-500">
+                  No secondary logos yet. Upload additional marks below to give the production team more options.
+                </p>
+              )}
+              {canEdit ? (
+                <form onSubmit={handleSecondaryLogoUpload} className="grid gap-3">
+                  <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] md:items-start">
+                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      Logo file
+                      <input
+                        className="mt-1"
+                        type="file"
+                        accept="image/*"
+                        onChange={(event) => handleSecondaryLogoFileChange(event.target.files?.[0] || null)}
+                        disabled={!canEdit}
+                      />
+                    </label>
+                    <div className="grid gap-3">
+                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Display name
+                        <input
+                          className="input mt-1"
+                          value={secondaryLogoName}
+                          onChange={(event) => setSecondaryLogoName(event.target.value)}
+                          placeholder="e.g. Monochrome icon"
+                          disabled={!canEdit}
+                        />
+                      </label>
+                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Usage notes
+                        <textarea
+                          className="input mt-1"
+                          rows={3}
+                          value={secondaryLogoNotes}
+                          onChange={(event) => setSecondaryLogoNotes(event.target.value)}
+                          placeholder="When to choose this logo, background requirements, animation notes…"
+                          disabled={!canEdit}
+                        />
+                      </label>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <button
+                      type="submit"
+                      className="btn btn-sm"
+                      disabled={!secondaryLogoFile || uploadingSecondaryLogo || !canEdit}
+                    >
+                      {uploadingSecondaryLogo ? "Uploading…" : "Upload secondary logo"}
+                    </button>
+                    {secondaryLogoFile ? (
+                      <button
+                        type="button"
+                        className="btn-outline btn-sm"
+                        onClick={() => {
+                          handleSecondaryLogoFileChange(null);
+                          setSecondaryLogoName("");
+                          setSecondaryLogoNotes("");
+                        }}
+                        disabled={uploadingSecondaryLogo}
+                      >
+                        Clear
+                      </button>
+                    ) : null}
+                  </div>
+                </form>
+              ) : null}
+            </div>
+            <div className="grid gap-4 rounded-2xl border border-slate-200/70 bg-slate-50/70 p-4">
+              <div>
+                <h3 className="text-sm font-semibold text-slate-900">Monochrome logo generator</h3>
+                <p className="mt-1 text-sm text-slate-500">
+                  Instantly convert a colour logo into all-white or all-black PNGs with preserved transparency for video overlays.
+                </p>
+              </div>
+              {monochromeError ? (
+                <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-xs text-rose-900">{monochromeError}</div>
+              ) : null}
+              <form onSubmit={handleMonochromeSubmit} className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Choose logo file
+                  <input
+                    className="mt-1"
+                    type="file"
+                    accept="image/*"
+                    onChange={(event) => {
+                      setMonochromeVariants({});
+                      setMonochromeError(null);
+                      setMonochromeSourceFile(event.target.files?.[0] || null);
+                    }}
+                  />
+                </label>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <button type="submit" className="btn btn-sm" disabled={!monochromeSourceFile || monochromeGenerating}>
+                    {monochromeGenerating ? "Generating…" : "Generate variants"}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-outline btn-sm"
+                    onClick={handleMonochromeFromPrimary}
+                    disabled={monochromeGenerating || !logoUrl}
+                  >
+                    Use saved primary logo
+                  </button>
+                </div>
+              </form>
+              {monochromeVariants.white || monochromeVariants.black ? (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {monochromeVariants.white ? (
+                    <div className="grid gap-2 rounded-2xl border border-slate-200 bg-white p-3 text-center">
+                      <div className="flex h-32 items-center justify-center rounded-xl bg-slate-900/95">
+                        <NextImage
+                          src={monochromeVariants.white}
+                          alt="White logo preview"
+                          width={240}
+                          height={120}
+                          unoptimized
+                          className="max-h-24 w-auto object-contain"
+                        />
+                      </div>
+                      <a
+                        href={monochromeVariants.white}
+                        download={`${orgName.toLowerCase().replace(/\s+/g, '-') || 'logo'}-white.png`}
+                        className="text-xs font-semibold uppercase tracking-wide text-slate-500 underline decoration-slate-300 decoration-2 underline-offset-4"
+                      >
+                        Download white PNG
+                      </a>
+                    </div>
+                  ) : null}
+                  {monochromeVariants.black ? (
+                    <div className="grid gap-2 rounded-2xl border border-slate-200 bg-white p-3 text-center">
+                      <div className="flex h-32 items-center justify-center rounded-xl bg-slate-100">
+                        <NextImage
+                          src={monochromeVariants.black}
+                          alt="Black logo preview"
+                          width={240}
+                          height={120}
+                          unoptimized
+                          className="max-h-24 w-auto object-contain"
+                        />
+                      </div>
+                      <a
+                        href={monochromeVariants.black}
+                        download={`${orgName.toLowerCase().replace(/\s+/g, '-') || 'logo'}-black.png`}
+                        className="text-xs font-semibold uppercase tracking-wide text-slate-500 underline decoration-slate-300 decoration-2 underline-offset-4"
+                      >
+                        Download black PNG
+                      </a>
+                    </div>
+                  ) : null}
+                </div>
+              ) : (
+                <p className="text-sm text-slate-500">
+                  Upload a logo file or reuse your saved primary logo to create monochrome overlays in seconds.
+                </p>
+              )}
+            </div>
           </div>
         </section>
 

--- a/apps/web/app/orgs/[orgId]/page.tsx
+++ b/apps/web/app/orgs/[orgId]/page.tsx
@@ -591,6 +591,46 @@ export default function OrgDetailPage() {
                   </div>
                 </div>
 
+                {guidelines.assets.secondaryLogos.length ? (
+                  <div className="rounded-2xl border border-slate-200/70 bg-white/90 p-5 shadow-sm">
+                    <h3 className="text-sm font-semibold text-slate-900">Secondary logos</h3>
+                    <ul className="mt-3 grid gap-3">
+                      {guidelines.assets.secondaryLogos.map((asset) => (
+                        <li
+                          key={asset.id}
+                          className="flex flex-col gap-3 rounded-2xl border border-slate-200/80 bg-slate-50/80 p-3 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                          <div className="flex items-center gap-3">
+                            <span className="flex h-14 w-14 items-center justify-center rounded-xl border border-slate-200 bg-white">
+                              <Image
+                                src={asset.url}
+                                alt={asset.name || 'Secondary logo'}
+                                width={56}
+                                height={56}
+                                className="h-14 w-14 rounded-xl object-contain p-2"
+                              />
+                            </span>
+                            <div>
+                              <p className="text-sm font-semibold text-slate-900">{asset.name || 'Secondary logo'}</p>
+                              <p className="mt-1 text-xs text-slate-500">
+                                {asset.notes || 'No usage notes yet. Add guidance in the brand guidelines workspace.'}
+                              </p>
+                            </div>
+                          </div>
+                          <a
+                            href={asset.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-xs font-semibold uppercase tracking-wide text-slate-500 underline decoration-slate-400 decoration-2 underline-offset-4"
+                          >
+                            View logo
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
                 <div className="grid gap-4 md:grid-cols-2">
                   <div className="rounded-2xl border border-slate-200/70 bg-slate-50/80 p-4">
                     <h3 className="text-sm font-semibold text-slate-900">Typography</h3>

--- a/apps/web/app/projects/[id]/tasks/page.tsx
+++ b/apps/web/app/projects/[id]/tasks/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { auth, db, ensureFirebase, functions, httpsCallable } from '@/lib/firebase';
 import {
@@ -85,6 +86,41 @@ const DETAIL_FORM_DEFAULT = {
   dueDate: '',
   assignedTo: '',
   status: 'todo',
+};
+
+const BRAND_TASK_KEYWORDS = [
+  'customer logo',
+  'customer brand colours',
+  'customer brand colors',
+  'brand guidelines',
+  'brand colour',
+  'brand color',
+];
+
+const brandTaskNoticeClasses =
+  'space-y-2 rounded-lg border border-dashed border-orange-200 bg-orange-50 p-3 text-xs text-orange-800';
+const brandTaskCtaClasses =
+  'inline-flex w-fit items-center rounded bg-orange-600 px-3 py-1 text-xs font-semibold text-white shadow-sm transition hover:bg-orange-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600';
+
+const hasStoredBrandGuidelines = (orgData: any): boolean => {
+  if (!orgData || typeof orgData !== 'object') return false;
+  if (typeof orgData.brandLogoUrl === 'string' && orgData.brandLogoUrl.trim().length > 0) {
+    return true;
+  }
+  if (orgData.brandGuidelines && typeof orgData.brandGuidelines === 'object') {
+    return Object.keys(orgData.brandGuidelines).length > 0;
+  }
+  if (orgData.brandGuidelinesUpdatedAt) {
+    return true;
+  }
+  return false;
+};
+
+const isBrandTaskTitle = (value: unknown): boolean => {
+  if (typeof value !== 'string') return false;
+  const normalised = value.trim().toLowerCase();
+  if (!normalised) return false;
+  return BRAND_TASK_KEYWORDS.some((keyword) => normalised.includes(keyword));
 };
 
 function coerceTaskDate(value: any): Date | null {
@@ -172,6 +208,11 @@ export default function ProjectTasksPage() {
   const [newCommentBody, setNewCommentBody] = useState('');
   const [commentError, setCommentError] = useState<string | null>(null);
   const [commentSubmitting, setCommentSubmitting] = useState(false);
+  const [orgBrandInfo, setOrgBrandInfo] = useState<{
+    loading: boolean;
+    hasGuidelines: boolean;
+    orgName: string | null;
+  }>({ loading: false, hasGuidelines: false, orgName: null });
 
   const franchiseMap = useMemo(() => {
     const map = new Map<string, any>();
@@ -230,6 +271,79 @@ export default function ProjectTasksPage() {
     );
     setTasks(tSnap.docs.map((d) => ({ id: d.id, ...d.data() })));
   }, [projectId]);
+
+  const brandTasks = useMemo(
+    () => tasks.filter((task) => isBrandTaskTitle(task?.title)),
+    [tasks]
+  );
+
+  const brandGuidelinesComplete = Boolean(project?.brandGuidelinesCompleted);
+
+  useEffect(() => {
+    let active = true;
+    if (!project?.orgId) {
+      setOrgBrandInfo({ loading: false, hasGuidelines: false, orgName: null });
+      return () => {
+        active = false;
+      };
+    }
+    setOrgBrandInfo((prev) => ({ ...prev, loading: true }));
+    (async () => {
+      try {
+        const orgSnap = await getDoc(doc(db, 'orgs', project.orgId));
+        if (!active) return;
+        if (!orgSnap.exists()) {
+          setOrgBrandInfo({ loading: false, hasGuidelines: false, orgName: null });
+          return;
+        }
+        const data = orgSnap.data() as any;
+        const hasGuidelines = hasStoredBrandGuidelines(data);
+        const orgName =
+          typeof data?.name === 'string' && data.name.trim().length > 0
+            ? data.name.trim()
+            : null;
+        setOrgBrandInfo({ loading: false, hasGuidelines, orgName });
+      } catch (err) {
+        console.error('Failed to load organisation brand info', err);
+        if (!active) return;
+        setOrgBrandInfo({ loading: false, hasGuidelines: false, orgName: null });
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [project?.orgId]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    if (!brandTasks.length) return;
+    const shouldComplete = brandGuidelinesComplete || orgBrandInfo.hasGuidelines;
+    if (!shouldComplete) return;
+    const pending = brandTasks.filter((task) => task.status !== 'done');
+    if (pending.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        await Promise.all(
+          pending.map((task) =>
+            updateDoc(doc(db, 'projects', projectId, 'tasks', task.id), {
+              status: 'done',
+              completedAt: serverTimestamp(),
+              autoCompleted: 'brand_guidelines',
+            })
+          )
+        );
+        if (!cancelled) {
+          await reloadTasks();
+        }
+      } catch (err) {
+        console.error('Failed to auto-complete brand guideline tasks', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [brandTasks, brandGuidelinesComplete, orgBrandInfo.hasGuidelines, projectId, reloadTasks]);
 
   const loadTaskComments = useCallback(
     async (taskId: string) => {
@@ -816,6 +930,40 @@ export default function ProjectTasksPage() {
                         <p className="text-xs text-gray-600">
                           Assigned: {task.assigneeName || 'Unassigned'}
                         </p>
+                        {isBrandTaskTitle(task.title) && (
+                          <div className={brandTaskNoticeClasses}>
+                            {!project?.orgId ? (
+                              <>
+                                <p>
+                                  Tell us which organisation this project belongs to so we can pull the correct brand assets
+                                  from your portfolio.
+                                </p>
+                                <Link href={`/projects/${projectId}`} className={brandTaskCtaClasses}>
+                                  Choose organisation
+                                </Link>
+                              </>
+                            ) : brandGuidelinesComplete || orgBrandInfo.hasGuidelines ? (
+                              <p>
+                                We already have the brand guidelines
+                                {orgBrandInfo.orgName ? ` for ${orgBrandInfo.orgName}` : ''}, so this task has been marked as
+                                complete automatically.
+                              </p>
+                            ) : (
+                              <>
+                                <p>
+                                  Open the brand guidelines form to upload your logo, fonts, and brand colours so production can
+                                  stay on-brand from the first draft.
+                                </p>
+                                <Link
+                                  href={`/projects/${projectId}/brand-wizard`}
+                                  className={brandTaskCtaClasses}
+                                >
+                                  Open brand guidelines form
+                                </Link>
+                              </>
+                            )}
+                          </div>
+                        )}
                         {isStaffOrAdmin && (
                           <div className="grid gap-2">
                             <select

--- a/apps/web/components/admin/tools/SocialSchedulerWorkspace.tsx
+++ b/apps/web/components/admin/tools/SocialSchedulerWorkspace.tsx
@@ -19,6 +19,7 @@ import {
   where,
   type DocumentData,
   type Firestore,
+  type QueryDocumentSnapshot,
 } from "firebase/firestore";
 import type { User as FirebaseUser } from "firebase/auth";
 
@@ -27,11 +28,21 @@ import SchedulerCalendar from "@/components/admin/tools/SchedulerCalendar";
 import { ensureFirebase, loadAuthModule } from "@/lib/firebase";
 import { hasRole, type RoleKey, type UserRoles } from "@/lib/roles";
 
+interface ClientOrganisation {
+  id: string;
+  name: string;
+  role: string | null;
+  isPrimary: boolean;
+}
+
 interface ClientRecord {
   id: string;
   name: string;
   email: string | null;
   company: string | null;
+  organisations: ClientOrganisation[];
+  defaultOrganisationId: string | null;
+  defaultOrganisationName: string | null;
 }
 
 interface ProjectSummary {
@@ -55,6 +66,7 @@ interface SchedulerAccount {
   platform: string;
   displayName: string;
   status: string;
+  hqManaged: boolean;
   scopes: { publish: boolean; analytics: boolean };
   providerAccountId: string | null;
   providerAccountName: string | null;
@@ -477,6 +489,7 @@ export default function SocialSchedulerWorkspace({
   const [clientError, setClientError] = useState<string | null>(null);
   const [clientSearch, setClientSearch] = useState("");
   const [selectedClientId, setSelectedClientId] = useState<string>("");
+  const [selectedOrganisationId, setSelectedOrganisationId] = useState<string>("");
   const [manualClientName, setManualClientName] = useState("");
 
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
@@ -914,11 +927,83 @@ export default function SocialSchedulerWorkspace({
               : typeof data.name === "string" && data.name.trim()
               ? data.name.trim()
               : data.email || `Client ${docSnap.id}`;
+          const membershipEntries = Array.isArray(data.memberships)
+            ? data.memberships
+                .map((entry: any) => {
+                  if (!entry || typeof entry !== "object") {
+                    return null;
+                  }
+                  const orgId =
+                    typeof entry.orgId === "string" && entry.orgId.trim().length > 0
+                      ? entry.orgId.trim()
+                      : null;
+                  if (!orgId) {
+                    return null;
+                  }
+                  const orgName =
+                    typeof entry.orgName === "string" && entry.orgName.trim().length > 0
+                      ? entry.orgName.trim()
+                      : null;
+                  const role =
+                    typeof entry.role === "string" && entry.role.trim().length > 0
+                      ? entry.role.trim()
+                      : null;
+                  return { id: orgId, name: orgName, role };
+                })
+                .filter((entry): entry is { id: string; name: string | null; role: string | null } => entry !== null)
+            : [];
+          const primaryOrganisationId =
+            typeof data.organisationId === "string" && data.organisationId.trim().length > 0
+              ? data.organisationId.trim()
+              : null;
+          const primaryOrganisationName =
+            typeof data.organisation === "string" && data.organisation.trim().length > 0
+              ? data.organisation.trim()
+              : null;
+          const organisationsMap = new Map<string, ClientOrganisation>();
+          membershipEntries.forEach((entry, index) => {
+            organisationsMap.set(entry.id, {
+              id: entry.id,
+              name: entry.name ?? `Organisation ${index + 1}`,
+              role: entry.role,
+              isPrimary: entry.id === primaryOrganisationId,
+            });
+          });
+          if (primaryOrganisationId && !organisationsMap.has(primaryOrganisationId)) {
+            organisationsMap.set(primaryOrganisationId, {
+              id: primaryOrganisationId,
+              name: primaryOrganisationName ?? data.company ?? name,
+              role: null,
+              isPrimary: true,
+            });
+          } else if (primaryOrganisationId) {
+            const existing = organisationsMap.get(primaryOrganisationId);
+            if (existing) {
+              organisationsMap.set(primaryOrganisationId, {
+                ...existing,
+                name: existing.name || primaryOrganisationName || data.company || name,
+                isPrimary: true,
+              });
+            }
+          }
+          const organisations = Array.from(organisationsMap.values()).map((org, index) => ({
+            ...org,
+            name: org.name || `Organisation ${index + 1}`,
+          }));
+          const defaultOrganisationId =
+            primaryOrganisationId || organisations.find((org) => org.isPrimary)?.id || organisations[0]?.id || null;
+          const defaultOrganisationName =
+            (defaultOrganisationId && organisationsMap.get(defaultOrganisationId)?.name) ||
+            primaryOrganisationName ||
+            null;
           return {
             id: docSnap.id,
             name,
             email: typeof data.email === "string" ? data.email : null,
             company: typeof data.company === "string" ? data.company : null,
+            organisations,
+            defaultOrganisationId,
+            defaultOrganisationName,
           } satisfies ClientRecord;
         });
         results.sort((a, b) => a.name.localeCompare(b.name));
@@ -956,18 +1041,62 @@ export default function SocialSchedulerWorkspace({
   }, [dbRef, firebaseReady]);
 
   useEffect(() => {
-    if (!dbRef || !selectedClientId) {
+    if (!dbRef) {
+      return;
+    }
+
+    const resolvedClient = selectedClientId
+      ? clients.find((client) => client.id === selectedClientId) || null
+      : null;
+
+    const orgIds = selectedOrganisationId
+      ? [selectedOrganisationId]
+      : resolvedClient
+      ? resolvedClient.organisations.map((org) => org.id).filter((id): id is string => Boolean(id))
+      : [];
+
+    if (orgIds.length === 0 && !selectedClientId) {
       setProjects([]);
       setSelectedProjectId("");
       setManualProjectName("");
       return;
     }
+
     setProjectLoading(true);
-    getDocs(
-      query(collection(dbRef, "projects"), where("userId", "==", selectedClientId), orderBy("createdAt", "desc"), limit(50))
-    )
-      .then((snapshot) => {
-        const records: ProjectSummary[] = snapshot.docs.map((docSnap) => {
+
+    const fetchByOrganisation = async () => {
+      const queries = orgIds.map((orgId) =>
+        getDocs(
+          query(
+            collection(dbRef, "projects"),
+            where("organisationId", "==", orgId),
+            orderBy("createdAt", "desc"),
+            limit(20)
+          )
+        )
+      );
+      const snapshots = await Promise.all(queries);
+      return snapshots.flatMap((snapshot) => snapshot.docs);
+    };
+
+    const fetchFallbackByUser = async () =>
+      getDocs(
+        query(collection(dbRef, "projects"), where("userId", "==", selectedClientId), orderBy("createdAt", "desc"), limit(50))
+      ).then((snapshot) => snapshot.docs);
+
+    (async () => {
+      try {
+        let docs: QueryDocumentSnapshot<DocumentData>[];
+        if (orgIds.length > 0) {
+          docs = await fetchByOrganisation();
+          if (docs.length === 0 && selectedClientId) {
+            docs = await fetchFallbackByUser();
+          }
+        } else {
+          docs = await fetchFallbackByUser();
+        }
+
+        const records: ProjectSummary[] = docs.map((docSnap) => {
           const data = docSnap.data() as DocumentData;
           const name =
             typeof data.name === "string" && data.name.trim()
@@ -989,12 +1118,13 @@ export default function SocialSchedulerWorkspace({
           return bTime - aTime;
         });
         setProjects(records);
-      })
-      .catch((error) => {
+      } catch (error) {
         console.error("Failed to load projects", error);
-      })
-      .finally(() => setProjectLoading(false));
-  }, [dbRef, selectedClientId]);
+      } finally {
+        setProjectLoading(false);
+      }
+    })();
+  }, [dbRef, clients, selectedClientId, selectedOrganisationId]);
   useEffect(() => {
     if (!dbRef) return;
     setAccountsLoading(true);
@@ -1058,6 +1188,7 @@ export default function SocialSchedulerWorkspace({
               ) ?? null,
             updatedAt: toDate(connectionData.updatedAt ?? data.updatedAt),
           };
+          const hqManaged = data.hqManaged === true;
           return {
             id: docSnap.id,
             organisationId: normaliseText(data.organisationId) ?? null,
@@ -1065,6 +1196,7 @@ export default function SocialSchedulerWorkspace({
             platform: normaliseText(data.platform) ?? "unknown",
             displayName: normaliseText(data.displayName) ?? `Account ${docSnap.id}`,
             status: normaliseText(data.status) ?? "active",
+            hqManaged,
             scopes,
             providerAccountId:
               normaliseText(
@@ -1262,12 +1394,82 @@ export default function SocialSchedulerWorkspace({
   const filteredClients = useMemo(() => {
     if (!clientSearch.trim()) return clients;
     const term = clientSearch.trim().toLowerCase();
-    return clients.filter((client) => client.name.toLowerCase().includes(term));
+    return clients.filter((client) => {
+      if (client.name.toLowerCase().includes(term)) {
+        return true;
+      }
+      if (client.email && client.email.toLowerCase().includes(term)) {
+        return true;
+      }
+      return client.organisations.some((org) => org.name.toLowerCase().includes(term));
+    });
   }, [clients, clientSearch]);
 
   const selectedClient = selectedClientId
     ? clients.find((client) => client.id === selectedClientId) || null
     : null;
+
+  const selectedOrganisation = selectedOrganisationId && selectedClient
+    ? selectedClient.organisations.find((org) => org.id === selectedOrganisationId) || null
+    : selectedClient?.organisations.find((org) => org.isPrimary) || null;
+
+  const [organisationOverrideTouched, setOrganisationOverrideTouched] = useState(false);
+
+  const organisationOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const options: Array<{ id: string; label: string }> = [];
+    clients.forEach((client) => {
+      client.organisations.forEach((org) => {
+        if (!org.id || seen.has(org.id)) {
+          return;
+        }
+        seen.add(org.id);
+        const label = client.name
+          ? `${org.name} — ${client.name}`
+          : org.name;
+        options.push({ id: org.id, label });
+      });
+    });
+    options.sort((a, b) => a.label.localeCompare(b.label));
+    if (selectedOrganisationId && !seen.has(selectedOrganisationId)) {
+      const fallbackLabel = selectedOrganisation?.name || manualClientName || "Selected organisation";
+      options.unshift({ id: selectedOrganisationId, label: fallbackLabel });
+    }
+    return options;
+  }, [clients, selectedOrganisationId, selectedOrganisation, manualClientName]);
+
+  useEffect(() => {
+    if (!selectedClient) {
+      setSelectedOrganisationId("");
+      if (!organisationOverrideTouched) {
+        setManualClientName("");
+      }
+      return;
+    }
+
+    const hasSelection =
+      selectedOrganisationId && selectedClient.organisations.some((org) => org.id === selectedOrganisationId);
+    if (hasSelection) {
+      return;
+    }
+
+    const fallbackId =
+      selectedClient.defaultOrganisationId ||
+      selectedClient.organisations.find((org) => org.isPrimary)?.id ||
+      selectedClient.organisations[0]?.id ||
+      "";
+    setSelectedOrganisationId(fallbackId || "");
+
+    if (!organisationOverrideTouched) {
+      const fallbackOrg =
+        (fallbackId && selectedClient.organisations.find((org) => org.id === fallbackId)) ||
+        selectedClient.organisations.find((org) => org.isPrimary) ||
+        null;
+      if (fallbackOrg?.name) {
+        setManualClientName(fallbackOrg.name);
+      }
+    }
+  }, [selectedClient, selectedOrganisationId, organisationOverrideTouched]);
 
   const selectedProject = selectedProjectId
     ? projects.find((project) => project.id === selectedProjectId) || null
@@ -1293,9 +1495,17 @@ export default function SocialSchedulerWorkspace({
   const canEditFlags = allowFlagEditing && hasRole(roles, "admin");
 
   const exportablePosts = useMemo(() => {
-    if (!selectedClientId) return posts;
-    return posts.filter((post) => post.organisationId === selectedClientId);
-  }, [posts, selectedClientId]);
+    if (selectedOrganisationId) {
+      return posts.filter((post) => post.organisationId === selectedOrganisationId);
+    }
+    if (selectedClient) {
+      const membershipIds = selectedClient.organisations.map((org) => org.id);
+      if (membershipIds.length > 0) {
+        return posts.filter((post) => post.organisationId && membershipIds.includes(post.organisationId));
+      }
+    }
+    return posts;
+  }, [posts, selectedOrganisationId, selectedClient]);
 
   const analyticsSummary = useMemo(() => {
     const totals = {
@@ -1375,14 +1585,14 @@ export default function SocialSchedulerWorkspace({
       return;
     }
 
-    const organisationId = account?.organisationId ?? selectedClient?.id ?? null;
+    const organisationId = account?.organisationId ?? selectedOrganisation?.id ?? null;
     const organisationName =
       account?.organisationName ??
-      selectedClient?.name ??
-      (manualClientName.trim() || null);
+      selectedOrganisation?.name ??
+      (manualClientName.trim() || selectedClient?.company || selectedClient?.name || null);
 
     if (!organisationId && !organisationName) {
-      setAccountError("Select a client or enter an organisation name before connecting an account.");
+      setAccountError("Select an organisation or provide an override name before connecting an account.");
       return;
     }
 
@@ -1418,6 +1628,10 @@ export default function SocialSchedulerWorkspace({
 
     if (account?.id) {
       authUrl.searchParams.set("accountId", account.id);
+    }
+
+    if (account?.hqManaged) {
+      authUrl.searchParams.set("hqManaged", "true");
     }
 
     setAccountError(null);
@@ -1465,11 +1679,12 @@ export default function SocialSchedulerWorkspace({
   async function handleCreatePost(event: FormEvent) {
     event.preventDefault();
     if (!dbRef) return;
-    const organisationId = selectedClient?.id ?? null;
+    const organisationId = selectedOrganisation?.id ?? null;
     const organisationName =
-      selectedClient?.name ?? (manualClientName.trim() || null);
+      selectedOrganisation?.name ??
+      (manualClientName.trim() || selectedClient?.company || selectedClient?.name || null);
     if (!organisationName) {
-      setPostError("Select or enter a client before drafting a post.");
+      setPostError("Select an organisation or provide an override before drafting a post.");
       return;
     }
     const scheduledAt = postForm.scheduledAtInput ? new Date(postForm.scheduledAtInput) : null;
@@ -1875,7 +2090,7 @@ export default function SocialSchedulerWorkspace({
               <table className="min-w-full divide-y divide-slate-200 text-sm">
   <thead className="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
   <tr>
-    <th className="p-2">Client</th>
+                  <th className="p-2">Organisation</th>
     <th className="p-2">Platform</th>
     <th className="p-2">Permissions</th>
     <th className="p-2">Connection</th>
@@ -2133,7 +2348,10 @@ export default function SocialSchedulerWorkspace({
       />
       <select
         value={selectedClientId}
-        onChange={(event) => setSelectedClientId(event.target.value)}
+        onChange={(event) => {
+          setSelectedClientId(event.target.value);
+          setOrganisationOverrideTouched(false);
+        }}
         className="mt-2 w-full rounded border px-3 py-2"
       >
         <option value="">Select a client (optional)</option>
@@ -2145,11 +2363,47 @@ export default function SocialSchedulerWorkspace({
       </select>
     </label>
     <label className="text-sm">
+      <span className="font-medium">Organisation</span>
+      <select
+        value={selectedOrganisationId}
+        onChange={(event) => {
+          const value = event.target.value;
+          setSelectedOrganisationId(value);
+          setOrganisationOverrideTouched(false);
+          if (value && selectedClient) {
+            const match = selectedClient.organisations.find((org) => org.id === value);
+            if (match?.name) {
+              setManualClientName(match.name);
+            }
+          }
+        }}
+        className="mt-1 w-full rounded border px-3 py-2"
+        disabled={!selectedClient || selectedClient.organisations.length === 0}
+      >
+        <option value="">Select an organisation</option>
+        {selectedClient?.organisations.map((org) => (
+          <option key={org.id} value={org.id}>
+            {org.name}
+            {org.role ? ` · ${org.role}` : ""}
+          </option>
+        ))}
+      </select>
+      {selectedClient && selectedClient.organisations.length === 0 ? (
+        <span className="mt-1 block text-xs text-slate-500">
+          No organisation memberships detected. Use the override field below.
+        </span>
+      ) : null}
+    </label>
+    <label className="text-sm">
       <span className="font-medium">Organisation name override</span>
       <input
         type="text"
         value={manualClientName}
-        onChange={(event) => setManualClientName(event.target.value)}
+        onChange={(event) => {
+          const value = event.target.value;
+          setManualClientName(value);
+          setOrganisationOverrideTouched(value.trim().length > 0);
+        }}
         placeholder="Use when the client is not yet in CRM"
         className="mt-1 w-full rounded border px-3 py-2"
       />
@@ -2213,7 +2467,7 @@ export default function SocialSchedulerWorkspace({
             <table className="min-w-full divide-y divide-slate-200 text-sm">
               <thead className="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
                 <tr>
-                  <th className="p-2">Client</th>
+                  <th className="p-2">Organisation</th>
                   <th className="p-2">Platform</th>
                   <th className="p-2">Connection</th>
                   <th className="p-2">Permissions</th>
@@ -2241,6 +2495,11 @@ export default function SocialSchedulerWorkspace({
                       <td className="p-2 align-top">
                         <div className="font-medium text-gray-900">
                           {account.organisationName || account.organisationId || "Unknown"}
+                          {account.hqManaged ? (
+                            <span className="ml-2 inline-flex items-center rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-700">
+                              HQ
+                            </span>
+                          ) : null}
                         </div>
                         <div className="text-xs text-gray-500">{account.displayName}</div>
                       </td>
@@ -2512,29 +2771,69 @@ export default function SocialSchedulerWorkspace({
           <form className="grid gap-4 rounded border border-slate-200 p-4" onSubmit={handleCreatePost}>
             <h3 className="text-sm font-semibold text-gray-900">Create draft</h3>
             <div className="grid gap-4 md:grid-cols-2">
-              <label className="text-sm">
-                <span className="font-medium">Client</span>
-                <select
-                  value={selectedClientId}
-                  onChange={(event) => setSelectedClientId(event.target.value)}
-                  className="mt-1 w-full rounded border px-3 py-2"
-                >
-                  <option value="">Select a client</option>
-                  {clients.map((client) => (
-                    <option key={client.id} value={client.id}>
-                      {client.name}
-                    </option>
-                  ))}
-                </select>
-                {clientLoading ? <span className="mt-1 block text-xs text-gray-500">Loading clients…</span> : null}
-              </label>
+            <label className="text-sm">
+              <span className="font-medium">Client</span>
+              <select
+                value={selectedClientId}
+                onChange={(event) => {
+                  setSelectedClientId(event.target.value);
+                  setOrganisationOverrideTouched(false);
+                }}
+                className="mt-1 w-full rounded border px-3 py-2"
+              >
+                <option value="">Select a client</option>
+                {clients.map((client) => (
+                  <option key={client.id} value={client.id}>
+                    {client.name}
+                  </option>
+                ))}
+              </select>
+              {clientLoading ? <span className="mt-1 block text-xs text-gray-500">Loading clients…</span> : null}
+            </label>
 
-              <label className="text-sm">
-                <span className="font-medium">Manual client label</span>
-                <input
-                  type="text"
+            <label className="text-sm">
+              <span className="font-medium">Organisation</span>
+              <select
+                value={selectedOrganisationId}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setSelectedOrganisationId(value);
+                  setOrganisationOverrideTouched(false);
+                  if (value && selectedClient) {
+                    const match = selectedClient.organisations.find((org) => org.id === value);
+                    if (match?.name) {
+                      setManualClientName(match.name);
+                    }
+                  }
+                }}
+                className="mt-1 w-full rounded border px-3 py-2"
+                disabled={!selectedClient || selectedClient.organisations.length === 0}
+              >
+                <option value="">Select an organisation</option>
+                {selectedClient?.organisations.map((org) => (
+                  <option key={org.id} value={org.id}>
+                    {org.name}
+                    {org.role ? ` · ${org.role}` : ""}
+                  </option>
+                ))}
+              </select>
+              {selectedClient && selectedClient.organisations.length === 0 ? (
+                <span className="mt-1 block text-xs text-gray-500">
+                  No organisation memberships detected. Use the manual label field.
+                </span>
+              ) : null}
+            </label>
+
+            <label className="text-sm">
+              <span className="font-medium">Organisation label override</span>
+              <input
+                type="text"
                   value={manualClientName}
-                  onChange={(event) => setManualClientName(event.target.value)}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setManualClientName(value);
+                    setOrganisationOverrideTouched(value.trim().length > 0);
+                  }}
                   className="mt-1 w-full rounded border px-3 py-2"
                   placeholder="Use if the client is not listed"
                 />
@@ -3078,16 +3377,16 @@ export default function SocialSchedulerWorkspace({
 
           <div className="flex flex-wrap items-center gap-3">
             <label className="text-sm">
-              <span className="mr-2 font-medium">Filter by client</span>
+              <span className="mr-2 font-medium">Filter by organisation</span>
               <select
-                value={selectedClientId}
-                onChange={(event) => setSelectedClientId(event.target.value)}
+                value={selectedOrganisationId}
+                onChange={(event) => setSelectedOrganisationId(event.target.value)}
                 className="rounded border px-3 py-2"
               >
-                <option value="">All clients</option>
-                {clients.map((client) => (
-                  <option key={client.id} value={client.id}>
-                    {client.name}
+                <option value="">All organisations</option>
+                {organisationOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
                   </option>
                 ))}
               </select>
@@ -3115,7 +3414,7 @@ export default function SocialSchedulerWorkspace({
             <table className="min-w-full divide-y divide-slate-200 text-sm">
               <thead className="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
                 <tr>
-                  <th className="p-2">Client</th>
+                  <th className="p-2">Organisation</th>
                   <th className="p-2">Deliverable</th>
                   <th className="p-2">Platforms</th>
                   <th className="p-2">Scheduled</th>

--- a/apps/web/lib/brand-guidelines.ts
+++ b/apps/web/lib/brand-guidelines.ts
@@ -5,6 +5,18 @@ export interface BrandGuidelineFonts {
   headingStyle: string;
 }
 
+export interface BrandGuidelineLogoAsset {
+  id: string;
+  name: string;
+  url: string;
+  notes: string;
+  storagePath?: string;
+}
+
+export interface BrandGuidelineAssets {
+  secondaryLogos: BrandGuidelineLogoAsset[];
+}
+
 export interface BrandGuidelineColors {
   primary: string;
   secondary: string;
@@ -25,6 +37,7 @@ export interface BrandGuidelineImagery {
 
 export interface BrandGuidelinesState {
   fonts: BrandGuidelineFonts;
+  assets: BrandGuidelineAssets;
   colors: BrandGuidelineColors;
   voice: BrandGuidelineVoice;
   imagery: BrandGuidelineImagery;
@@ -36,6 +49,9 @@ export const DEFAULT_BRAND_GUIDELINES: BrandGuidelinesState = {
     secondary: "",
     accent: "",
     headingStyle: "Poppins Bold for headings, Regular for body copy",
+  },
+  assets: {
+    secondaryLogos: [],
   },
   colors: {
     primary: "#215696",
@@ -75,6 +91,29 @@ export const parseBrandGuidelines = (
       accent: normaliseGuidelineString(source?.fonts?.accent) || defaults.fonts.accent,
       headingStyle: fallbackString(source?.fonts?.headingStyle, defaults.fonts.headingStyle),
     },
+    assets: {
+      secondaryLogos: Array.isArray(source?.assets?.secondaryLogos)
+        ? source.assets.secondaryLogos
+            .map((logo: any): BrandGuidelineLogoAsset | null => {
+              if (!logo || typeof logo !== "object") {
+                return null;
+              }
+              const id = normaliseGuidelineString(logo.id) || normaliseGuidelineString(logo.key) || "";
+              const url = normaliseGuidelineString(logo.url);
+              if (!id || !url) {
+                return null;
+              }
+              return {
+                id,
+                name: fallbackString(logo.name, normaliseGuidelineString(logo.fileName) || "Secondary logo"),
+                url,
+                notes: normaliseGuidelineString(logo.notes),
+                storagePath: normaliseGuidelineString(logo.storagePath),
+              };
+            })
+            .filter((logo: BrandGuidelineLogoAsset | null): logo is BrandGuidelineLogoAsset => Boolean(logo))
+        : defaults.assets.secondaryLogos,
+    },
     colors: {
       primary: String(source?.colors?.primary || defaults.colors.primary),
       secondary: String(source?.colors?.secondary || defaults.colors.secondary),
@@ -101,6 +140,19 @@ export const sanitiseBrandGuidelines = (
     secondary: normaliseGuidelineString(value.fonts.secondary),
     accent: normaliseGuidelineString(value.fonts.accent),
     headingStyle: normaliseGuidelineString(value.fonts.headingStyle),
+  },
+  assets: {
+    secondaryLogos: Array.isArray(value.assets.secondaryLogos)
+      ? value.assets.secondaryLogos
+          .map((logo) => ({
+            id: normaliseGuidelineString(logo.id),
+            name: normaliseGuidelineString(logo.name),
+            url: normaliseGuidelineString(logo.url),
+            notes: normaliseGuidelineString(logo.notes),
+            storagePath: normaliseGuidelineString(logo.storagePath),
+          }))
+          .filter((logo) => Boolean(logo.id && logo.url))
+      : [],
   },
   colors: {
     primary: normaliseGuidelineString(value.colors.primary) || DEFAULT_BRAND_GUIDELINES.colors.primary,

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -516,6 +516,7 @@ async function storeSocialAccountCredentials(payload) {
     const scopes = coerceScopes(payload.scopes);
     const organisationId = normaliseString(payload.organisationId);
     const organisationName = normaliseString(payload.organisationName);
+    const hqManaged = payload.hqManaged === true;
     const initiatorUid = normaliseString(payload.initiator?.uid);
     const initiatorEmail = normaliseString(payload.initiator?.email);
     const requestedBy = normaliseString(payload.requestedBy);
@@ -559,6 +560,7 @@ async function storeSocialAccountCredentials(payload) {
             organisationName: organisationName ?? null,
             displayName,
             status,
+            hqManaged,
             scopes: { publish: scopes.publish, analytics: scopes.analytics },
             provider: {
                 accountId: providerAccountId ?? null,
@@ -602,6 +604,7 @@ async function storeSocialAccountCredentials(payload) {
             platform,
             organisationId: organisationId ?? null,
             organisationName: organisationName ?? null,
+            hqManaged,
             current: {
                 accessToken: encryptedAccess,
                 refreshToken: encryptedRefresh,

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -11126,13 +11126,15 @@ export const admin_assignWorkflow = functions.https.onCall(async (data, context)
  */
 export const admin_createProposal = functions.https.onCall(async (data, context) => {
     await assertStaff(context, ['admin', 'sales']);
-    const { orgId, clientEmail, items = [], agreementIds = [], sectionIds = [], templateId, customText, setupPlan, } = data;
+    const { orgId, clientEmail, items = [], agreementIds = [], sectionIds = [], templateId, customText, setupPlan, brandColor: rawBrandColor, logoUrl: rawLogoUrl, } = data;
     if (!orgId || !clientEmail) {
         throw new functions.https.HttpsError('invalid-argument', 'orgId and clientEmail required');
     }
     let finalItems = Array.isArray(items) ? items : [];
     let finalAgreements = Array.isArray(agreementIds) ? agreementIds : [];
     let finalSections = Array.isArray(sectionIds) ? sectionIds : [];
+    let brandColor = typeof rawBrandColor === 'string' ? rawBrandColor.trim() : '';
+    let logoUrl = typeof rawLogoUrl === 'string' ? rawLogoUrl.trim() : '';
     if (templateId) {
         const tplSnap = await db.collection('proposalTemplates').doc(templateId).get();
         if (tplSnap.exists) {
@@ -11144,11 +11146,62 @@ export const admin_createProposal = functions.https.onCall(async (data, context)
             if (tpl.sectionIds) {
                 finalSections = Array.from(new Set([...tpl.sectionIds, ...finalSections]));
             }
+            if (!brandColor && typeof tpl.brandColor === 'string') {
+                brandColor = tpl.brandColor.trim();
+            }
+            if (!logoUrl && typeof tpl.logoUrl === 'string') {
+                logoUrl = tpl.logoUrl.trim();
+            }
         }
     }
     const serviceIds = finalItems
         .filter((i) => i.type === 'product' && i.productId)
         .map((i) => i.productId);
+    const [sectionDocs, agreementDocs] = await Promise.all([
+        Promise.all(finalSections.map((id) => db.collection('proposalSections').doc(id).get())),
+        Promise.all(finalAgreements.map((id) => db.collection('agreements').doc(id).get())),
+    ]);
+    const sections = sectionDocs
+        .filter((snap) => snap.exists)
+        .map((snap) => {
+        const section = snap.data();
+        const title = typeof section?.title === 'string' ? section.title : snap.id;
+        const content = typeof section?.content === 'string' ? section.content : '';
+        const summary = typeof section?.summary === 'string' ? section.summary : undefined;
+        return {
+            id: snap.id,
+            title,
+            content,
+            summary: summary || undefined,
+        };
+    });
+    const agreements = agreementDocs
+        .filter((snap) => snap.exists)
+        .map((snap) => {
+        const agreement = snap.data();
+        const title = typeof agreement?.title === 'string' ? agreement.title : snap.id;
+        const content = typeof agreement?.content === 'string' ? agreement.content : '';
+        const category = typeof agreement?.category === 'string' ? agreement.category : undefined;
+        const requireSign = agreement?.requireSign === true;
+        return {
+            id: snap.id,
+            title,
+            content,
+            category: category || undefined,
+            requireSign,
+        };
+    });
+    const terms = agreements
+        .map((agreement) => {
+        const heading = agreement.title?.trim();
+        const body = agreement.content?.trim();
+        if (heading && body) {
+            return `${heading}\n\n${body}`;
+        }
+        return heading || body || null;
+    })
+        .filter((value) => Boolean(value && value.trim()))
+        .join('\n\n---\n\n');
     const normalizedSetupPlan = (() => {
         if (!setupPlan || typeof setupPlan !== 'object')
             return null;
@@ -11201,6 +11254,11 @@ export const admin_createProposal = functions.https.onCall(async (data, context)
         serviceIds,
         customText: customText || '',
         setupPlan: normalizedSetupPlan,
+        sections,
+        agreements,
+        terms: terms || null,
+        brandColor: brandColor || null,
+        logoUrl: logoUrl || null,
         status: 'sent',
         createdAt: admin.firestore.FieldValue.serverTimestamp()
     };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12936,6 +12936,8 @@ export const admin_createProposal = functions.https.onCall(async (data: any, con
     templateId,
     customText,
     setupPlan,
+    brandColor: rawBrandColor,
+    logoUrl: rawLogoUrl,
   } = data;
   if (!orgId || !clientEmail) {
     throw new functions.https.HttpsError('invalid-argument', 'orgId and clientEmail required');
@@ -12944,6 +12946,9 @@ export const admin_createProposal = functions.https.onCall(async (data: any, con
   let finalItems: any[] = Array.isArray(items) ? items : [];
   let finalAgreements: string[] = Array.isArray(agreementIds) ? agreementIds : [];
   let finalSections: string[] = Array.isArray(sectionIds) ? sectionIds : [];
+  let brandColor = typeof rawBrandColor === 'string' ? rawBrandColor.trim() : '';
+  let logoUrl = typeof rawLogoUrl === 'string' ? rawLogoUrl.trim() : '';
+
   if (templateId) {
     const tplSnap = await db.collection('proposalTemplates').doc(templateId).get();
     if (tplSnap.exists) {
@@ -12955,12 +12960,71 @@ export const admin_createProposal = functions.https.onCall(async (data: any, con
       if (tpl.sectionIds) {
         finalSections = Array.from(new Set([...(tpl.sectionIds as string[]), ...finalSections]));
       }
+      if (!brandColor && typeof tpl.brandColor === 'string') {
+        brandColor = tpl.brandColor.trim();
+      }
+      if (!logoUrl && typeof tpl.logoUrl === 'string') {
+        logoUrl = tpl.logoUrl.trim();
+      }
     }
   }
 
   const serviceIds = finalItems
     .filter((i) => i.type === 'product' && i.productId)
     .map((i) => i.productId);
+
+  const [sectionDocs, agreementDocs] = await Promise.all([
+    Promise.all(
+      finalSections.map((id) => db.collection('proposalSections').doc(id).get())
+    ),
+    Promise.all(
+      finalAgreements.map((id) => db.collection('agreements').doc(id).get())
+    ),
+  ]);
+
+  const sections = sectionDocs
+    .filter((snap) => snap.exists)
+    .map((snap) => {
+      const section = snap.data() as Record<string, any>;
+      const title = typeof section?.title === 'string' ? section.title : snap.id;
+      const content = typeof section?.content === 'string' ? section.content : '';
+      const summary = typeof section?.summary === 'string' ? section.summary : undefined;
+      return {
+        id: snap.id,
+        title,
+        content,
+        summary: summary || undefined,
+      };
+    });
+
+  const agreements = agreementDocs
+    .filter((snap) => snap.exists)
+    .map((snap) => {
+      const agreement = snap.data() as Record<string, any>;
+      const title = typeof agreement?.title === 'string' ? agreement.title : snap.id;
+      const content = typeof agreement?.content === 'string' ? agreement.content : '';
+      const category = typeof agreement?.category === 'string' ? agreement.category : undefined;
+      const requireSign = agreement?.requireSign === true;
+      return {
+        id: snap.id,
+        title,
+        content,
+        category: category || undefined,
+        requireSign,
+      };
+    });
+
+  const terms = agreements
+    .map((agreement) => {
+      const heading = agreement.title?.trim();
+      const body = agreement.content?.trim();
+      if (heading && body) {
+        return `${heading}\n\n${body}`;
+      }
+      return heading || body || null;
+    })
+    .filter((value): value is string => Boolean(value && value.trim()))
+    .join('\n\n---\n\n');
 
   const normalizedSetupPlan = (() => {
     if (!setupPlan || typeof setupPlan !== 'object') return null;
@@ -13013,6 +13077,11 @@ export const admin_createProposal = functions.https.onCall(async (data: any, con
     serviceIds,
     customText: customText || '',
     setupPlan: normalizedSetupPlan,
+    sections,
+    agreements,
+    terms: terms || null,
+    brandColor: brandColor || null,
+    logoUrl: logoUrl || null,
     status: 'sent',
     createdAt: admin.firestore.FieldValue.serverTimestamp()
   };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -454,6 +454,7 @@ type StoreSocialAccountCredentialRequest = {
   provider?: SocialAccountProviderInput;
   initiator?: { uid?: string | null; email?: string | null } | null;
   requestedBy?: string | null;
+  hqManaged?: boolean | null;
 };
 
 type StoreSocialAccountCredentialResponse = {
@@ -683,6 +684,7 @@ async function storeSocialAccountCredentials(
   const scopes = coerceScopes(payload.scopes);
   const organisationId = normaliseString(payload.organisationId);
   const organisationName = normaliseString(payload.organisationName);
+  const hqManaged = payload.hqManaged === true;
   const initiatorUid = normaliseString(payload.initiator?.uid);
   const initiatorEmail = normaliseString(payload.initiator?.email);
   const requestedBy = normaliseString(payload.requestedBy);
@@ -740,6 +742,7 @@ async function storeSocialAccountCredentials(
       organisationName: organisationName ?? null,
       displayName,
       status,
+      hqManaged,
       scopes: { publish: scopes.publish, analytics: scopes.analytics },
       provider: {
         accountId: providerAccountId ?? null,
@@ -787,6 +790,7 @@ async function storeSocialAccountCredentials(
       platform,
       organisationId: organisationId ?? null,
       organisationName: organisationName ?? null,
+      hqManaged,
       current: {
         accessToken: encryptedAccess,
         refreshToken: encryptedRefresh,


### PR DESCRIPTION
## Summary
- detect customer-facing brand asset tasks and load organisation branding details
- auto-complete brand guideline tasks when an organisation already has saved branding
- provide customers with direct links to choose an organisation or open the brand guidelines form from relevant tasks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3a4c74d8c832386f802f986567be2