### PR TITLE
Add deliverable quantities for product variations

### DIFF
--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -469,6 +469,12 @@ type VariationFormState = {
   tier2Price: string;
   tier3Price: string;
   featuresText: string;
+  onsiteDays: string;
+  onsiteSetupMinutes: string;
+  onsiteShootMinutes: string;
+  onsiteBreakdownMinutes: string;
+  onsiteWindowStart: string;
+  onsiteWindowEnd: string;
   budgetOverrides: BudgetOverrideFormState;
   crewOverrides: Record<string, CrewOverrideFormState>;
 };
@@ -516,6 +522,42 @@ const buildVariationFormState = (
     tier3Price:
       typeof tier3 === "number" && Number.isFinite(tier3) ? String(tier3) : "",
     featuresText: features.join("\n"),
+    onsiteDays:
+      typeof variation?.onsiteDays === "number" &&
+      Number.isFinite(variation.onsiteDays)
+        ? String(variation.onsiteDays)
+        : typeof variation?.onsiteDays === "string"
+          ? variation.onsiteDays
+          : "",
+    onsiteSetupMinutes:
+      typeof variation?.onsiteSetupMinutes === "number" &&
+      Number.isFinite(variation.onsiteSetupMinutes)
+        ? String(variation.onsiteSetupMinutes)
+        : typeof variation?.onsiteSetupMinutes === "string"
+          ? variation.onsiteSetupMinutes
+          : "",
+    onsiteShootMinutes:
+      typeof variation?.onsiteShootMinutes === "number" &&
+      Number.isFinite(variation.onsiteShootMinutes)
+        ? String(variation.onsiteShootMinutes)
+        : typeof variation?.onsiteShootMinutes === "string"
+          ? variation.onsiteShootMinutes
+          : "",
+    onsiteBreakdownMinutes:
+      typeof variation?.onsiteBreakdownMinutes === "number" &&
+      Number.isFinite(variation.onsiteBreakdownMinutes)
+        ? String(variation.onsiteBreakdownMinutes)
+        : typeof variation?.onsiteBreakdownMinutes === "string"
+          ? variation.onsiteBreakdownMinutes
+          : "",
+    onsiteWindowStart:
+      typeof variation?.onsiteTimeWindowStart === "string"
+        ? variation.onsiteTimeWindowStart
+        : "",
+    onsiteWindowEnd:
+      typeof variation?.onsiteTimeWindowEnd === "string"
+        ? variation.onsiteTimeWindowEnd
+        : "",
     budgetOverrides: createBudgetForm(variation?.budgetOverrides ?? null),
     crewOverrides: createCrewOverrideMap(
       crewRoleState,
@@ -829,6 +871,11 @@ export default function EditProductPage() {
     if (!value || value.trim().length === 0) return null;
     const parsed = Number(value);
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  const parseOptionalDays = (value: string): number | null => {
+    if (!value || value.trim().length === 0) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   };
   const normaliseTimeOfDay = (value: string): string | null => {
     if (!value) return null;
@@ -1776,6 +1823,30 @@ export default function EditProductPage() {
         ),
       };
       if (features.length) entry.features = features;
+      const onsiteDaysOverride = parseOptionalDays(variation.onsiteDays);
+      if (onsiteDaysOverride !== null) entry.onsiteDays = onsiteDaysOverride;
+      const onsiteSetupOverride = parseOptionalMinutes(
+        variation.onsiteSetupMinutes
+      );
+      if (onsiteSetupOverride !== null)
+        entry.onsiteSetupMinutes = onsiteSetupOverride;
+      const onsiteShootOverride = parseOptionalMinutes(
+        variation.onsiteShootMinutes
+      );
+      if (onsiteShootOverride !== null)
+        entry.onsiteShootMinutes = onsiteShootOverride;
+      const onsiteBreakdownOverride = parseOptionalMinutes(
+        variation.onsiteBreakdownMinutes
+      );
+      if (onsiteBreakdownOverride !== null)
+        entry.onsiteBreakdownMinutes = onsiteBreakdownOverride;
+      const onsiteStartOverride = normaliseTimeOfDay(
+        variation.onsiteWindowStart
+      );
+      if (onsiteStartOverride)
+        entry.onsiteTimeWindowStart = onsiteStartOverride;
+      const onsiteEndOverride = normaliseTimeOfDay(variation.onsiteWindowEnd);
+      if (onsiteEndOverride) entry.onsiteTimeWindowEnd = onsiteEndOverride;
       const budgetOverrides = parseBudgetFormToOverride(
         variation.budgetOverrides
       );
@@ -3768,6 +3839,128 @@ export default function EditProductPage() {
                       placeholder="List the differentiators for this package (one per line)."
                     />
                   </label>
+                  <details className="rounded border border-dashed p-3">
+                    <summary className="cursor-pointer text-sm font-medium">
+                      On-site schedule overrides
+                    </summary>
+                    <div className="mt-3 grid gap-3">
+                      <label className="grid gap-1">
+                        <span className="text-xs font-medium text-gray-600">
+                          On-site duration (days)
+                        </span>
+                        <input
+                          type="number"
+                          min="0.25"
+                          step="0.25"
+                          className="input"
+                          value={variation.onsiteDays}
+                          onChange={(e) =>
+                            updateVariation(index, { onsiteDays: e.target.value })
+                          }
+                          placeholder="Inherit"
+                        />
+                        <span className="text-[11px] text-gray-500">
+                          Leave blank to inherit the base product duration.
+                        </span>
+                      </label>
+                      <div className="grid gap-3 md:grid-cols-3">
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Setup minutes
+                          </span>
+                          <input
+                            type="number"
+                            min="0"
+                            step="15"
+                            className="input"
+                            value={variation.onsiteSetupMinutes}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteSetupMinutes: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Filming minutes
+                          </span>
+                          <input
+                            type="number"
+                            min="0"
+                            step="15"
+                            className="input"
+                            value={variation.onsiteShootMinutes}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteShootMinutes: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Breakdown minutes
+                          </span>
+                          <input
+                            type="number"
+                            min="0"
+                            step="15"
+                            className="input"
+                            value={variation.onsiteBreakdownMinutes}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteBreakdownMinutes: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                      </div>
+                      <div className="grid gap-3 md:grid-cols-2">
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Earliest arrival
+                          </span>
+                          <input
+                            type="time"
+                            step={900}
+                            className="input"
+                            value={variation.onsiteWindowStart}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteWindowStart: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Latest finish
+                          </span>
+                          <input
+                            type="time"
+                            step={900}
+                            className="input"
+                            value={variation.onsiteWindowEnd}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteWindowEnd: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                      </div>
+                      <p className="text-[11px] text-gray-500">
+                        These overrides adjust booking spans and time slots for this variation
+                        without changing the base product configuration.
+                      </p>
+                    </div>
+                  </details>
                   <details
                     className="rounded border border-dashed p-3"
                     open={budgetHasValues}

--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -662,6 +662,7 @@ export default function EditProductPage() {
   const imageObjectUrlsRef = useRef<string[]>([]);
   const [requirements, setRequirements] = useState("");
   const [operationsInfo, setOperationsInfo] = useState("");
+  const [closingWhyItWorks, setClosingWhyItWorks] = useState("");
   const [deliveryIndex, setDeliveryIndex] = useState(0);
   const [deliverables, setDeliverables] = useState<
     (ProductDeliverable & { file?: File })[]
@@ -1228,6 +1229,9 @@ export default function EditProductPage() {
           );
           setRequirements(p.requirements || "");
           setOperationsInfo(p.operationsInfo || "");
+          setClosingWhyItWorks(
+            typeof p.closingWhyItWorks === "string" ? p.closingWhyItWorks : ""
+          );
           const idx = deliveryOptions.indexOf(p.deliveryTime || "");
           setDeliveryIndex(idx >= 0 ? idx : 0);
           setDeliverables((p.deliverables || []) as any);
@@ -1977,6 +1981,8 @@ export default function EditProductPage() {
       imageUrls: finalImageUrls,
       requirements: requirements || null,
       operationsInfo: operationsInfo || null,
+      closingWhyItWorks:
+        closingWhyItWorks.trim().length > 0 ? closingWhyItWorks.trim() : null,
       deliveryTime: deliveryOptions[deliveryIndex],
       deliverables: deliverableData,
       variations: variationData,
@@ -2938,6 +2944,13 @@ export default function EditProductPage() {
           </label>
           <label className="text-sm font-medium">Requirements</label>
           <textarea className="input" value={requirements} onChange={(e) => setRequirements(e.target.value)} />
+          <label className="text-sm font-medium">Why it works summary</label>
+          <textarea
+            className="input"
+            value={closingWhyItWorks}
+            onChange={(e) => setClosingWhyItWorks(e.target.value)}
+            placeholder="Optional closing statement shown on the product page CTA"
+          />
           <label className="text-sm font-medium">
             Delivery Time: {deliveryOptions[deliveryIndex]}
           </label>

--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -1685,7 +1685,7 @@ export default function EditProductPage() {
           ) {
             storyboardInputs = (p as any).storyboardImages
               .filter((url: unknown): url is string => typeof url === "string")
-              .map((url: string, index) =>
+              .map((url: string, index: number) =>
                 createStoryboardSceneState({
                   title: `Scene ${index + 1}`,
                   imageUrl: url.trim().length > 0 ? url.trim() : null,

--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -31,6 +31,7 @@ import type {
   ProductCrewRoleOverride,
   ProductModifierSelection,
   ProductOrderFormField,
+  ProductStoryboardScene,
 } from "@/lib/products";
 import type { PriceTiers } from "@/lib/pricing";
 import type { Venue } from "@/lib/venues";
@@ -40,6 +41,12 @@ import { generateFormId } from "@/lib/forms";
 import ProductOrderFieldsEditor, {
   OrderFormFieldFormState,
 } from "@/components/admin/products/ProductOrderFieldsEditor";
+import ProductStoryboardEditor, {
+  STORYBOARD_SCENE_COLOURS,
+  StoryboardSceneFormState,
+  formatStoryboardSeconds,
+  parseStoryboardTimecode,
+} from "@/components/admin/products/ProductStoryboardEditor";
 import type { IconType } from "react-icons";
 import {
   FiCheck,
@@ -207,6 +214,49 @@ const createCrewRoleInput = (
     unitRate: defaults?.unitRate ?? "",
     includeInBudget: defaults?.includeInBudget ?? true,
   };
+};
+
+const createStoryboardSceneState = (
+  defaults?: Partial<StoryboardSceneFormState>
+): StoryboardSceneFormState => {
+  const id =
+    typeof defaults?.id === "string" && defaults.id.trim().length > 0
+      ? defaults.id
+      : generateFormId();
+  return {
+    id,
+    title: defaults?.title ?? "",
+    description: defaults?.description ?? "",
+    start: defaults?.start ?? "",
+    end: defaults?.end ?? "",
+    variationIds: Array.isArray(defaults?.variationIds)
+      ? defaults.variationIds.filter(
+          (value): value is string => typeof value === "string" && value.trim().length > 0
+        )
+      : [],
+    imageUrl: defaults?.imageUrl ?? null,
+    previewUrl: defaults?.previewUrl ?? null,
+    imageFile: defaults?.imageFile ?? null,
+    imageStoragePath: defaults?.imageStoragePath ?? null,
+    persistedImage: defaults?.persistedImage ?? false,
+    aiStatus: defaults?.aiStatus ?? "idle",
+    aiError: defaults?.aiError ?? null,
+  };
+};
+
+const resolveImageExtension = (file: File): string => {
+  const name = typeof file.name === "string" ? file.name : "";
+  const match = name.match(/\.([a-zA-Z0-9]{2,5})$/);
+  if (match) {
+    const ext = match[1].toLowerCase();
+    if (["jpg", "jpeg", "png", "webp"].includes(ext)) {
+      return ext === "jpeg" ? "jpg" : ext;
+    }
+  }
+  const type = typeof file.type === "string" ? file.type.toLowerCase() : "";
+  if (type.includes("png")) return "png";
+  if (type.includes("webp")) return "webp";
+  return "jpg";
 };
 
 const normaliseNumberString = (value: unknown, fallback: string): string => {
@@ -690,6 +740,7 @@ export default function EditProductPage() {
     | "spec"
     | "pnl"
     | "variations"
+    | "storyboard"
     | "orderFields"
     | "deliverables"
     | "kit"
@@ -707,6 +758,7 @@ export default function EditProductPage() {
   const [priceTier3, setPriceTier3] = useState("");
   const [galleryImages, setGalleryImages] = useState<GalleryImage[]>([]);
   const imageObjectUrlsRef = useRef<string[]>([]);
+  const storyboardPreviewUrlsRef = useRef<string[]>([]);
   const [requirements, setRequirements] = useState("");
   const [operationsInfo, setOperationsInfo] = useState("");
   const [closingWhyItWorks, setClosingWhyItWorks] = useState("");
@@ -717,6 +769,12 @@ export default function EditProductPage() {
   const [orderFormFields, setOrderFormFields] = useState<
     OrderFormFieldFormState[]
   >([]);
+  const [storyboardEnabled, setStoryboardEnabled] = useState(false);
+  const [storyboardScenes, setStoryboardScenes] = useState<
+    StoryboardSceneFormState[]
+  >([]);
+  const [storyboardGeneratingSceneId, setStoryboardGeneratingSceneId] =
+    useState<string | null>(null);
   const [variations, setVariations] = useState<VariationFormState[]>([]);
   const [organiserEnabled, setOrganiserEnabled] = useState(false);
   const [organiserMinimum, setOrganiserMinimum] = useState("");
@@ -1566,6 +1624,81 @@ export default function EditProductPage() {
                 )
               : []
           );
+          const storyboardSource = Array.isArray((p as any).storyboard)
+            ? ((p as any).storyboard as ProductStoryboardScene[])
+            : [];
+          let storyboardInputs = storyboardSource.map((scene) => {
+            const startSeconds =
+              typeof scene?.startSeconds === "number"
+                ? scene.startSeconds
+                : typeof (scene as any)?.start === "string"
+                ? parseStoryboardTimecode((scene as any).start)
+                : null;
+            const endSeconds =
+              typeof scene?.endSeconds === "number"
+                ? scene.endSeconds
+                : typeof (scene as any)?.end === "string"
+                ? parseStoryboardTimecode((scene as any).end)
+                : null;
+            const startLabel = (() => {
+              const formatted = formatStoryboardSeconds(startSeconds);
+              if (formatted) return formatted;
+              return typeof (scene as any)?.start === "string"
+                ? ((scene as any).start as string)
+                : "";
+            })();
+            const endLabel = (() => {
+              const formatted = formatStoryboardSeconds(endSeconds);
+              if (formatted) return formatted;
+              return typeof (scene as any)?.end === "string"
+                ? ((scene as any).end as string)
+                : "";
+            })();
+            return createStoryboardSceneState({
+              id:
+                typeof scene?.id === "string" && scene.id.length > 0
+                  ? scene.id
+                  : undefined,
+              title: typeof scene?.title === "string" ? scene.title : "",
+              description:
+                typeof scene?.description === "string" ? scene.description : "",
+              start: startLabel,
+              end: endLabel,
+              variationIds: Array.isArray(scene?.variationIds)
+                ? scene.variationIds
+                : [],
+              imageUrl:
+                typeof scene?.imageUrl === "string" && scene.imageUrl.trim().length > 0
+                  ? scene.imageUrl.trim()
+                  : null,
+              imageStoragePath:
+                typeof scene?.storagePath === "string"
+                  ? scene.storagePath
+                  : null,
+              persistedImage:
+                typeof scene?.imageUrl === "string" && scene.imageUrl.trim().length > 0,
+            });
+          });
+          if (
+            storyboardInputs.length === 0 &&
+            Array.isArray((p as any).storyboardImages)
+          ) {
+            storyboardInputs = (p as any).storyboardImages
+              .filter((url: unknown): url is string => typeof url === "string")
+              .map((url, index) =>
+                createStoryboardSceneState({
+                  title: `Scene ${index + 1}`,
+                  imageUrl: url.trim().length > 0 ? url.trim() : null,
+                  persistedImage: url.trim().length > 0,
+                })
+              );
+          }
+          setStoryboardScenes(storyboardInputs);
+          setStoryboardEnabled(
+            (p as any).storyboardEnabled === false
+              ? false
+              : storyboardInputs.length > 0
+          );
         }
         const [
           catSnap,
@@ -1715,6 +1848,14 @@ export default function EditProductPage() {
         }
       });
       imageObjectUrlsRef.current = [];
+      storyboardPreviewUrlsRef.current.forEach((url) => {
+        try {
+          URL.revokeObjectURL(url);
+        } catch {
+          // Ignore revoke failures during cleanup.
+        }
+      });
+      storyboardPreviewUrlsRef.current = [];
     },
     []
   );
@@ -1830,6 +1971,45 @@ export default function EditProductPage() {
       deliverableData.push(item);
     }
 
+    const storyboardUploads: { sceneId: string; file: File }[] = [];
+    const storyboardData: ProductStoryboardScene[] = [];
+    if (storyboardEnabled) {
+      storyboardScenes.forEach((scene) => {
+        const sceneId = scene.id || generateFormId();
+        const title = scene.title.trim();
+        const description = scene.description.trim();
+        const startSeconds = parseStoryboardTimecode(scene.start);
+        const endSeconds = parseStoryboardTimecode(scene.end);
+        const hasContent =
+          title.length > 0 ||
+          description.length > 0 ||
+          typeof startSeconds === "number" ||
+          typeof endSeconds === "number" ||
+          Boolean(scene.imageUrl) ||
+          Boolean(scene.imageFile);
+        if (!hasContent) {
+          return;
+        }
+        const variationIds = Array.isArray(scene.variationIds)
+          ? scene.variationIds.filter(
+              (value): value is string => typeof value === "string" && value.trim().length > 0
+            )
+          : [];
+        const entry: ProductStoryboardScene = { id: sceneId };
+        if (title.length > 0) entry.title = title;
+        if (description.length > 0) entry.description = description;
+        if (typeof startSeconds === "number") entry.startSeconds = startSeconds;
+        if (typeof endSeconds === "number") entry.endSeconds = endSeconds;
+        if (scene.imageUrl) entry.imageUrl = scene.imageUrl;
+        if (scene.imageStoragePath) entry.storagePath = scene.imageStoragePath;
+        if (variationIds.length > 0) entry.variationIds = variationIds;
+        if (scene.imageFile) {
+          storyboardUploads.push({ sceneId, file: scene.imageFile });
+        }
+        storyboardData.push(entry);
+      });
+    }
+
     const orderFieldData: ProductOrderFormField[] = orderFormFields
       .map((field) => {
         const label = field.label.trim();
@@ -1849,6 +2029,23 @@ export default function EditProductPage() {
         return entry;
       })
       .filter((entry): entry is ProductOrderFormField => entry !== null);
+
+    if (storyboardUploads.length > 0) {
+      for (const uploadEntry of storyboardUploads) {
+        const extension = resolveImageExtension(uploadEntry.file);
+        const storagePath = `${PRODUCT_IMAGE_ROOT}/${id}/storyboard-${uploadEntry.sceneId}.${extension}`;
+        const url = await upload(storagePath, uploadEntry.file);
+        const target = storyboardData.find((entry) => entry.id === uploadEntry.sceneId);
+        if (target) {
+          target.imageUrl = url;
+          target.storagePath = storagePath;
+        }
+      }
+    }
+    const storyboardImages = storyboardData
+      .map((entry) => (entry.imageUrl ? entry.imageUrl : null))
+      .filter((url): url is string => typeof url === "string" && url.trim().length > 0);
+    const storyboardEnabledValue = storyboardEnabled && storyboardData.length > 0;
 
     const variationData: ProductVariation[] = variations.map((variation) => {
       const name = variation.name.trim();
@@ -2105,6 +2302,9 @@ export default function EditProductPage() {
       deliverables: deliverableData,
       variations: variationData,
       orderFormFields: orderFieldData,
+      storyboardEnabled: storyboardEnabledValue ? true : false,
+      storyboard: storyboardEnabledValue ? storyboardData : null,
+      storyboardImages: storyboardEnabledValue ? storyboardImages : [],
       exampleVideos: videoData,
       exampleWorkUrl: primaryExampleVideo,
       modifierGroups: enabledGroups,
@@ -2210,6 +2410,197 @@ export default function EditProductPage() {
 
   const addExampleVideo = () => {
     setExampleVideos((prev) => [...prev, createVideoInput()]);
+  };
+
+  const addStoryboardScene = () => {
+    setStoryboardScenes((prev) => [...prev, createStoryboardSceneState()]);
+    setStoryboardEnabled(true);
+  };
+
+  const updateStoryboardScene = (
+    sceneId: string,
+    patch: Partial<StoryboardSceneFormState>
+  ) => {
+    setStoryboardScenes((prev) =>
+      prev.map((scene) => (scene.id === sceneId ? { ...scene, ...patch } : scene))
+    );
+  };
+
+  const removeStoryboardScene = (sceneId: string) => {
+    setStoryboardScenes((prev) => {
+      const target = prev.find((scene) => scene.id === sceneId);
+      if (target?.previewUrl) {
+        try {
+          URL.revokeObjectURL(target.previewUrl);
+        } catch {
+          // Ignore preview cleanup failures when removing scenes.
+        }
+        storyboardPreviewUrlsRef.current = storyboardPreviewUrlsRef.current.filter(
+          (url) => url !== target.previewUrl
+        );
+      }
+      return prev.filter((scene) => scene.id !== sceneId);
+    });
+  };
+
+  const handleStoryboardSceneImage = (sceneId: string, file: File | null) => {
+    setStoryboardScenes((prev) =>
+      prev.map((scene) => {
+        if (scene.id !== sceneId) return scene;
+        if (scene.previewUrl) {
+          try {
+            URL.revokeObjectURL(scene.previewUrl);
+          } catch {
+            // Ignore preview cleanup failures while swapping images.
+          }
+          storyboardPreviewUrlsRef.current = storyboardPreviewUrlsRef.current.filter(
+            (url) => url !== scene.previewUrl
+          );
+        }
+        if (!file) {
+          return {
+            ...scene,
+            imageFile: null,
+            previewUrl: null,
+            imageUrl: null,
+            persistedImage: false,
+            imageStoragePath: null,
+            aiError: null,
+          };
+        }
+        const previewUrl = URL.createObjectURL(file);
+        storyboardPreviewUrlsRef.current.push(previewUrl);
+        return {
+          ...scene,
+          imageFile: file,
+          previewUrl,
+          imageUrl: null,
+          persistedImage: false,
+          imageStoragePath: null,
+          aiError: null,
+        };
+      })
+    );
+  };
+
+  const handleGenerateStoryboardSceneImage = async (sceneId: string) => {
+    const scene = storyboardScenes.find((entry) => entry.id === sceneId);
+    if (!scene) return;
+    const description = scene.description.trim();
+    if (!description) {
+      setStoryboardScenes((prev) =>
+        prev.map((entry) =>
+          entry.id === sceneId
+            ? {
+                ...entry,
+                aiStatus: "error",
+                aiError: "Add a scene description before generating artwork.",
+              }
+            : entry
+        )
+      );
+      return;
+    }
+    setStoryboardScenes((prev) =>
+      prev.map((entry) =>
+        entry.id === sceneId
+          ? { ...entry, aiStatus: "loading", aiError: null }
+          : entry
+      )
+    );
+    setStoryboardGeneratingSceneId(sceneId);
+    try {
+      const startSeconds = parseStoryboardTimecode(scene.start);
+      const endSeconds = parseStoryboardTimecode(scene.end);
+      const variationNames = scene.variationIds
+        .map((variationId) =>
+          variations.find((variation) => variation.id === variationId)?.name?.trim() || null
+        )
+        .filter((value): value is string => Boolean(value && value.length > 0));
+      const deliverableSummaries = deliverables
+        .map((deliverable) => {
+          const title = (deliverable.title || "").trim();
+          if (!title) return null;
+          const qty =
+            typeof deliverable.quantity === "number" && Number.isFinite(deliverable.quantity)
+              ? Math.max(1, Math.round(deliverable.quantity))
+              : 1;
+          return `${qty > 1 ? `${qty}× ` : ""}${title}`;
+        })
+        .filter((value): value is string => Boolean(value));
+      const sceneIndex = storyboardScenes.findIndex((entry) => entry.id === sceneId);
+      const accentColor =
+        STORYBOARD_SCENE_COLOURS[
+          (sceneIndex >= 0 ? sceneIndex : 0) % STORYBOARD_SCENE_COLOURS.length
+        ];
+      const fn = httpsCallable(functions, "admin_generateStoryboardSceneImage");
+      const response = await fn({
+        productId: id,
+        sceneId,
+        sceneTitle: scene.title,
+        sceneDescription: description,
+        productName: name,
+        productTagline: tagline,
+        productDescription: description,
+        operationsInfo,
+        startSeconds,
+        endSeconds,
+        variationNames,
+        deliverables: deliverableSummaries,
+        accentColor,
+      });
+      const payload = (response?.data ?? {}) as {
+        imageUrl?: string;
+        storagePath?: string;
+        promptSummary?: string;
+      };
+      if (!payload.imageUrl) {
+        throw new Error("Image generation failed");
+      }
+      setStoryboardScenes((prev) =>
+        prev.map((entry) => {
+          if (entry.id !== sceneId) return entry;
+          if (entry.previewUrl) {
+            try {
+              URL.revokeObjectURL(entry.previewUrl);
+            } catch {
+              // Ignore preview cleanup failures after generation.
+            }
+            storyboardPreviewUrlsRef.current = storyboardPreviewUrlsRef.current.filter(
+              (url) => url !== entry.previewUrl
+            );
+          }
+          return {
+            ...entry,
+            imageUrl: payload.imageUrl || null,
+            imageStoragePath: payload.storagePath ?? null,
+            previewUrl: null,
+            imageFile: null,
+            persistedImage: true,
+            aiStatus: "idle",
+            aiError: null,
+          };
+        })
+      );
+    } catch (error) {
+      console.error("Failed to generate storyboard scene image", error);
+      setStoryboardScenes((prev) =>
+        prev.map((entry) =>
+          entry.id === sceneId
+            ? {
+                ...entry,
+                aiStatus: "error",
+                aiError:
+                  error instanceof Error
+                    ? error.message
+                    : "Unable to generate artwork. Please try again.",
+              }
+            : entry
+        )
+      );
+    } finally {
+      setStoryboardGeneratingSceneId(null);
+    }
   };
 
   const updateExampleVideo = (
@@ -2641,6 +3032,7 @@ export default function EditProductPage() {
       { key: "spec", label: "Product Spec" },
       { key: "pnl", label: "P&L" },
       { key: "variations", label: "Variations" },
+      { key: "storyboard", label: "Storyboard" },
       { key: "deliverables", label: "Deliverables" },
       { key: "orderFields", label: "Custom form fields" },
       { key: "kit", label: "Kit" },
@@ -4298,6 +4690,24 @@ export default function EditProductPage() {
             Add variation
           </button>
         </div>
+      )}
+
+      {tab === "storyboard" && (
+        <ProductStoryboardEditor
+          enabled={storyboardEnabled}
+          onToggleEnabled={(value) => setStoryboardEnabled(value)}
+          scenes={storyboardScenes}
+          onSceneChange={updateStoryboardScene}
+          onSceneImageSelect={handleStoryboardSceneImage}
+          onAddScene={addStoryboardScene}
+          onRemoveScene={removeStoryboardScene}
+          onGenerateSceneImage={handleGenerateStoryboardSceneImage}
+          generatingSceneId={storyboardGeneratingSceneId}
+          variationOptions={variations.map((variation) => ({
+            id: variation.id,
+            name: variation.name || variation.id,
+          }))}
+        />
       )}
 
       {tab === "orderFields" && (

--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -1732,6 +1732,13 @@ export default function EditProductPage() {
         );
       const item: ProductDeliverable = { title: d.title };
       if (d.type) item.type = d.type;
+      if (
+        typeof d.quantity === "number" &&
+        Number.isFinite(d.quantity) &&
+        d.quantity > 0
+      ) {
+        item.quantity = Math.round(d.quantity);
+      }
       const desc = d.description?.trim();
       if (desc) item.description = desc;
       if (thumb) item.thumbnailUrl = thumb;
@@ -4063,6 +4070,37 @@ export default function EditProductPage() {
                   </option>
                 ))}
               </select>
+              <div className="grid gap-1">
+                <label
+                  htmlFor={`deliverable-${i}-quantity`}
+                  className="text-xs font-medium text-gray-600"
+                >
+                  Quantity (optional)
+                </label>
+                <input
+                  id={`deliverable-${i}-quantity`}
+                  type="number"
+                  min={1}
+                  inputMode="numeric"
+                  className="input"
+                  placeholder="Leave blank to treat as a single deliverable"
+                  value={
+                    typeof d.quantity === "number" &&
+                    Number.isFinite(d.quantity) &&
+                    d.quantity > 0
+                      ? String(Math.round(d.quantity))
+                      : ""
+                  }
+                  onChange={(e) => {
+                    const parsed = Number.parseInt(e.target.value, 10);
+                    if (Number.isNaN(parsed) || parsed <= 0) {
+                      updateDeliverable(i, { quantity: undefined });
+                      return;
+                    }
+                    updateDeliverable(i, { quantity: parsed });
+                  }}
+                />
+              </div>
               <textarea
                 className="input"
                 placeholder="Description"

--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -30,12 +30,16 @@ import type {
   ProductBudgetOverride,
   ProductCrewRoleOverride,
   ProductModifierSelection,
+  ProductOrderFormField,
 } from "@/lib/products";
 import type { PriceTiers } from "@/lib/pricing";
 import type { Venue } from "@/lib/venues";
 import type { KitBag, EquipmentStandard } from "@/lib/equipment";
 import { defaultFranchiseRoyaltyConfig } from "@/lib/franchises";
 import { generateFormId } from "@/lib/forms";
+import ProductOrderFieldsEditor, {
+  OrderFormFieldFormState,
+} from "@/components/admin/products/ProductOrderFieldsEditor";
 import type { IconType } from "react-icons";
 import {
   FiCheck,
@@ -686,6 +690,7 @@ export default function EditProductPage() {
     | "spec"
     | "pnl"
     | "variations"
+    | "orderFields"
     | "deliverables"
     | "kit"
     | "tasks"
@@ -708,6 +713,9 @@ export default function EditProductPage() {
   const [deliveryIndex, setDeliveryIndex] = useState(0);
   const [deliverables, setDeliverables] = useState<
     (ProductDeliverable & { file?: File })[]
+  >([]);
+  const [orderFormFields, setOrderFormFields] = useState<
+    OrderFormFieldFormState[]
   >([]);
   const [variations, setVariations] = useState<VariationFormState[]>([]);
   const [organiserEnabled, setOrganiserEnabled] = useState(false);
@@ -1282,6 +1290,25 @@ export default function EditProductPage() {
           const idx = deliveryOptions.indexOf(p.deliveryTime || "");
           setDeliveryIndex(idx >= 0 ? idx : 0);
           setDeliverables((p.deliverables || []) as any);
+          const initialOrderFields = Array.isArray(p.orderFormFields)
+            ? (p.orderFormFields as ProductOrderFormField[])
+            : [];
+          setOrderFormFields(
+            initialOrderFields.map((field) => ({
+              id:
+                typeof field.id === "string" && field.id.trim().length > 0
+                  ? field.id
+                  : generateFormId(),
+              label:
+                typeof field.label === "string" ? field.label : "",
+              description:
+                typeof field.description === "string"
+                  ? field.description
+                  : "",
+              required: field.required === true,
+              type: field.type === "long-text" ? "long-text" : "short-text",
+            }))
+          );
           variationEntries = Array.isArray(p.variations)
             ? (p.variations as ProductVariation[])
             : [];
@@ -1803,6 +1830,26 @@ export default function EditProductPage() {
       deliverableData.push(item);
     }
 
+    const orderFieldData: ProductOrderFormField[] = orderFormFields
+      .map((field) => {
+        const label = field.label.trim();
+        if (!label) return null;
+        const idValue = field.id && field.id.trim().length > 0
+          ? field.id
+          : generateFormId();
+        const description = field.description.trim();
+        const type = field.type === "long-text" ? "long-text" : "short-text";
+        const entry: ProductOrderFormField = {
+          id: idValue,
+          label,
+          type,
+        };
+        if (description) entry.description = description;
+        if (field.required) entry.required = true;
+        return entry;
+      })
+      .filter((entry): entry is ProductOrderFormField => entry !== null);
+
     const variationData: ProductVariation[] = variations.map((variation) => {
       const name = variation.name.trim();
       const features = variation.featuresText
@@ -2057,6 +2104,7 @@ export default function EditProductPage() {
       deliveryTime: deliveryOptions[deliveryIndex],
       deliverables: deliverableData,
       variations: variationData,
+      orderFormFields: orderFieldData,
       exampleVideos: videoData,
       exampleWorkUrl: primaryExampleVideo,
       modifierGroups: enabledGroups,
@@ -2091,6 +2139,15 @@ export default function EditProductPage() {
         socialImageUrl: seoImage || null,
       },
     });
+    setOrderFormFields(
+      orderFieldData.map((field) => ({
+        id: field.id,
+        label: field.label,
+        description: field.description ?? "",
+        required: field.required === true,
+        type: field.type === "long-text" ? "long-text" : "short-text",
+      }))
+    );
     setGalleryImages(
       finalImageUrls.map((url) => ({
         id: generateFormId(),
@@ -2585,6 +2642,7 @@ export default function EditProductPage() {
       { key: "pnl", label: "P&L" },
       { key: "variations", label: "Variations" },
       { key: "deliverables", label: "Deliverables" },
+      { key: "orderFields", label: "Custom form fields" },
       { key: "kit", label: "Kit" },
       { key: "tasks", label: "Default Tasks" },
       { key: "seo", label: "SEO" },
@@ -4239,6 +4297,24 @@ export default function EditProductPage() {
           >
             Add variation
           </button>
+        </div>
+      )}
+
+      {tab === "orderFields" && (
+        <div className="space-y-4">
+          <div className="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+            <p className="font-medium text-slate-900">
+              Collect extra details when customers add this product to their cart.
+            </p>
+            <p className="mt-2">
+              Configure optional or required questions for project information such as stand numbers,
+              campaign goals, or billing references.
+            </p>
+          </div>
+          <ProductOrderFieldsEditor
+            fields={orderFormFields}
+            onChange={setOrderFormFields}
+          />
         </div>
       )}
 

--- a/apps/web/app/admin/products/[id]/ClientPage.tsx
+++ b/apps/web/app/admin/products/[id]/ClientPage.tsx
@@ -1685,7 +1685,7 @@ export default function EditProductPage() {
           ) {
             storyboardInputs = (p as any).storyboardImages
               .filter((url: unknown): url is string => typeof url === "string")
-              .map((url, index) =>
+              .map((url: string, index) =>
                 createStoryboardSceneState({
                   title: `Scene ${index + 1}`,
                   imageUrl: url.trim().length > 0 ? url.trim() : null,

--- a/apps/web/app/admin/products/new/ClientPage.tsx
+++ b/apps/web/app/admin/products/new/ClientPage.tsx
@@ -1581,6 +1581,13 @@ export default function NewProductPage() {
         );
       const item: ProductDeliverable = { title: d.title };
       if (d.type) item.type = d.type;
+      if (
+        typeof d.quantity === "number" &&
+        Number.isFinite(d.quantity) &&
+        d.quantity > 0
+      ) {
+        item.quantity = Math.round(d.quantity);
+      }
       const desc = d.description?.trim();
       if (desc) item.description = desc;
       if (thumb) item.thumbnailUrl = thumb;
@@ -3344,6 +3351,37 @@ export default function NewProductPage() {
                   </option>
                 ))}
               </select>
+              <div className="grid gap-1">
+                <label
+                  htmlFor={`deliverable-${i}-quantity`}
+                  className="text-xs font-medium text-gray-600"
+                >
+                  Quantity (optional)
+                </label>
+                <input
+                  id={`deliverable-${i}-quantity`}
+                  type="number"
+                  min={1}
+                  inputMode="numeric"
+                  className="input"
+                  placeholder="Leave blank to treat as a single deliverable"
+                  value={
+                    typeof d.quantity === "number" &&
+                    Number.isFinite(d.quantity) &&
+                    d.quantity > 0
+                      ? String(Math.round(d.quantity))
+                      : ""
+                  }
+                  onChange={(e) => {
+                    const parsed = Number.parseInt(e.target.value, 10);
+                    if (Number.isNaN(parsed) || parsed <= 0) {
+                      updateDeliverable(i, { quantity: undefined });
+                      return;
+                    }
+                    updateDeliverable(i, { quantity: parsed });
+                  }}
+                />
+              </div>
               <textarea
                 className="input"
                 placeholder="Description"

--- a/apps/web/app/admin/products/new/ClientPage.tsx
+++ b/apps/web/app/admin/products/new/ClientPage.tsx
@@ -445,6 +445,12 @@ type VariationFormState = {
   tier2Price: string;
   tier3Price: string;
   featuresText: string;
+  onsiteDays: string;
+  onsiteSetupMinutes: string;
+  onsiteShootMinutes: string;
+  onsiteBreakdownMinutes: string;
+  onsiteWindowStart: string;
+  onsiteWindowEnd: string;
   budgetOverrides: BudgetOverrideFormState;
   crewOverrides: Record<string, CrewOverrideFormState>;
 };
@@ -634,6 +640,11 @@ export default function NewProductPage() {
     if (!value || value.trim().length === 0) return null;
     const parsed = Number(value);
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  const parseOptionalDays = (value: string): number | null => {
+    if (!value || value.trim().length === 0) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   };
   const normaliseTimeOfDay = (value: string): string | null => {
     if (!value) return null;
@@ -1097,6 +1108,42 @@ export default function NewProductPage() {
         tier3Price:
           typeof tier3 === "number" && Number.isFinite(tier3) ? String(tier3) : "",
         featuresText: features.join("\n"),
+        onsiteDays:
+          typeof variation?.onsiteDays === "number" &&
+          Number.isFinite(variation.onsiteDays)
+            ? String(variation.onsiteDays)
+            : typeof variation?.onsiteDays === "string"
+              ? variation.onsiteDays
+              : "",
+        onsiteSetupMinutes:
+          typeof variation?.onsiteSetupMinutes === "number" &&
+          Number.isFinite(variation.onsiteSetupMinutes)
+            ? String(variation.onsiteSetupMinutes)
+            : typeof variation?.onsiteSetupMinutes === "string"
+              ? variation.onsiteSetupMinutes
+              : "",
+        onsiteShootMinutes:
+          typeof variation?.onsiteShootMinutes === "number" &&
+          Number.isFinite(variation.onsiteShootMinutes)
+            ? String(variation.onsiteShootMinutes)
+            : typeof variation?.onsiteShootMinutes === "string"
+              ? variation.onsiteShootMinutes
+              : "",
+        onsiteBreakdownMinutes:
+          typeof variation?.onsiteBreakdownMinutes === "number" &&
+          Number.isFinite(variation.onsiteBreakdownMinutes)
+            ? String(variation.onsiteBreakdownMinutes)
+            : typeof variation?.onsiteBreakdownMinutes === "string"
+              ? variation.onsiteBreakdownMinutes
+              : "",
+        onsiteWindowStart:
+          typeof variation?.onsiteTimeWindowStart === "string"
+            ? variation.onsiteTimeWindowStart
+            : "",
+        onsiteWindowEnd:
+          typeof variation?.onsiteTimeWindowEnd === "string"
+            ? variation.onsiteTimeWindowEnd
+            : "",
         budgetOverrides: createBudgetForm(variation?.budgetOverrides ?? null),
         crewOverrides: createCrewOverrideMap(
           crewRoleState,
@@ -1329,6 +1376,30 @@ export default function NewProductPage() {
         ),
       };
       if (features.length) entry.features = features;
+      const onsiteDaysOverride = parseOptionalDays(variation.onsiteDays);
+      if (onsiteDaysOverride !== null) entry.onsiteDays = onsiteDaysOverride;
+      const onsiteSetupOverride = parseOptionalMinutes(
+        variation.onsiteSetupMinutes
+      );
+      if (onsiteSetupOverride !== null)
+        entry.onsiteSetupMinutes = onsiteSetupOverride;
+      const onsiteShootOverride = parseOptionalMinutes(
+        variation.onsiteShootMinutes
+      );
+      if (onsiteShootOverride !== null)
+        entry.onsiteShootMinutes = onsiteShootOverride;
+      const onsiteBreakdownOverride = parseOptionalMinutes(
+        variation.onsiteBreakdownMinutes
+      );
+      if (onsiteBreakdownOverride !== null)
+        entry.onsiteBreakdownMinutes = onsiteBreakdownOverride;
+      const onsiteStartOverride = normaliseTimeOfDay(
+        variation.onsiteWindowStart
+      );
+      if (onsiteStartOverride)
+        entry.onsiteTimeWindowStart = onsiteStartOverride;
+      const onsiteEndOverride = normaliseTimeOfDay(variation.onsiteWindowEnd);
+      if (onsiteEndOverride) entry.onsiteTimeWindowEnd = onsiteEndOverride;
       const budgetOverrides = parseBudgetFormToOverride(
         variation.budgetOverrides
       );
@@ -3047,6 +3118,128 @@ export default function NewProductPage() {
                       placeholder="List the differentiators for this package (one per line)."
                     />
                   </label>
+                  <details className="rounded border border-dashed p-3">
+                    <summary className="cursor-pointer text-sm font-medium">
+                      On-site schedule overrides
+                    </summary>
+                    <div className="mt-3 grid gap-3">
+                      <label className="grid gap-1">
+                        <span className="text-xs font-medium text-gray-600">
+                          On-site duration (days)
+                        </span>
+                        <input
+                          type="number"
+                          min="0.25"
+                          step="0.25"
+                          className="input"
+                          value={variation.onsiteDays}
+                          onChange={(e) =>
+                            updateVariation(index, { onsiteDays: e.target.value })
+                          }
+                          placeholder="Inherit"
+                        />
+                        <span className="text-[11px] text-gray-500">
+                          Leave blank to inherit the base product duration.
+                        </span>
+                      </label>
+                      <div className="grid gap-3 md:grid-cols-3">
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Setup minutes
+                          </span>
+                          <input
+                            type="number"
+                            min="0"
+                            step="15"
+                            className="input"
+                            value={variation.onsiteSetupMinutes}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteSetupMinutes: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Filming minutes
+                          </span>
+                          <input
+                            type="number"
+                            min="0"
+                            step="15"
+                            className="input"
+                            value={variation.onsiteShootMinutes}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteShootMinutes: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Breakdown minutes
+                          </span>
+                          <input
+                            type="number"
+                            min="0"
+                            step="15"
+                            className="input"
+                            value={variation.onsiteBreakdownMinutes}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteBreakdownMinutes: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                      </div>
+                      <div className="grid gap-3 md:grid-cols-2">
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Earliest arrival
+                          </span>
+                          <input
+                            type="time"
+                            step={900}
+                            className="input"
+                            value={variation.onsiteWindowStart}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteWindowStart: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                        <label className="grid gap-1">
+                          <span className="text-xs font-medium text-gray-600">
+                            Latest finish
+                          </span>
+                          <input
+                            type="time"
+                            step={900}
+                            className="input"
+                            value={variation.onsiteWindowEnd}
+                            onChange={(e) =>
+                              updateVariation(index, {
+                                onsiteWindowEnd: e.target.value,
+                              })
+                            }
+                            placeholder="Inherit"
+                          />
+                        </label>
+                      </div>
+                      <p className="text-[11px] text-gray-500">
+                        Overrides update the booking span and time slots for this variation
+                        while leaving other packages untouched.
+                      </p>
+                    </div>
+                  </details>
                   <details
                     className="rounded border border-dashed p-3"
                     open={budgetHasValues}

--- a/apps/web/app/admin/products/new/ClientPage.tsx
+++ b/apps/web/app/admin/products/new/ClientPage.tsx
@@ -21,11 +21,15 @@ import type {
   ProductBudgetOverride,
   ProductCrewRoleOverride,
   ProductModifierSelection,
+  ProductOrderFormField,
 } from "@/lib/products";
 import type { PriceTiers } from "@/lib/pricing";
 import type { Venue } from "@/lib/venues";
 import { defaultFranchiseRoyaltyConfig } from "@/lib/franchises";
 import { generateFormId } from "@/lib/forms";
+import ProductOrderFieldsEditor, {
+  OrderFormFieldFormState,
+} from "@/components/admin/products/ProductOrderFieldsEditor";
 import type { IconType } from "react-icons";
 import {
   FiCheck,
@@ -482,6 +486,7 @@ export default function NewProductPage() {
     | "spec"
     | "pnl"
     | "variations"
+    | "orderFields"
     | "deliverables"
     | "kit"
     | "tasks"
@@ -504,6 +509,9 @@ export default function NewProductPage() {
   const [deliveryIndex, setDeliveryIndex] = useState(0);
   const [deliverables, setDeliverables] = useState<
     (ProductDeliverable & { file?: File })[]
+  >([]);
+  const [orderFormFields, setOrderFormFields] = useState<
+    OrderFormFieldFormState[]
   >([]);
   const [variations, setVariations] = useState<VariationFormState[]>([]);
   const [organiserEnabled, setOrganiserEnabled] = useState(false);
@@ -1563,6 +1571,25 @@ export default function NewProductPage() {
           commissionRate: organiserCommissionValue,
         }
       : null;
+    const orderFieldData: ProductOrderFormField[] = orderFormFields
+      .map((field) => {
+        const label = field.label.trim();
+        if (!label) return null;
+        const idValue = field.id && field.id.trim().length > 0
+          ? field.id
+          : generateFormId();
+        const description = field.description.trim();
+        const type = field.type === "long-text" ? "long-text" : "short-text";
+        const entry: ProductOrderFormField = {
+          id: idValue,
+          label,
+          type,
+        };
+        if (description) entry.description = description;
+        if (field.required) entry.required = true;
+        return entry;
+      })
+      .filter((entry): entry is ProductOrderFormField => entry !== null);
     const docRef = await addDoc(collection(db, "products"), {
       name,
       description,
@@ -1619,6 +1646,7 @@ export default function NewProductPage() {
       productSpec: specPayload,
       crewRoles: crewRoleData,
       organiserProgram: organiserProgramPayload,
+      orderFormFields: orderFieldData,
     });
     const uploadedGalleryUrls = new Map<string, string>();
     const uploadBatchId = Date.now();
@@ -1905,6 +1933,7 @@ export default function NewProductPage() {
       { key: "pnl", label: "P&L" },
       { key: "variations", label: "Variations" },
       { key: "deliverables", label: "Deliverables" },
+      { key: "orderFields", label: "Custom form fields" },
       { key: "tasks", label: "Default Tasks" },
       { key: "seo", label: "SEO" },
       { key: "modifiers", label: "Modifiers" }
@@ -3517,6 +3546,24 @@ export default function NewProductPage() {
           >
             Add variation
           </button>
+        </div>
+      )}
+
+      {tab === "orderFields" && (
+        <div className="space-y-4">
+          <div className="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+            <p className="font-medium text-slate-900">
+              Collect extra details when customers add this product to their cart.
+            </p>
+            <p className="mt-2">
+              Configure optional or required questions for project information such as stand numbers,
+              campaign goals, or billing references.
+            </p>
+          </div>
+          <ProductOrderFieldsEditor
+            fields={orderFormFields}
+            onChange={setOrderFormFields}
+          />
         </div>
       )}
 

--- a/apps/web/app/admin/products/new/ClientPage.tsx
+++ b/apps/web/app/admin/products/new/ClientPage.tsx
@@ -494,6 +494,7 @@ export default function NewProductPage() {
   const imageObjectUrlsRef = useRef<string[]>([]);
   const [requirements, setRequirements] = useState("");
   const [operationsInfo, setOperationsInfo] = useState("");
+  const [closingWhyItWorks, setClosingWhyItWorks] = useState("");
   const [deliveryIndex, setDeliveryIndex] = useState(0);
   const [deliverables, setDeliverables] = useState<
     (ProductDeliverable & { file?: File })[]
@@ -1514,6 +1515,8 @@ export default function NewProductPage() {
       },
       requirements: requirements || null,
       operationsInfo: operationsInfo || null,
+      closingWhyItWorks:
+        closingWhyItWorks.trim().length > 0 ? closingWhyItWorks.trim() : null,
       deliveryTime: deliveryOptions[deliveryIndex],
       category: category || null,
       eventDate: eventStartDate || null,
@@ -2260,6 +2263,13 @@ export default function NewProductPage() {
           </label>
           <label className="text-sm font-medium">Requirements</label>
           <textarea className="input" value={requirements} onChange={(e) => setRequirements(e.target.value)} />
+          <label className="text-sm font-medium">Why it works summary</label>
+          <textarea
+            className="input"
+            value={closingWhyItWorks}
+            onChange={(e) => setClosingWhyItWorks(e.target.value)}
+            placeholder="Optional closing statement shown on the product page CTA"
+          />
           <label className="text-sm font-medium">
             Delivery Time: {deliveryOptions[deliveryIndex]}
           </label>

--- a/apps/web/app/admin/products/new/ClientPage.tsx
+++ b/apps/web/app/admin/products/new/ClientPage.tsx
@@ -22,6 +22,7 @@ import type {
   ProductCrewRoleOverride,
   ProductModifierSelection,
   ProductOrderFormField,
+  ProductStoryboardScene,
 } from "@/lib/products";
 import type { PriceTiers } from "@/lib/pricing";
 import type { Venue } from "@/lib/venues";
@@ -30,6 +31,11 @@ import { generateFormId } from "@/lib/forms";
 import ProductOrderFieldsEditor, {
   OrderFormFieldFormState,
 } from "@/components/admin/products/ProductOrderFieldsEditor";
+import ProductStoryboardEditor, {
+  STORYBOARD_SCENE_COLOURS,
+  StoryboardSceneFormState,
+  parseStoryboardTimecode,
+} from "@/components/admin/products/ProductStoryboardEditor";
 import type { IconType } from "react-icons";
 import {
   FiCheck,
@@ -181,6 +187,49 @@ const createCrewRoleInput = (
     unitRate: defaults?.unitRate ?? "",
     includeInBudget: defaults?.includeInBudget ?? true,
   };
+};
+
+const createStoryboardSceneState = (
+  defaults?: Partial<StoryboardSceneFormState>
+): StoryboardSceneFormState => {
+  const id =
+    typeof defaults?.id === "string" && defaults.id.trim().length > 0
+      ? defaults.id
+      : generateFormId();
+  return {
+    id,
+    title: defaults?.title ?? "",
+    description: defaults?.description ?? "",
+    start: defaults?.start ?? "",
+    end: defaults?.end ?? "",
+    variationIds: Array.isArray(defaults?.variationIds)
+      ? defaults.variationIds.filter(
+          (value): value is string => typeof value === "string" && value.trim().length > 0
+        )
+      : [],
+    imageUrl: defaults?.imageUrl ?? null,
+    previewUrl: defaults?.previewUrl ?? null,
+    imageFile: defaults?.imageFile ?? null,
+    imageStoragePath: defaults?.imageStoragePath ?? null,
+    persistedImage: defaults?.persistedImage ?? false,
+    aiStatus: defaults?.aiStatus ?? "idle",
+    aiError: defaults?.aiError ?? null,
+  };
+};
+
+const resolveImageExtension = (file: File): string => {
+  const name = typeof file.name === "string" ? file.name : "";
+  const match = name.match(/\.([a-zA-Z0-9]{2,5})$/);
+  if (match) {
+    const ext = match[1].toLowerCase();
+    if (["jpg", "jpeg", "png", "webp"].includes(ext)) {
+      return ext === "jpeg" ? "jpg" : ext;
+    }
+  }
+  const type = typeof file.type === "string" ? file.type.toLowerCase() : "";
+  if (type.includes("png")) return "png";
+  if (type.includes("webp")) return "webp";
+  return "jpg";
 };
 
 const normaliseNumberString = (value: unknown, fallback: string): string => {
@@ -486,6 +535,7 @@ export default function NewProductPage() {
     | "spec"
     | "pnl"
     | "variations"
+    | "storyboard"
     | "orderFields"
     | "deliverables"
     | "kit"
@@ -503,6 +553,8 @@ export default function NewProductPage() {
   const [priceTier3, setPriceTier3] = useState("");
   const [galleryImages, setGalleryImages] = useState<GalleryImage[]>([]);
   const imageObjectUrlsRef = useRef<string[]>([]);
+  const storyboardPreviewUrlsRef = useRef<string[]>([]);
+  const storyboardDraftIdRef = useRef<string>(`draft-${generateFormId()}`);
   const [requirements, setRequirements] = useState("");
   const [operationsInfo, setOperationsInfo] = useState("");
   const [closingWhyItWorks, setClosingWhyItWorks] = useState("");
@@ -513,6 +565,12 @@ export default function NewProductPage() {
   const [orderFormFields, setOrderFormFields] = useState<
     OrderFormFieldFormState[]
   >([]);
+  const [storyboardEnabled, setStoryboardEnabled] = useState(false);
+  const [storyboardScenes, setStoryboardScenes] = useState<
+    StoryboardSceneFormState[]
+  >([]);
+  const [storyboardGeneratingSceneId, setStoryboardGeneratingSceneId] =
+    useState<string | null>(null);
   const [variations, setVariations] = useState<VariationFormState[]>([]);
   const [organiserEnabled, setOrganiserEnabled] = useState(false);
   const [organiserMinimum, setOrganiserMinimum] = useState("");
@@ -1039,6 +1097,14 @@ export default function NewProductPage() {
         }
       });
       imageObjectUrlsRef.current = [];
+      storyboardPreviewUrlsRef.current.forEach((url) => {
+        try {
+          URL.revokeObjectURL(url);
+        } catch {
+          // Ignore storyboard preview cleanup failures.
+        }
+      });
+      storyboardPreviewUrlsRef.current = [];
     },
     []
   );
@@ -1647,6 +1713,9 @@ export default function NewProductPage() {
       crewRoles: crewRoleData,
       organiserProgram: organiserProgramPayload,
       orderFormFields: orderFieldData,
+      storyboardEnabled: storyboardEnabledValue ? true : false,
+      storyboard: storyboardEnabledValue ? storyboardData : [],
+      storyboardImages: storyboardEnabledValue ? initialStoryboardImages : [],
     });
     const uploadedGalleryUrls = new Map<string, string>();
     const uploadBatchId = Date.now();
@@ -1707,6 +1776,21 @@ export default function NewProductPage() {
         `${PRODUCT_IMAGE_ROOT}/${docRef.id}/seo`,
         seoImageFile
       );
+    if (storyboardUploads.length > 0) {
+      for (const uploadEntry of storyboardUploads) {
+        const extension = resolveImageExtension(uploadEntry.file);
+        const storagePath = `${PRODUCT_IMAGE_ROOT}/${docRef.id}/storyboard-${uploadEntry.sceneId}.${extension}`;
+        const url = await upload(storagePath, uploadEntry.file);
+        const target = storyboardData.find((entry) => entry.id === uploadEntry.sceneId);
+        if (target) {
+          target.imageUrl = url;
+          target.storagePath = storagePath;
+        }
+      }
+    }
+    const finalStoryboardImages = storyboardData
+      .map((entry) => (entry.imageUrl ? entry.imageUrl : null))
+      .filter((url): url is string => typeof url === "string" && url.trim().length > 0);
     await updateDoc(docRef, {
       imageUrl: finalImageUrls[0] ?? null,
       imageUrls: finalImageUrls,
@@ -1714,6 +1798,9 @@ export default function NewProductPage() {
       modifierGroups: enabledGroups,
       modifiers: modifierData,
       seo: { ...seo, socialImageUrl: seoImage || null },
+      storyboardEnabled: storyboardEnabledValue ? true : false,
+      storyboard: storyboardEnabledValue ? storyboardData : [],
+      storyboardImages: storyboardEnabledValue ? finalStoryboardImages : [],
     });
     if (workflowId) {
       const fn = httpsCallable(functions, "admin_assignWorkflow");
@@ -1724,6 +1811,197 @@ export default function NewProductPage() {
 
   const addExampleVideo = () => {
     setExampleVideos((prev) => [...prev, createVideoInput()]);
+  };
+
+  const addStoryboardScene = () => {
+    setStoryboardScenes((prev) => [...prev, createStoryboardSceneState()]);
+    setStoryboardEnabled(true);
+  };
+
+  const updateStoryboardScene = (
+    sceneId: string,
+    patch: Partial<StoryboardSceneFormState>
+  ) => {
+    setStoryboardScenes((prev) =>
+      prev.map((scene) => (scene.id === sceneId ? { ...scene, ...patch } : scene))
+    );
+  };
+
+  const removeStoryboardScene = (sceneId: string) => {
+    setStoryboardScenes((prev) => {
+      const target = prev.find((scene) => scene.id === sceneId);
+      if (target?.previewUrl) {
+        try {
+          URL.revokeObjectURL(target.previewUrl);
+        } catch {
+          // Ignore storyboard preview cleanup failures when removing scenes.
+        }
+        storyboardPreviewUrlsRef.current = storyboardPreviewUrlsRef.current.filter(
+          (url) => url !== target.previewUrl
+        );
+      }
+      return prev.filter((scene) => scene.id !== sceneId);
+    });
+  };
+
+  const handleStoryboardSceneImage = (sceneId: string, file: File | null) => {
+    setStoryboardScenes((prev) =>
+      prev.map((scene) => {
+        if (scene.id !== sceneId) return scene;
+        if (scene.previewUrl) {
+          try {
+            URL.revokeObjectURL(scene.previewUrl);
+          } catch {
+            // Ignore cleanup failures.
+          }
+          storyboardPreviewUrlsRef.current = storyboardPreviewUrlsRef.current.filter(
+            (url) => url !== scene.previewUrl
+          );
+        }
+        if (!file) {
+          return {
+            ...scene,
+            imageFile: null,
+            previewUrl: null,
+            imageUrl: null,
+            persistedImage: false,
+            imageStoragePath: null,
+            aiError: null,
+          };
+        }
+        const previewUrl = URL.createObjectURL(file);
+        storyboardPreviewUrlsRef.current.push(previewUrl);
+        return {
+          ...scene,
+          imageFile: file,
+          previewUrl,
+          imageUrl: null,
+          persistedImage: false,
+          imageStoragePath: null,
+          aiError: null,
+        };
+      })
+    );
+  };
+
+  const handleGenerateStoryboardSceneImage = async (sceneId: string) => {
+    const scene = storyboardScenes.find((entry) => entry.id === sceneId);
+    if (!scene) return;
+    const description = scene.description.trim();
+    if (!description) {
+      setStoryboardScenes((prev) =>
+        prev.map((entry) =>
+          entry.id === sceneId
+            ? {
+                ...entry,
+                aiStatus: "error",
+                aiError: "Add a scene description before generating artwork.",
+              }
+            : entry
+        )
+      );
+      return;
+    }
+    setStoryboardScenes((prev) =>
+      prev.map((entry) =>
+        entry.id === sceneId
+          ? { ...entry, aiStatus: "loading", aiError: null }
+          : entry
+      )
+    );
+    setStoryboardGeneratingSceneId(sceneId);
+    try {
+      const startSeconds = parseStoryboardTimecode(scene.start);
+      const endSeconds = parseStoryboardTimecode(scene.end);
+      const variationNames = scene.variationIds
+        .map((variationId) =>
+          variations.find((variation) => variation.id === variationId)?.name?.trim() || null
+        )
+        .filter((value): value is string => Boolean(value && value.length > 0));
+      const deliverableSummaries = deliverables
+        .map((deliverable) => {
+          const title = (deliverable.title || "").trim();
+          if (!title) return null;
+          const qty =
+            typeof deliverable.quantity === "number" && Number.isFinite(deliverable.quantity)
+              ? Math.max(1, Math.round(deliverable.quantity))
+              : 1;
+          return `${qty > 1 ? `${qty}× ` : ""}${title}`;
+        })
+        .filter((value): value is string => Boolean(value));
+      const sceneIndex = storyboardScenes.findIndex((entry) => entry.id === sceneId);
+      const accentColor =
+        STORYBOARD_SCENE_COLOURS[
+          (sceneIndex >= 0 ? sceneIndex : 0) % STORYBOARD_SCENE_COLOURS.length
+        ];
+      const productKey = storyboardDraftIdRef.current;
+      const fn = httpsCallable(functions, "admin_generateStoryboardSceneImage");
+      const response = await fn({
+        productId: productKey,
+        sceneId,
+        sceneTitle: scene.title,
+        sceneDescription: description,
+        productName: name,
+        productTagline: tagline,
+        productDescription: description,
+        operationsInfo,
+        startSeconds,
+        endSeconds,
+        variationNames,
+        deliverables: deliverableSummaries,
+        accentColor,
+      });
+      const payload = (response?.data ?? {}) as {
+        imageUrl?: string;
+        storagePath?: string;
+      };
+      if (!payload.imageUrl) {
+        throw new Error("Image generation failed");
+      }
+      setStoryboardScenes((prev) =>
+        prev.map((entry) => {
+          if (entry.id !== sceneId) return entry;
+          if (entry.previewUrl) {
+            try {
+              URL.revokeObjectURL(entry.previewUrl);
+            } catch {
+              // Ignore cleanup failures after generation.
+            }
+            storyboardPreviewUrlsRef.current = storyboardPreviewUrlsRef.current.filter(
+              (url) => url !== entry.previewUrl
+            );
+          }
+          return {
+            ...entry,
+            imageUrl: payload.imageUrl || null,
+            imageStoragePath: payload.storagePath ?? null,
+            previewUrl: null,
+            imageFile: null,
+            persistedImage: true,
+            aiStatus: "idle",
+            aiError: null,
+          };
+        })
+      );
+    } catch (error) {
+      console.error("Failed to generate storyboard scene image", error);
+      setStoryboardScenes((prev) =>
+        prev.map((entry) =>
+          entry.id === sceneId
+            ? {
+                ...entry,
+                aiStatus: "error",
+                aiError:
+                  error instanceof Error
+                    ? error.message
+                    : "Unable to generate artwork. Please try again.",
+              }
+            : entry
+        )
+      );
+    } finally {
+      setStoryboardGeneratingSceneId(null);
+    }
   };
 
   const updateExampleVideo = (
@@ -1932,6 +2210,7 @@ export default function NewProductPage() {
       { key: "spec", label: "Product Spec" },
       { key: "pnl", label: "P&L" },
       { key: "variations", label: "Variations" },
+      { key: "storyboard", label: "Storyboard" },
       { key: "deliverables", label: "Deliverables" },
       { key: "orderFields", label: "Custom form fields" },
       { key: "tasks", label: "Default Tasks" },
@@ -3547,6 +3826,24 @@ export default function NewProductPage() {
             Add variation
           </button>
         </div>
+      )}
+
+      {tab === "storyboard" && (
+        <ProductStoryboardEditor
+          enabled={storyboardEnabled}
+          onToggleEnabled={(value) => setStoryboardEnabled(value)}
+          scenes={storyboardScenes}
+          onSceneChange={updateStoryboardScene}
+          onSceneImageSelect={handleStoryboardSceneImage}
+          onAddScene={addStoryboardScene}
+          onRemoveScene={removeStoryboardScene}
+          onGenerateSceneImage={handleGenerateStoryboardSceneImage}
+          generatingSceneId={storyboardGeneratingSceneId}
+          variationOptions={variations.map((variation) => ({
+            id: variation.id,
+            name: variation.name || variation.id,
+          }))}
+        />
       )}
 
       {tab === "orderFields" && (

--- a/apps/web/app/checkout/CheckoutClient.tsx
+++ b/apps/web/app/checkout/CheckoutClient.tsx
@@ -261,6 +261,30 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
 
         organiserMap.set(organiserKey, accumulator);
       }
+      const orderFormResponses = Array.isArray(item.orderFormResponses)
+        ? item.orderFormResponses.map((response) => ({
+            fieldId:
+              typeof response.fieldId === "string" && response.fieldId.trim().length > 0
+                ? response.fieldId.trim()
+                : "",
+            label:
+              typeof response.label === "string" && response.label.trim().length > 0
+                ? response.label.trim()
+                : "",
+            value:
+              typeof response.value === "string"
+                ? response.value
+                : response.value != null
+                  ? String(response.value)
+                  : "",
+            required: response.required === true,
+            type: response.type === "long-text" ? "long-text" : "short-text",
+            description:
+              typeof response.description === "string" && response.description.trim().length > 0
+                ? response.description.trim()
+                : null,
+          }))
+        : [];
       return {
         id: item.id,
         quantity: item.quantity,
@@ -273,6 +297,7 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
         location: item.location ?? null,
         postalCode: item.postalCode ?? null,
         exhibition: item.exhibition ?? null,
+        orderFormResponses,
         timeSlot: item.timeSlot ?? null,
         coverage: item.coverage ?? null,
         campaignBooking,
@@ -360,6 +385,7 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
           date: item.date,
           location: item.location,
           postalCode: item.postalCode,
+          orderFormResponses: item.orderFormResponses,
           coverage: item.coverage,
           timeSlot: item.timeSlot ?? null,
           exhibition: item.exhibition ?? null,

--- a/apps/web/components/AddToCartWizard.tsx
+++ b/apps/web/components/AddToCartWizard.tsx
@@ -533,25 +533,34 @@ export default function AddToCartWizard({
   const { items, add } = useCart();
   const [groups, setGroups] = useState<ModifierGroup[]>([]);
   const eventWindow = useMemo(() => getProductEventWindow(product), [product]);
+  const selectedVariation = useMemo(() => {
+    if (!variationId) {
+      return null;
+    }
+    const entries = Array.isArray(product.variations)
+      ? product.variations
+      : [];
+    return entries.find((entry) => entry?.id === variationId) ?? null;
+  }, [product.variations, variationId]);
   const onsiteDaysConfigured = useMemo(
-    () => resolveProductOnsiteDays(product) ?? 1,
-    [product]
+    () => resolveProductOnsiteDays(product, selectedVariation) ?? 1,
+    [product, selectedVariation]
   );
   const onsiteBlockingDays = useMemo(
     () => Math.max(1, Math.ceil(onsiteDaysConfigured)),
     [onsiteDaysConfigured]
   );
   const onsiteTiming = useMemo(
-    () => resolveProductOnsiteTiming(product),
-    [product]
+    () => resolveProductOnsiteTiming(product, selectedVariation),
+    [product, selectedVariation]
   );
   const timeSlotRequired = useMemo(
     () => onsiteTiming !== null && onsiteBlockingDays <= 1,
     [onsiteTiming, onsiteBlockingDays]
   );
   const onsiteSummary = useMemo(
-    () => formatProductOnsiteDuration(product),
-    [product]
+    () => formatProductOnsiteDuration(product, undefined, selectedVariation),
+    [product, selectedVariation]
   );
   const eventRangeLabel = useMemo(
     () => getProductEventRangeLabel(product),

--- a/apps/web/components/AddToCartWizard.tsx
+++ b/apps/web/components/AddToCartWizard.tsx
@@ -11,6 +11,7 @@ import {
   getProductEventMonthKeys,
   resolveProductOnsiteTiming,
   type ProductOnsiteTiming,
+  type ProductOrderFieldType,
 } from "@/lib/products";
 import { useCart } from "@/lib/cart";
 import { db, functions } from "@/lib/firebase";
@@ -143,6 +144,14 @@ interface PostcodeLookupResult {
   lat: number | null;
   lng: number | null;
 }
+
+type OrderFormQuestion = {
+  id: string;
+  label: string;
+  description: string | null;
+  required: boolean;
+  type: ProductOrderFieldType;
+};
 
 const normalisePostalCode = (value: string): string | null => {
   if (typeof value !== "string") return null;
@@ -853,6 +862,94 @@ export default function AddToCartWizard({
   const [availabilityOverrides, setAvailabilityOverrides] = useState<
     Record<string, ProductAvailabilityStatus>
   >({});
+  const orderFormQuestions = useMemo<OrderFormQuestion[]>(() => {
+    const fields = Array.isArray(product.orderFormFields)
+      ? (product.orderFormFields as any[])
+      : [];
+    return fields
+      .map((raw, index) => {
+        if (!raw || typeof raw !== "object") {
+          return null;
+        }
+        const label =
+          typeof raw.label === "string" && raw.label.trim().length > 0
+            ? raw.label.trim()
+            : "";
+        if (!label) {
+          return null;
+        }
+        const id =
+          typeof raw.id === "string" && raw.id.trim().length > 0
+            ? raw.id.trim()
+            : `order-field-${index}`;
+        const description =
+          typeof raw.description === "string" && raw.description.trim().length > 0
+            ? raw.description.trim()
+            : null;
+        const typeValue =
+          typeof raw.type === "string" && raw.type === "long-text"
+            ? "long-text"
+            : "short-text";
+        const required = raw.required === true;
+        return {
+          id,
+          label,
+          description,
+          required,
+          type: typeValue as ProductOrderFieldType,
+        } satisfies OrderFormQuestion;
+      })
+      .filter((entry): entry is OrderFormQuestion => entry !== null);
+  }, [product.orderFormFields]);
+  const [orderFormValues, setOrderFormValues] = useState<Record<string, string>>(() => {
+    const initial: Record<string, string> = {};
+    orderFormQuestions.forEach((question) => {
+      initial[question.id] = "";
+    });
+    return initial;
+  });
+  const [orderFormErrors, setOrderFormErrors] = useState<Record<string, string>>({});
+  useEffect(() => {
+    setOrderFormValues((prev) => {
+      const next: Record<string, string> = {};
+      orderFormQuestions.forEach((question) => {
+        next[question.id] = prev[question.id] ?? "";
+      });
+      return next;
+    });
+    setOrderFormErrors({});
+  }, [orderFormQuestions]);
+  const handleOrderFieldChange = useCallback((id: string, value: string) => {
+    setOrderFormValues((prev) => ({ ...prev, [id]: value }));
+    setOrderFormErrors((prev) => {
+      if (!prev[id]) {
+        return prev;
+      }
+      if (value.trim().length > 0) {
+        const { [id]: _removed, ...rest } = prev;
+        return rest;
+      }
+      return prev;
+    });
+  }, []);
+  const validateOrderForm = useCallback(() => {
+    if (orderFormQuestions.length === 0) {
+      setOrderFormErrors({});
+      return true;
+    }
+    const errors: Record<string, string> = {};
+    orderFormQuestions.forEach((question) => {
+      if (!question.required) {
+        return;
+      }
+      const value = orderFormValues[question.id]?.trim() ?? "";
+      if (value.length === 0) {
+        errors[question.id] = "Please provide a response.";
+      }
+    });
+    setOrderFormErrors(errors);
+    return Object.keys(errors).length === 0;
+  }, [orderFormQuestions, orderFormValues]);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   const territoriesRef = useRef<TerritoryRecord[] | null>(null);
@@ -1113,9 +1210,14 @@ export default function AddToCartWizard({
   }, [product]);
 
   const hasLocationStep = !hasPresetVenue || overrideLocation;
-  const totalSteps = groups.length + (hasLocationStep ? 2 : 1);
+  const hasOrderFields = orderFormQuestions.length > 0;
+  const totalSteps =
+    groups.length + (hasLocationStep ? 1 : 0) + (hasOrderFields ? 1 : 0) + 1;
   const locationStep = hasLocationStep && step === 0;
-  const modifierIndex = step - (hasLocationStep ? 1 : 0);
+  const orderFieldsStepIndex = hasLocationStep ? 1 : 0;
+  const orderFieldsStep = hasOrderFields && step === orderFieldsStepIndex;
+  const modifierIndex =
+    step - (hasLocationStep ? 1 : 0) - (hasOrderFields ? 1 : 0);
   const currentGroup =
     modifierIndex >= 0 && modifierIndex < groups.length ? groups[modifierIndex] : null;
   const dateStep = step === totalSteps - 1;
@@ -1123,15 +1225,19 @@ export default function AddToCartWizard({
     ? overrideLocation && hasPresetVenue
       ? "Enter the alternate filming location"
       : "Confirm the filming location"
-    : currentGroup
-      ? `Choose ${currentGroup.multiple ? "one or more" : "an"} option for ${currentGroup.name}`
-      : isCampaignProduct
-        ? "Choose a campaign slot"
-        : "Confirm the production date";
+    : orderFieldsStep
+      ? orderFormQuestions.length > 1
+        ? "Answer the booking questions"
+        : "Provide the booking detail"
+      : currentGroup
+        ? `Choose ${currentGroup.multiple ? "one or more" : "an"} option for ${currentGroup.name}`
+        : isCampaignProduct
+          ? "Choose a campaign slot"
+          : "Confirm the production date";
 
   useEffect(() => {
     setStep(0);
-  }, [hasLocationStep]);
+  }, [hasLocationStep, hasOrderFields]);
 
   useEffect(() => {
     setLiveMessage(`Step ${step + 1} of ${totalSteps}: ${stepLabel}`);
@@ -1549,7 +1655,14 @@ export default function AddToCartWizard({
     });
   };
 
-  const next = () => setStep((s) => Math.min(s + 1, totalSteps - 1));
+  const next = () => {
+    setError(null);
+    if (orderFieldsStep && !validateOrderForm()) {
+      setLiveMessage("Answer the required booking questions to continue");
+      return;
+    }
+    setStep((s) => Math.min(s + 1, totalSteps - 1));
+  };
   const back = () => {
     if (step === 0) onClose();
     else setStep((s) => s - 1);
@@ -1558,6 +1671,14 @@ export default function AddToCartWizard({
   const handleFinish = async () => {
     setError(null);
     setConflicts([]);
+    if (!validateOrderForm()) {
+      setLiveMessage("Answer the required booking questions to continue");
+      if (hasOrderFields) {
+        setStep(orderFieldsStepIndex);
+      }
+      setError("Answer the required booking questions to continue.");
+      return;
+    }
     const selections: ProductModifierSelection[] = [];
     let adj = 0;
     groups.forEach((g) => {
@@ -1771,6 +1892,14 @@ export default function AddToCartWizard({
                   : null,
             }
           : null;
+      const orderFormResponses = orderFormQuestions.map((question) => ({
+        fieldId: question.id,
+        label: question.label,
+        value: (orderFormValues[question.id] ?? "").trim(),
+        required: question.required,
+        type: question.type,
+        description: question.description ?? null,
+      }));
       add({
         id: product.id,
         name: product.name,
@@ -1788,6 +1917,7 @@ export default function AddToCartWizard({
         kitStatus: reservationStatus,
         kitWarnings: warnings,
         exhibition: exhibitionSelection,
+        orderFormResponses,
         location: locationLabel.length > 0 ? locationLabel : null,
         postalCode: postalCodeLabel,
         timeSlot:
@@ -1916,11 +2046,19 @@ export default function AddToCartWizard({
 
   const canNext = locationStep
     ? coverageStatus === "success" && !!coverage && locationInput.trim().length > 0
-    : currentGroup
-      ? (selected[currentGroup.id] || []).length > 0
-      : isCampaignProduct
-        ? campaignSlotStatus === "success" && !!selectedSlotId
-        : !!date;
+    : orderFieldsStep
+      ? orderFormQuestions.every((question) => {
+          if (!question.required) {
+            return true;
+          }
+          const value = orderFormValues[question.id] ?? "";
+          return value.trim().length > 0;
+        })
+      : currentGroup
+        ? (selected[currentGroup.id] || []).length > 0
+        : isCampaignProduct
+          ? campaignSlotStatus === "success" && !!selectedSlotId
+          : !!date;
 
   const descriptionIds = useMemo(() => {
     const ids = ["wizard-description"];
@@ -2103,6 +2241,61 @@ export default function AddToCartWizard({
             <p className="text-xs text-gray-500">
               Confirming the filming location routes your booking to the right franchise or HQ
               team before we show available production dates.
+            </p>
+          </div>
+        ) : orderFieldsStep ? (
+          <div className="space-y-3">
+            {orderFormQuestions.map((question) => {
+              const inputId = `order-question-${question.id}`;
+              const value = orderFormValues[question.id] ?? "";
+              const fieldError = orderFormErrors[question.id];
+              return (
+                <div key={question.id} className="space-y-1">
+                  <label
+                    htmlFor={inputId}
+                    className="flex items-center gap-2 text-sm font-semibold text-gray-900"
+                  >
+                    {question.label}
+                    {question.required && (
+                      <span className="text-xs font-medium text-red-600">Required</span>
+                    )}
+                  </label>
+                  {question.description && (
+                    <p className="text-xs text-gray-500">{question.description}</p>
+                  )}
+                  {question.type === "long-text" ? (
+                    <textarea
+                      id={inputId}
+                      className={`textarea textarea-bordered mt-1 w-full ${
+                        fieldError ? "border-red-500 focus:border-red-500 focus:ring-red-500" : ""
+                      }`}
+                      value={value}
+                      rows={3}
+                      onChange={(event) =>
+                        handleOrderFieldChange(question.id, event.target.value)
+                      }
+                    />
+                  ) : (
+                    <input
+                      id={inputId}
+                      type="text"
+                      className={`input input-bordered mt-1 w-full ${
+                        fieldError ? "border-red-500 focus:border-red-500 focus:ring-red-500" : ""
+                      }`}
+                      value={value}
+                      onChange={(event) =>
+                        handleOrderFieldChange(question.id, event.target.value)
+                      }
+                    />
+                  )}
+                  {fieldError && (
+                    <p className="text-xs text-red-600">{fieldError}</p>
+                  )}
+                </div>
+              );
+            })}
+            <p className="text-xs text-gray-500">
+              Your answers help the production team prepare for the shoot.
             </p>
           </div>
         ) : currentGroup ? (

--- a/apps/web/components/ProductDetail.tsx
+++ b/apps/web/components/ProductDetail.tsx
@@ -314,14 +314,22 @@ export default function ProductDetail({
     () => getProductEventRangeLabel(product),
     [product]
   );
-  const onsiteSummary = useMemo(
-    () => formatProductOnsiteDuration(product),
-    [product]
-  );
 
   const variationEntries = useMemo(
     () => (Array.isArray(product.variations) ? product.variations : []),
     [product.variations]
+  );
+
+  const activeVariation = useMemo(() => {
+    if (!variation) {
+      return null;
+    }
+    return variationEntries.find((entry) => entry?.id === variation) ?? null;
+  }, [variationEntries, variation]);
+
+  const onsiteSummary = useMemo(
+    () => formatProductOnsiteDuration(product, undefined, activeVariation),
+    [product, activeVariation]
   );
 
   const computePriceForSelection = useCallback(
@@ -534,13 +542,6 @@ export default function ProductDetail({
       ])
     );
   }, [variationEntries]);
-
-  const activeVariation = useMemo(() => {
-    if (!variation) {
-      return null;
-    }
-    return variationEntries.find((entry) => entry?.id === variation) ?? null;
-  }, [variationEntries, variation]);
 
   const selectedVariationSummary = useMemo(() => {
     if (!variation) return null;
@@ -931,6 +932,15 @@ export default function ProductDetail({
             ? `${total} included`
             : "Confirmed during scoping";
         }),
+      });
+    }
+    const onsiteValues = variationEntries.map((variationEntry) =>
+      formatProductOnsiteDuration(product, undefined, variationEntry) || ""
+    );
+    if (onsiteValues.some((value) => value.length > 0)) {
+      rows.push({
+        label: "On-site",
+        values: onsiteValues.map((value) => value || "—"),
       });
     }
     const variationTurnarounds = variationEntries.map((variationEntry) =>

--- a/apps/web/components/ProductDetail.tsx
+++ b/apps/web/components/ProductDetail.tsx
@@ -985,6 +985,7 @@ export default function ProductDetail({
     organiserContext,
     organiserUpsellIds,
     variationEntries,
+    product,
   ]);
 
   const hasVariations = availableVariationIds.length > 0;

--- a/apps/web/components/ProductDetail.tsx
+++ b/apps/web/components/ProductDetail.tsx
@@ -47,6 +47,26 @@ const deliverableIcons: Record<DeliverableType, IconType> = {
   document: FiFileText,
 };
 
+function getDeliverableDisplayQuantity(entry: unknown): number | null {
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+  const raw = (entry as { quantity?: unknown }).quantity;
+  if (typeof raw !== "number" || Number.isNaN(raw)) {
+    return null;
+  }
+  const rounded = Math.round(raw);
+  return rounded > 0 ? rounded : null;
+}
+
+function getDeliverableCount(entry: unknown): number {
+  const explicit = getDeliverableDisplayQuantity(entry);
+  if (explicit && explicit > 0) {
+    return explicit;
+  }
+  return 1;
+}
+
 type VideoPlayback =
   | { kind: "iframe"; src: string }
   | { kind: "file"; src: string }
@@ -560,11 +580,16 @@ export default function ProductDetail({
       return true;
     });
 
+    const totalCount = entries.reduce(
+      (count, entry) => count + getDeliverableCount(entry),
+      0
+    );
+
     return {
       visible,
       hasRestricted,
       selectedId,
-      total: entries.length,
+      total: totalCount,
     } as const;
   }, [product.deliverables, availableVariationIds, variation]);
 
@@ -595,6 +620,8 @@ export default function ProductDetail({
         typeof deliverable.title === "string"
           ? deliverable.title.trim()
           : "";
+      const quantity = getDeliverableDisplayQuantity(deliverable);
+      const displayTitle = quantity ? `${quantity}× ${title}`.trim() : title;
       const description =
         typeof deliverable.description === "string"
           ? deliverable.description.trim()
@@ -639,7 +666,7 @@ export default function ProductDetail({
 
       items.push({
         key: `${index}-${title || "deliverable"}`,
-        title,
+        title: displayTitle,
         description,
         thumb: thumb || undefined,
         Icon,
@@ -662,6 +689,9 @@ export default function ProductDetail({
       return null;
     }
     const byId = new Map<string, number>();
+    let fallbackCount = 0;
+    const generalTargets = availableVariationIds;
+
     product.deliverables.forEach((entry) => {
       if (!entry) return;
       const scoped = Array.isArray(entry.variationIds)
@@ -672,17 +702,26 @@ export default function ProductDetail({
                 typeof id === "string" && availableVariationIds.includes(id)
             )
         : [];
-      const targetIds = scoped.length > 0 ? scoped : availableVariationIds;
-      if (targetIds.length === 0) {
+      const quantity = getDeliverableCount(entry);
+      if (scoped.length > 0) {
+        scoped.forEach((id) => {
+          byId.set(id, (byId.get(id) || 0) + quantity);
+        });
         return;
       }
-      targetIds.forEach((id) => {
-        byId.set(id, (byId.get(id) || 0) + 1);
+
+      fallbackCount += quantity;
+      if (generalTargets.length === 0) {
+        return;
+      }
+      generalTargets.forEach((id) => {
+        byId.set(id, (byId.get(id) || 0) + quantity);
       });
     });
+
     return {
       byId,
-      fallback: product.deliverables.length,
+      fallback: fallbackCount,
     } as const;
   }, [product.deliverables, availableVariationIds]);
 
@@ -771,9 +810,18 @@ export default function ProductDetail({
   const deliverableHighlights = useMemo(() => {
     if (!Array.isArray(product.deliverables)) return [] as string[];
     return product.deliverables
-      .map((entry) =>
-        typeof entry?.title === "string" ? entry.title.trim() : ""
-      )
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return "";
+        }
+        const title =
+          typeof entry.title === "string" ? entry.title.trim() : "";
+        if (!title) {
+          return "";
+        }
+        const quantity = getDeliverableDisplayQuantity(entry);
+        return quantity ? `${quantity}× ${title}`.trim() : title;
+      })
       .filter((title) => title.length > 0)
       .slice(0, 3);
   }, [product.deliverables]);
@@ -867,11 +915,20 @@ export default function ProductDetail({
       rows.push({
         label: "Deliverables",
         values: variationEntries.map((variationEntry) => {
-          const count =
-            deliverablesByVariation.byId.get(variationEntry.id) ??
-            deliverablesByVariation.fallback;
-          return count > 0
-            ? `${count} included`
+          const rawCount = deliverablesByVariation.byId.get(
+            variationEntry.id
+          );
+          const fallbackCount = deliverablesByVariation.fallback;
+          const resolved =
+            typeof rawCount === "number" && Number.isFinite(rawCount)
+              ? rawCount
+              : fallbackCount;
+          const total =
+            typeof resolved === "number" && Number.isFinite(resolved)
+              ? Math.max(0, Math.round(resolved))
+              : 0;
+          return total > 0
+            ? `${total} included`
             : "Confirmed during scoping";
         }),
       });

--- a/apps/web/components/admin/email/EmailTemplatesWorkspace.tsx
+++ b/apps/web/components/admin/email/EmailTemplatesWorkspace.tsx
@@ -472,6 +472,7 @@ export default function EmailTemplatesWorkspace() {
   const [savingTemplate, setSavingTemplate] = useState(false);
   const [savingGlobal, setSavingGlobal] = useState(false);
   const [currentUser, setCurrentUser] = useState<any>(null);
+  const [removingSenderId, setRemovingSenderId] = useState<string | null>(null);
 
   const dbRef = useRef<any>(null);
   const authUnsubscribeRef = useRef<() => void>();
@@ -658,6 +659,20 @@ export default function EmailTemplatesWorkspace() {
     () => senders.filter((sender) => sender.status === "connected"),
     [senders]
   );
+
+  useEffect(() => {
+    if (!formState.sendFromAccountId) return;
+    const senderExists = senders.some((sender) => sender.id === formState.sendFromAccountId);
+    if (senderExists) return;
+    setFormState((prev) => ({ ...prev, sendFromAccountId: "" }));
+  }, [formState.sendFromAccountId, senders]);
+
+  useEffect(() => {
+    if (!globalForm.defaultSenderId) return;
+    const senderExists = senders.some((sender) => sender.id === globalForm.defaultSenderId);
+    if (senderExists) return;
+    setGlobalForm((prev) => ({ ...prev, defaultSenderId: "" }));
+  }, [globalForm.defaultSenderId, senders]);
 
   const inboxMessagesThisWeek = useMemo(() => {
     const now = new Date();
@@ -856,6 +871,79 @@ export default function EmailTemplatesWorkspace() {
       );
     } finally {
       setSavingGlobal(false);
+    }
+  };
+
+  const handleRemoveSender = async (sender: EmailSenderRecord) => {
+    const confirmed = window.confirm(
+      `Remove ${sender.displayName || sender.email} from the connected accounts? Templates using this inbox will fall back to the global default.`
+    );
+    if (!confirmed) return;
+
+    setRemovingSenderId(sender.id);
+    setErrorMessage(null);
+    setStatusMessage(null);
+
+    try {
+      if (!dbRef.current) {
+        const { db } = await ensureFirebase();
+        dbRef.current = db;
+      }
+
+      const db = dbRef.current;
+
+      const updates: Promise<unknown>[] = [];
+
+      if (globalSettings?.defaultSenderId === sender.id) {
+        updates.push(
+          setDoc(
+            doc(db, "emailSettings", "global"),
+            {
+              defaultSenderId: null,
+              updatedAt: serverTimestamp(),
+              updatedBy: currentUser?.uid ?? null,
+              updatedByName:
+                (currentUser?.displayName as string | undefined) ||
+                (currentUser?.email as string | undefined) ||
+                null,
+              updatedByEmail: currentUser?.email ?? null,
+            },
+            { merge: true }
+          )
+        );
+      }
+
+      const impactedScenarios = scenarios.filter((scenario) => scenario.sendFromAccountId === sender.id);
+      impactedScenarios.forEach((scenario) => {
+        updates.push(
+          setDoc(
+            doc(db, "emailTemplates", scenario.id),
+            {
+              sendFromAccountId: null,
+              updatedAt: serverTimestamp(),
+              updatedBy: currentUser?.uid ?? null,
+              updatedByName:
+                (currentUser?.displayName as string | undefined) ||
+                (currentUser?.email as string | undefined) ||
+                null,
+              updatedByEmail: currentUser?.email ?? null,
+            },
+            { merge: true }
+          )
+        );
+      });
+
+      await Promise.all([
+        deleteDoc(doc(db, "emailSenders", sender.id)),
+        ...updates,
+      ]);
+
+      setStatusMessage("Sender removed. Any automations using it now inherit the default configuration.");
+    } catch (error) {
+      console.error("Failed to remove email sender", error);
+      setErrorMessage(error instanceof Error ? error.message : "Unable to remove sender. Try again.");
+    } finally {
+      setRemovingSenderId(null);
     }
   };
 
@@ -1152,6 +1240,15 @@ export default function EmailTemplatesWorkspace() {
                 Link shared Gmail inboxes to power automated sending. Once authorised, the account can be selected per template or set as the global default.
               </p>
 
+              <div className="mt-4 rounded-2xl bg-slate-50 p-4 text-xs text-slate-600">
+                <h3 className="text-sm font-semibold text-slate-900">Connection checklist</h3>
+                <ol className="mt-2 list-decimal space-y-1 pl-5">
+                  <li>Request access with the shared Gmail address so we create a pending record.</li>
+                  <li>Approve the OAuth prompt from the generated Cloud Functions link or Google Cloud console.</li>
+                  <li>Return here to confirm the status shows <span className="font-semibold text-emerald-700">connected</span> and assign it to templates or the global default.</li>
+                </ol>
+              </div>
+
               <form className="mt-4 space-y-3" onSubmit={handleRequestGmailConnection}>
                 <label className="space-y-1 text-sm text-slate-700">
                   <span className="font-medium">Connect new Gmail address</span>
@@ -1191,17 +1288,27 @@ export default function EmailTemplatesWorkspace() {
                             <p className="font-semibold text-slate-900">{sender.displayName}</p>
                             <p className="text-xs text-slate-500">{sender.email}</p>
                           </div>
-                          <span
-                            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
-                              sender.status === "connected"
-                                ? "bg-emerald-100 text-emerald-700"
-                                : sender.status === "error"
-                                ? "bg-rose-100 text-rose-700"
-                                : "bg-amber-100 text-amber-700"
-                            }`}
-                          >
-                            {sender.status}
-                          </span>
+                          <div className="flex items-center gap-2">
+                            <span
+                              className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
+                                sender.status === "connected"
+                                  ? "bg-emerald-100 text-emerald-700"
+                                  : sender.status === "error"
+                                  ? "bg-rose-100 text-rose-700"
+                                  : "bg-amber-100 text-amber-700"
+                              }`}
+                            >
+                              {sender.status}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveSender(sender)}
+                              disabled={removingSenderId === sender.id}
+                              className="rounded-full border border-rose-200 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-rose-700 transition hover:border-rose-300 hover:bg-rose-50 disabled:cursor-not-allowed disabled:border-rose-100 disabled:text-rose-300"
+                            >
+                              {removingSenderId === sender.id ? "Removing…" : "Remove"}
+                            </button>
+                          </div>
                         </div>
                         <dl className="mt-2 grid gap-2 text-xs text-slate-500">
                           <div className="flex items-center justify-between">

--- a/apps/web/components/admin/products/ProductOrderFieldsEditor.tsx
+++ b/apps/web/components/admin/products/ProductOrderFieldsEditor.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { generateFormId } from "@/lib/forms";
+import { useCallback } from "react";
+
+export type OrderFormFieldInputType = "short-text" | "long-text";
+
+export interface OrderFormFieldFormState {
+  id: string;
+  label: string;
+  description: string;
+  required: boolean;
+  type: OrderFormFieldInputType;
+}
+
+interface Props {
+  fields: OrderFormFieldFormState[];
+  onChange: (fields: OrderFormFieldFormState[]) => void;
+}
+
+const createField = (): OrderFormFieldFormState => ({
+  id: generateFormId(),
+  label: "",
+  description: "",
+  required: false,
+  type: "short-text",
+});
+
+const typeOptions: { value: OrderFormFieldInputType; label: string }[] = [
+  { value: "short-text", label: "Short text" },
+  { value: "long-text", label: "Paragraph" },
+];
+
+export default function ProductOrderFieldsEditor({ fields, onChange }: Props) {
+  const addField = useCallback(() => {
+    onChange([...fields, createField()]);
+  }, [fields, onChange]);
+
+  const updateField = useCallback(
+    (index: number, patch: Partial<OrderFormFieldFormState>) => {
+      onChange(
+        fields.map((field, i) => (i === index ? { ...field, ...patch } : field))
+      );
+    },
+    [fields, onChange]
+  );
+
+  const removeField = useCallback(
+    (index: number) => {
+      onChange(fields.filter((_, i) => i !== index));
+    },
+    [fields, onChange]
+  );
+
+  const moveField = useCallback(
+    (index: number, delta: -1 | 1) => {
+      const nextIndex = index + delta;
+      if (nextIndex < 0 || nextIndex >= fields.length) {
+        return;
+      }
+      const next = [...fields];
+      const [entry] = next.splice(index, 1);
+      next.splice(nextIndex, 0, entry);
+      onChange(next);
+    },
+    [fields, onChange]
+  );
+
+  return (
+    <div className="space-y-4">
+      {fields.length === 0 ? (
+        <div className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-600">
+          <p>No custom questions configured yet.</p>
+          <p className="mt-2">
+            Add prompts to collect extra booking details like stand numbers or
+            campaign goals when customers add this product to their cart.
+          </p>
+          <button type="button" className="btn btn-sm mt-4" onClick={addField}>
+            Add question
+          </button>
+        </div>
+      ) : (
+        <>
+          {fields.map((field, index) => {
+            const id = `order-field-${field.id}`;
+            const descriptionId = `${id}-help`;
+            return (
+              <div key={field.id} className="space-y-4 rounded-md border border-slate-200 p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-sm font-semibold text-slate-900">
+                      Question {index + 1}
+                    </h3>
+                    <p className="text-xs text-slate-500">
+                      Shown during checkout before the customer selects their production date.
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-xs"
+                      onClick={() => moveField(index, -1)}
+                      disabled={index === 0}
+                    >
+                      Move up
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-xs"
+                      onClick={() => moveField(index, 1)}
+                      disabled={index === fields.length - 1}
+                    >
+                      Move down
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-xs text-red-600"
+                      onClick={() => removeField(index)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+                <div>
+                  <label htmlFor={id} className="block text-sm font-medium text-slate-900">
+                    Field label
+                  </label>
+                  <input
+                    id={id}
+                    type="text"
+                    className="input input-bordered mt-1 w-full"
+                    value={field.label}
+                    onChange={(event) => updateField(index, { label: event.target.value })}
+                    placeholder="e.g. Exhibition stand number"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor={`${id}-description`}
+                    className="block text-sm font-medium text-slate-900"
+                  >
+                    Helper text (optional)
+                  </label>
+                  <textarea
+                    id={`${id}-description`}
+                    className="textarea textarea-bordered mt-1 w-full"
+                    value={field.description}
+                    onChange={(event) =>
+                      updateField(index, { description: event.target.value })
+                    }
+                    placeholder="Provide guidance for the team reviewing this booking."
+                  />
+                </div>
+                <div className="flex flex-wrap items-center gap-4">
+                  <div>
+                    <label
+                      htmlFor={`${id}-type`}
+                      className="block text-sm font-medium text-slate-900"
+                    >
+                      Response type
+                    </label>
+                    <select
+                      id={`${id}-type`}
+                      className="select select-bordered mt-1"
+                      value={field.type}
+                      onChange={(event) =>
+                        updateField(index, {
+                          type: event.target.value as OrderFormFieldInputType,
+                        })
+                      }
+                    >
+                      {typeOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm text-slate-700">
+                    <input
+                      type="checkbox"
+                      className="checkbox"
+                      checked={field.required}
+                      onChange={(event) =>
+                        updateField(index, { required: event.target.checked })
+                      }
+                      aria-describedby={descriptionId}
+                    />
+                    Required response
+                  </label>
+                  <span id={descriptionId} className="text-xs text-slate-500">
+                    Required questions must be answered before the product can be added to the cart.
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+          <div>
+            <button type="button" className="btn btn-sm" onClick={addField}>
+              Add another question
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export { createField as createOrderFormField };

--- a/apps/web/components/admin/products/ProductStoryboardEditor.tsx
+++ b/apps/web/components/admin/products/ProductStoryboardEditor.tsx
@@ -1,0 +1,476 @@
+import { useMemo } from "react";
+import Image from "next/image";
+
+export const STORYBOARD_SCENE_COLOURS = [
+  "#f97316",
+  "#0ea5e9",
+  "#8b5cf6",
+  "#10b981",
+  "#ec4899",
+  "#facc15",
+  "#38bdf8",
+  "#14b8a6",
+];
+
+const TIME_PATTERN = /^\s*(?:(\d{1,2}):)?(\d{1,2}):(\d{2})\s*$/;
+const SHORT_TIME_PATTERN = /^\s*(\d{1,2}):(\d{2})\s*$/;
+
+export const parseStoryboardTimecode = (value: string): number | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  let hours = 0;
+  let minutes = 0;
+  let seconds = 0;
+  const longMatch = trimmed.match(TIME_PATTERN);
+  if (longMatch) {
+    hours = Number(longMatch[1] ?? "0");
+    minutes = Number(longMatch[2] ?? "0");
+    seconds = Number(longMatch[3] ?? "0");
+  } else {
+    const shortMatch = trimmed.match(SHORT_TIME_PATTERN);
+    if (!shortMatch) {
+      const fallback = Number(trimmed);
+      return Number.isFinite(fallback) && fallback >= 0 ? fallback : null;
+    }
+    minutes = Number(shortMatch[1] ?? "0");
+    seconds = Number(shortMatch[2] ?? "0");
+  }
+  if (
+    !Number.isFinite(hours) ||
+    !Number.isFinite(minutes) ||
+    !Number.isFinite(seconds) ||
+    minutes > 59 ||
+    seconds > 59 ||
+    hours < 0 ||
+    minutes < 0 ||
+    seconds < 0
+  ) {
+    return null;
+  }
+  return hours * 3600 + minutes * 60 + seconds;
+};
+
+export const formatStoryboardSeconds = (seconds: number | null | undefined): string => {
+  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds < 0) {
+    return "";
+  }
+  const rounded = Math.round(seconds);
+  const hrs = Math.floor(rounded / 3600);
+  const mins = Math.floor((rounded % 3600) / 60);
+  const secs = rounded % 60;
+  if (hrs > 0) {
+    return `${String(hrs).padStart(2, "0")}:${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+  }
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+};
+
+export type StoryboardSceneFormState = {
+  id: string;
+  title: string;
+  description: string;
+  start: string;
+  end: string;
+  variationIds: string[];
+  imageUrl: string | null;
+  previewUrl: string | null;
+  imageFile?: File | null;
+  imageStoragePath: string | null;
+  persistedImage: boolean;
+  aiStatus: "idle" | "loading" | "error";
+  aiError: string | null;
+};
+
+type VariationOption = { id: string; name: string };
+
+type ProductStoryboardEditorProps = {
+  enabled: boolean;
+  onToggleEnabled: (enabled: boolean) => void;
+  scenes: StoryboardSceneFormState[];
+  onSceneChange: (sceneId: string, patch: Partial<StoryboardSceneFormState>) => void;
+  onSceneImageSelect: (sceneId: string, file: File | null) => void;
+  onAddScene: () => void;
+  onRemoveScene: (sceneId: string) => void;
+  onGenerateSceneImage: (sceneId: string) => void;
+  generatingSceneId: string | null;
+  variationOptions: VariationOption[];
+};
+
+type TimelineSegment = {
+  id: string;
+  label: string;
+  startLabel: string;
+  endLabel: string;
+  durationLabel: string;
+  width: number;
+  color: string;
+  image: string | null;
+};
+
+const buildDurationLabel = (startSeconds: number | null, endSeconds: number | null): string => {
+  if (startSeconds === null && endSeconds === null) return "Timing TBD";
+  if (startSeconds === null) return `0:00 – ${formatStoryboardSeconds(endSeconds)}`;
+  if (endSeconds === null) return `${formatStoryboardSeconds(startSeconds)} onwards`;
+  if (endSeconds <= startSeconds) {
+    return `${formatStoryboardSeconds(startSeconds)} – ${formatStoryboardSeconds(endSeconds)}`;
+  }
+  return `${formatStoryboardSeconds(startSeconds)} – ${formatStoryboardSeconds(endSeconds)}`;
+};
+
+const ProductStoryboardEditor = ({
+  enabled,
+  onToggleEnabled,
+  scenes,
+  onSceneChange,
+  onSceneImageSelect,
+  onAddScene,
+  onRemoveScene,
+  onGenerateSceneImage,
+  generatingSceneId,
+  variationOptions,
+}: ProductStoryboardEditorProps) => {
+  const timeline = useMemo(() => {
+    if (!enabled || scenes.length === 0) return [] as TimelineSegment[];
+    const segments = scenes.map((scene, index) => {
+      const startSeconds = parseStoryboardTimecode(scene.start);
+      const endSeconds = parseStoryboardTimecode(scene.end);
+      let duration = 0;
+      if (
+        typeof startSeconds === "number" &&
+        typeof endSeconds === "number" &&
+        endSeconds > startSeconds
+      ) {
+        duration = endSeconds - startSeconds;
+      } else if (typeof endSeconds === "number") {
+        duration = Math.max(endSeconds, 30);
+      } else if (typeof startSeconds === "number") {
+        duration = Math.max(60 - startSeconds, 30);
+      } else {
+        duration = 60;
+      }
+      return {
+        id: scene.id,
+        duration,
+        color: STORYBOARD_SCENE_COLOURS[index % STORYBOARD_SCENE_COLOURS.length],
+        label: scene.title.trim() || `Scene ${index + 1}`,
+        startLabel:
+          typeof startSeconds === "number"
+            ? formatStoryboardSeconds(startSeconds)
+            : "0:00",
+        endLabel:
+          typeof endSeconds === "number"
+            ? formatStoryboardSeconds(endSeconds)
+            : "…",
+        durationLabel: buildDurationLabel(startSeconds, endSeconds),
+        image: scene.previewUrl || scene.imageUrl || null,
+      } satisfies TimelineSegment & { duration: number };
+    });
+    const total = segments.reduce((sum, item) => sum + item.duration, 0) || 1;
+    return segments.map((segment) => ({
+      ...segment,
+      width: Math.max(10, Math.round((segment.duration / total) * 100)),
+    }));
+  }, [enabled, scenes]);
+
+  return (
+    <section className="grid gap-6">
+      <header className="grid gap-2">
+        <h2 className="text-lg font-semibold">Storyboard</h2>
+        <p className="text-sm text-gray-600">
+          Share a visual timeline of the shoot. Scenes appear on the product page when
+          the storyboard is enabled, helping customers picture the flow before they
+          book.
+        </p>
+        <label className="flex w-fit items-center gap-2 text-sm font-medium">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-gray-300"
+            checked={enabled}
+            onChange={(event) => onToggleEnabled(event.target.checked)}
+          />
+          Show storyboard on product detail page
+        </label>
+      </header>
+
+      {enabled ? (
+        <>
+          <div className="grid gap-4 rounded border border-dashed border-slate-300 bg-white p-4">
+            {timeline.length === 0 ? (
+              <p className="text-sm text-gray-500">
+                Add scenes with start and end times to preview the timeline layout.
+              </p>
+            ) : (
+              <div className="grid gap-6">
+                <div className="grid gap-2">
+                  <div className="flex h-4 overflow-hidden rounded">
+                    {timeline.map((segment) => (
+                      <div
+                        key={segment.id}
+                        style={{ width: `${segment.width}%`, backgroundColor: segment.color }}
+                        className="h-full"
+                        title={`${segment.label} (${segment.durationLabel})`}
+                      />
+                    ))}
+                  </div>
+                  <div className="flex flex-wrap gap-3 text-xs text-gray-600">
+                    {timeline.map((segment) => (
+                      <span key={segment.id} className="flex items-center gap-1">
+                        <span
+                          className="inline-block h-3 w-3 rounded"
+                          style={{ backgroundColor: segment.color }}
+                          aria-hidden
+                        />
+                        {segment.label}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  {timeline.map((segment) => (
+                    <div
+                      key={segment.id}
+                      className="grid gap-2 rounded border bg-slate-50 p-3 text-sm"
+                    >
+                      <p className="font-medium text-gray-900">{segment.label}</p>
+                      <p className="text-xs uppercase tracking-wide text-gray-500">
+                        {segment.durationLabel}
+                      </p>
+                      {segment.image ? (
+                        <div className="relative h-40 w-full overflow-hidden rounded">
+                          <Image
+                            src={segment.image}
+                            alt={`${segment.label} artwork`}
+                            fill
+                            sizes="(min-width: 768px) 50vw, 100vw"
+                            className="object-cover"
+                          />
+                        </div>
+                      ) : (
+                        <div
+                          className="grid h-40 place-items-center rounded bg-white text-xs text-gray-400"
+                          style={{ border: `1px dashed ${segment.color}` }}
+                        >
+                          Scene artwork
+                        </div>
+                      )}
+                      <p className="text-xs text-gray-600">{segment.durationLabel}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-base font-semibold">Scenes</h3>
+              <p className="text-sm text-gray-600">
+                Document the sequence, timings, and visuals your crew will capture.
+              </p>
+            </div>
+            <button type="button" className="btn btn-sm" onClick={onAddScene}>
+              Add scene
+            </button>
+          </div>
+
+          {scenes.length === 0 ? (
+            <p className="rounded border border-dashed border-slate-300 bg-white p-4 text-sm text-gray-500">
+              No scenes yet. Add the key beats customers can expect from this production.
+            </p>
+          ) : (
+            <div className="grid gap-6">
+              {scenes.map((scene, index) => {
+                const variationChips = scene.variationIds
+                  .map((id) => variationOptions.find((option) => option.id === id))
+                  .filter((option): option is VariationOption => Boolean(option));
+                const preview = scene.previewUrl || scene.imageUrl;
+                const generating = generatingSceneId === scene.id || scene.aiStatus === "loading";
+                return (
+                  <article key={scene.id} className="grid gap-4 rounded border bg-white p-4">
+                    <header className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-gray-700">
+                          Scene {index + 1}
+                        </p>
+                        {variationChips.length > 0 ? (
+                          <p className="text-xs text-gray-500">
+                            Variations: {variationChips.map((chip) => chip.name).join(", ")}
+                          </p>
+                        ) : null}
+                      </div>
+                      <button
+                        type="button"
+                        className="btn btn-ghost btn-xs text-rose-600"
+                        onClick={() => onRemoveScene(scene.id)}
+                      >
+                        Remove
+                      </button>
+                    </header>
+
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <label className="grid gap-1 text-sm">
+                        <span className="font-medium text-gray-700">Scene title</span>
+                        <input
+                          className="input"
+                          value={scene.title}
+                          onChange={(event) =>
+                            onSceneChange(scene.id, { title: event.target.value })
+                          }
+                          placeholder="Opening titles"
+                        />
+                      </label>
+                      <div className="grid gap-1 text-sm">
+                        <span className="font-medium text-gray-700">Timing</span>
+                        <div className="grid grid-cols-2 gap-2">
+                          <input
+                            className="input"
+                            value={scene.start}
+                            onChange={(event) =>
+                              onSceneChange(scene.id, { start: event.target.value })
+                            }
+                            placeholder="00:00"
+                          />
+                          <input
+                            className="input"
+                            value={scene.end}
+                            onChange={(event) =>
+                              onSceneChange(scene.id, { end: event.target.value })
+                            }
+                            placeholder="00:45"
+                          />
+                        </div>
+                        <p className="text-xs text-gray-500">
+                          Use mm:ss or hh:mm:ss to map the segment on the timeline.
+                        </p>
+                      </div>
+                    </div>
+
+                    <label className="grid gap-1 text-sm">
+                      <span className="font-medium text-gray-700">Scene description</span>
+                      <textarea
+                        className="input min-h-[100px]"
+                        value={scene.description}
+                        onChange={(event) =>
+                          onSceneChange(scene.id, { description: event.target.value })
+                        }
+                        placeholder="Walkthrough, key shots, and emotions to capture."
+                      />
+                    </label>
+
+                    {variationOptions.length > 0 ? (
+                      <div className="grid gap-2 text-sm">
+                        <span className="font-medium text-gray-700">
+                          Show for variations
+                          <span className="ml-1 text-xs font-normal text-gray-500">
+                            (leave blank to show for all packages)
+                          </span>
+                        </span>
+                        <div className="flex flex-wrap gap-3">
+                          {variationOptions.map((variation) => {
+                            const checked = scene.variationIds.includes(variation.id);
+                            return (
+                              <label
+                                key={variation.id}
+                                className="flex items-center gap-2 rounded border border-gray-200 bg-slate-50 px-3 py-1 text-xs font-medium text-gray-700"
+                              >
+                                <input
+                                  type="checkbox"
+                                  className="h-4 w-4 rounded border-gray-300"
+                                  checked={checked}
+                                  onChange={(event) => {
+                                    const next = event.target.checked
+                                      ? Array.from(new Set([...scene.variationIds, variation.id]))
+                                      : scene.variationIds.filter((id) => id !== variation.id);
+                                    onSceneChange(scene.id, { variationIds: next });
+                                  }}
+                                />
+                                {variation.name || "Variation"}
+                              </label>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ) : null}
+
+                    <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                      <div className="grid gap-2">
+                        <span className="text-sm font-medium text-gray-700">Artwork</span>
+                        <div className="flex items-center gap-3">
+                          <div className="relative h-32 w-48 overflow-hidden rounded border bg-slate-100">
+                            {preview ? (
+                              <Image
+                                src={preview}
+                                alt={`${scene.title || `Scene ${index + 1}`} artwork`}
+                                fill
+                                sizes="192px"
+                                className="object-cover"
+                              />
+                            ) : (
+                              <div className="grid h-full place-items-center text-xs text-gray-400">
+                                No image
+                              </div>
+                            )}
+                          </div>
+                          <div className="grid gap-2 text-xs">
+                            <label className="btn btn-xs">
+                              Upload image
+                              <input
+                                type="file"
+                                accept="image/*"
+                                className="hidden"
+                                onChange={(event) =>
+                                  onSceneImageSelect(
+                                    scene.id,
+                                    event.target.files && event.target.files.length > 0
+                                      ? event.target.files[0]
+                                      : null
+                                  )
+                                }
+                              />
+                            </label>
+                            {preview ? (
+                              <button
+                                type="button"
+                                className="btn btn-ghost btn-xs text-rose-600"
+                                onClick={() => onSceneImageSelect(scene.id, null)}
+                              >
+                                Remove image
+                              </button>
+                            ) : null}
+                            <button
+                              type="button"
+                              className="btn btn-xs"
+                              onClick={() => onGenerateSceneImage(scene.id)}
+                              disabled={generating}
+                            >
+                              {generating ? "Generating…" : "Generate with AI"}
+                            </button>
+                            {scene.persistedImage ? (
+                              <span className="text-[11px] text-emerald-600">
+                                Saved to library
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                        {scene.aiError ? (
+                          <p className="text-xs text-rose-600">{scene.aiError}</p>
+                        ) : null}
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </>
+      ) : (
+        <p className="rounded border border-dashed border-slate-300 bg-white p-4 text-sm text-gray-500">
+          Enable the storyboard to unlock a timeline preview and collect example scenes
+          for this product.
+        </p>
+      )}
+    </section>
+  );
+};
+
+export default ProductStoryboardEditor;

--- a/apps/web/components/productListingUtils.ts
+++ b/apps/web/components/productListingUtils.ts
@@ -100,7 +100,7 @@ type DeliverableBadge = {
 function normaliseDeliverables(
   rawDeliverables: unknown,
   options: { variationId?: string | null } = {}
-): { title: string; type?: DeliverableType }[] {
+): { title: string; type?: DeliverableType; quantity?: number }[] {
   const variationFilter = options.variationId ?? null;
   if (!rawDeliverables) return [];
 
@@ -114,7 +114,7 @@ function normaliseDeliverables(
     if (!entry) return [];
 
     if (Array.isArray(entry)) {
-      return normaliseDeliverables(entry);
+      return normaliseDeliverables(entry, options);
     }
 
     if (typeof entry === "string") {
@@ -139,6 +139,12 @@ function normaliseDeliverables(
         typeof candidate.type === "string"
           ? (candidate.type as DeliverableType)
           : undefined;
+      const quantity =
+        typeof candidate.quantity === "number" &&
+        Number.isFinite(candidate.quantity) &&
+        candidate.quantity > 0
+          ? Math.round(candidate.quantity)
+          : undefined;
       const restrictedIds = Array.isArray(candidate.variationIds)
         ? candidate.variationIds.filter(
             (id): id is string => typeof id === "string" && id.trim().length > 0
@@ -156,6 +162,7 @@ function normaliseDeliverables(
         {
           title,
           type,
+          quantity,
         },
       ];
     }
@@ -170,8 +177,13 @@ export function getDeliverableSummary(product: Product) {
   const deliverables: DeliverableBadge[] = deliverableEntries.map(
     (deliverable, index) => {
       const title = deliverable.title.trim();
+      const quantity =
+        typeof deliverable.quantity === "number" && deliverable.quantity > 0
+          ? deliverable.quantity
+          : null;
+      const label = quantity ? `${quantity}× ${title}`.trim() : title;
       return {
-        label: title,
+        label,
         type: deliverable.type ?? null,
         key: `${title}-${deliverable.type ?? index}`,
       } as DeliverableBadge;

--- a/apps/web/lib/cart.tsx
+++ b/apps/web/lib/cart.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   ReactNode,
 } from "react";
-import { ProductModifierSelection } from "@/lib/products";
+import { ProductModifierSelection, type ProductOrderFieldType } from "@/lib/products";
 
 export interface CartCampaignBooking {
   projectId: string;
@@ -30,6 +30,15 @@ export interface CartTimeSlot {
   setupMinutes?: number | null;
   shootMinutes?: number | null;
   breakdownMinutes?: number | null;
+}
+
+export interface CartOrderFormResponse {
+  fieldId: string;
+  label: string;
+  value: string;
+  required: boolean;
+  type: ProductOrderFieldType;
+  description?: string | null;
 }
 
 export interface CartOrganiserInfo {
@@ -60,6 +69,7 @@ export interface CartItem {
     setupDate?: string | null;
     setupIncluded?: boolean;
   } | null;
+  orderFormResponses?: CartOrderFormResponse[] | null;
   timeSlot?: CartTimeSlot | null;
   coverage?: {
     type: "hq" | "franchise";
@@ -100,6 +110,7 @@ interface ProductInput {
     setupDate?: string | null;
     setupIncluded?: boolean;
   } | null;
+  orderFormResponses?: CartOrderFormResponse[] | null;
   timeSlot?: CartTimeSlot | null;
   coverage?: {
     type: "hq" | "franchise";
@@ -225,6 +236,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
             JSON.stringify(product.coverage || null) &&
           JSON.stringify(i.campaignBooking || null) ===
             JSON.stringify(product.campaignBooking || null) &&
+          JSON.stringify(i.orderFormResponses || []) ===
+            JSON.stringify(product.orderFormResponses || []) &&
           JSON.stringify(i.organiser || null) ===
             JSON.stringify(product.organiser || null) &&
           (i.kitStatus || "confirmed") === (product.kitStatus || "confirmed") &&

--- a/apps/web/lib/products.ts
+++ b/apps/web/lib/products.ts
@@ -111,6 +111,19 @@ export interface ProductModifierDeliverable {
   label?: string | null;
 }
 
+export type ProductOrderFieldType = "short-text" | "long-text";
+
+export interface ProductOrderFormField {
+  id: string;
+  label: string;
+  /** Optional helper copy displayed with the question. */
+  description?: string | null;
+  /** Whether the customer must answer the question before checkout. */
+  required?: boolean;
+  /** Controls how the response is collected in the add to cart wizard. */
+  type?: ProductOrderFieldType | null;
+}
+
 export interface ProductBudgetOverride {
   labourFilming?: number | null;
   labourEditing?: number | null;
@@ -354,6 +367,8 @@ export interface Product {
   venueCoverage?: ProductVenueCoverage | null;
   /** Optional organiser partner configuration for exhibitor programmes. */
   organiserProgram?: ProductOrganiserProgram | null;
+  /** Custom questions shown during checkout when customers add this product. */
+  orderFormFields?: ProductOrderFormField[];
 }
 
 export interface ProductOnsiteTiming {

--- a/apps/web/lib/products.ts
+++ b/apps/web/lib/products.ts
@@ -180,6 +180,22 @@ export interface ProductVariation {
   onsiteTimeWindowEnd?: string | null;
 }
 
+export interface ProductStoryboardScene {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  startSeconds?: number | null;
+  endSeconds?: number | null;
+  imageUrl?: string | null;
+  /**
+   * Optional storage path reference for the generated or uploaded scene artwork so
+   * admin tooling can locate the original asset if it needs to be refreshed.
+   */
+  storagePath?: string | null;
+  /** Optional list of variation IDs this scene applies to. */
+  variationIds?: string[] | null;
+}
+
 export interface ProductVideoLink {
   url: string;
   title?: string;
@@ -314,6 +330,8 @@ export interface Product {
   /** Modifier group IDs enabled for this product. */
   modifierGroups?: string[];
   variations?: ProductVariation[];
+  storyboardEnabled?: boolean | null;
+  storyboard?: ProductStoryboardScene[] | null;
   storyboardImages?: string[];
   /** @deprecated replaced by exampleVideos */
   exampleWorkUrl?: string | null;

--- a/apps/web/lib/products.ts
+++ b/apps/web/lib/products.ts
@@ -153,6 +153,18 @@ export interface ProductVariation {
   crewOverrides?: ProductCrewRoleOverride[];
   /** Optional turnaround label specific to the variation. */
   turnaround?: string | null;
+  /** Optional override for the total on-site span, measured in days. */
+  onsiteDays?: number | null;
+  /** Optional override for minutes spent setting up on site. */
+  onsiteSetupMinutes?: number | null;
+  /** Optional override for minutes allocated to filming. */
+  onsiteShootMinutes?: number | null;
+  /** Optional override for minutes spent breaking down kit. */
+  onsiteBreakdownMinutes?: number | null;
+  /** Optional override for the earliest bookable arrival window. */
+  onsiteTimeWindowStart?: string | null;
+  /** Optional override for the latest bookable departure window. */
+  onsiteTimeWindowEnd?: string | null;
 }
 
 export interface ProductVideoLink {
@@ -452,10 +464,27 @@ export const getProductEventMonthKeys = (product: Product): string[] => {
   return Array.from(months);
 };
 
+const resolveSchedulingOverride = <T>(
+  variationValue: T | null | undefined,
+  productValue: T | null | undefined
+): T | null | undefined => {
+  if (variationValue !== null && variationValue !== undefined) {
+    return variationValue;
+  }
+  if (productValue !== null && productValue !== undefined) {
+    return productValue;
+  }
+  return null;
+};
+
 export const resolveProductOnsiteDays = (
-  product: Product
+  product: Product,
+  variation?: ProductVariation | null
 ): number | null => {
-  const raw = (product as any)?.onsiteDays;
+  const raw = resolveSchedulingOverride(
+    variation?.onsiteDays,
+    (product as any)?.onsiteDays ?? null
+  );
   if (typeof raw === "number") {
     return Number.isFinite(raw) && raw > 0 ? raw : null;
   }
@@ -463,7 +492,7 @@ export const resolveProductOnsiteDays = (
     const parsed = Number(raw);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   }
-  const timing = resolveProductOnsiteTiming(product);
+  const timing = resolveProductOnsiteTiming(product, variation ?? null);
   if (timing) {
     const days = timing.totalMinutes / (24 * 60);
     return days > 0 ? days : null;
@@ -513,11 +542,27 @@ const parseWindowTime = (value: unknown): number | null => {
 };
 
 export const resolveProductOnsiteTiming = (
-  product: Product
+  product: Product,
+  variation?: ProductVariation | null
 ): ProductOnsiteTiming | null => {
-  const setup = parseMinutes((product as any)?.onsiteSetupMinutes);
-  const shoot = parseMinutes((product as any)?.onsiteShootMinutes);
-  const breakdown = parseMinutes((product as any)?.onsiteBreakdownMinutes);
+  const setup = parseMinutes(
+    resolveSchedulingOverride(
+      variation?.onsiteSetupMinutes,
+      (product as any)?.onsiteSetupMinutes ?? null
+    )
+  );
+  const shoot = parseMinutes(
+    resolveSchedulingOverride(
+      variation?.onsiteShootMinutes,
+      (product as any)?.onsiteShootMinutes ?? null
+    )
+  );
+  const breakdown = parseMinutes(
+    resolveSchedulingOverride(
+      variation?.onsiteBreakdownMinutes,
+      (product as any)?.onsiteBreakdownMinutes ?? null
+    )
+  );
   const total = setup + shoot + breakdown;
   if (total <= 0) {
     return null;
@@ -525,9 +570,19 @@ export const resolveProductOnsiteTiming = (
   const defaultStart = 8 * 60;
   const defaultEnd = 18 * 60;
   const startMinutes =
-    parseWindowTime((product as any)?.onsiteTimeWindowStart) ?? defaultStart;
+    parseWindowTime(
+      resolveSchedulingOverride(
+        variation?.onsiteTimeWindowStart,
+        (product as any)?.onsiteTimeWindowStart ?? null
+      )
+    ) ?? defaultStart;
   let endMinutes =
-    parseWindowTime((product as any)?.onsiteTimeWindowEnd) ?? defaultEnd;
+    parseWindowTime(
+      resolveSchedulingOverride(
+        variation?.onsiteTimeWindowEnd,
+        (product as any)?.onsiteTimeWindowEnd ?? null
+      )
+    ) ?? defaultEnd;
   if (endMinutes <= startMinutes) {
     endMinutes = startMinutes + total;
   }
@@ -592,9 +647,10 @@ const formatCompactMinutes = (minutes: number): string => {
 
 export const formatProductOnsiteDuration = (
   product: Product,
-  locale?: string
+  locale?: string,
+  variation?: ProductVariation | null
 ): string | null => {
-  const timing = resolveProductOnsiteTiming(product);
+  const timing = resolveProductOnsiteTiming(product, variation ?? null);
   if (timing) {
     const totalLabel = formatMinutesSummary(timing.totalMinutes, locale);
     const breakdownParts: string[] = [];
@@ -613,7 +669,7 @@ export const formatProductOnsiteDuration = (
       breakdownParts.length > 0 ? ` (${breakdownParts.join(" · ")})` : "";
     return `${totalLabel} on site${breakdown}`;
   }
-  const days = resolveProductOnsiteDays(product);
+  const days = resolveProductOnsiteDays(product, variation ?? null);
   if (!days) {
     return null;
   }

--- a/apps/web/lib/products.ts
+++ b/apps/web/lib/products.ts
@@ -94,6 +94,8 @@ export interface ProductDeliverable {
   title: string;
   /** Classification used to show an appropriate icon for the deliverable. */
   type?: DeliverableType;
+  /** Optional quantity label used to communicate how many of the deliverable are included. */
+  quantity?: number | null;
   /** Optional text describing what the customer will receive. */
   description?: string;
   /** Optional thumbnail image for visual deliverable previews. */

--- a/docs/website-design-admin-review.md
+++ b/docs/website-design-admin-review.md
@@ -1,0 +1,19 @@
+# Website Design Admin Page Review
+
+## Overview
+The Website Design admin screen (`apps/web/app/admin/website-design/ClientPage.tsx`) currently exposes four primary tabs:
+
+- **Homepage** – edit hero, about, CTA copy and a set of homepage cards, persisting to `settings/homepage` in Firestore. 【F:apps/web/app/admin/website-design/ClientPage.tsx†L33-L140】
+- **Pages** – add barebones page documents (title & slug). 【F:apps/web/app/admin/website-design/ClientPage.tsx†L183-L197】
+- **Menu** – reorder top-level categories used for navigation. 【F:apps/web/app/admin/website-design/ClientPage.tsx†L200-L229】
+- **Branding** – set tracking pixel IDs, with a CTA directing editors to brand guidelines for visual assets. 【F:apps/web/app/admin/website-design/ClientPage.tsx†L232-L240】【F:apps/web/app/admin/website-design/ClientPage.tsx†L243-L262】
+
+## Front-end coverage
+The public homepage (`apps/web/app/page.tsx`) reads from `getHomepage()` and other services to render a number of sections. 【F:apps/web/app/page.tsx†L1-L151】 While the admin Homepage tab controls headline text, about copy, CTA messaging, and the optional card grid, several key elements remain hard-coded or sourced elsewhere:
+
+- **Hero media** – the hero video URL and poster are fixed in the component and cannot be updated from the admin UI. 【F:apps/web/app/page.tsx†L27-L33】
+- **Process section** – title, description, video, poster, and the list of stages are expected in Firestore, but the admin page offers no interface to edit them. 【F:apps/web/app/page.tsx†L35-L41】
+- **Services, products, blog, and client logos** – these sections rely on category, product, blog post, and logo collections managed by other parts of the CMS, not by the Website Design screen. 【F:apps/web/app/page.tsx†L61-L149】
+
+## Conclusion
+The current Website Design admin page does **not** provide control over every piece of text or every element displayed on the public site. Editors can manage key homepage copy blocks and card content, but hero media, the process walkthrough, and the dynamically generated sections (services, product highlights, blog feed, client logos) must be updated through other dedicated admin tooling or code changes.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8765,6 +8765,60 @@ export const createOrder = functions.https.onCall(async (data, context) => {
             };
           })()
         : null;
+    const rawOrderResponses = Array.isArray(items[idx]?.orderFormResponses)
+      ? (items[idx].orderFormResponses as any[])
+      : [];
+    const orderFormResponses = rawOrderResponses
+      .map((response, responseIndex) => {
+        if (!response || typeof response !== 'object') {
+          return null;
+        }
+        const rawFieldId =
+          typeof (response as any).fieldId === 'string' && (response as any).fieldId.trim().length > 0
+            ? (response as any).fieldId.trim()
+            : '';
+        const rawLabel =
+          typeof (response as any).label === 'string' && (response as any).label.trim().length > 0
+            ? (response as any).label.trim()
+            : '';
+        if (!rawFieldId && !rawLabel) {
+          return null;
+        }
+        const value =
+          typeof (response as any).value === 'string'
+            ? (response as any).value
+            : (response as any).value != null
+              ? String((response as any).value)
+              : '';
+        const description =
+          typeof (response as any).description === 'string' &&
+          (response as any).description.trim().length > 0
+            ? (response as any).description.trim()
+            : null;
+        const typeValue =
+          typeof (response as any).type === 'string' && (response as any).type === 'long-text'
+            ? 'long-text'
+            : 'short-text';
+        const resolvedFieldId = rawFieldId || `field-${responseIndex}`;
+        return {
+          fieldId: resolvedFieldId,
+          label: rawLabel || rawFieldId || resolvedFieldId,
+          value,
+          description,
+          required: (response as any).required === true,
+          type: typeValue,
+        };
+      })
+      .filter(
+        (entry): entry is {
+          fieldId: string;
+          label: string;
+          value: string;
+          description: string | null;
+          required: boolean;
+          type: 'short-text' | 'long-text';
+        } => entry !== null
+      );
     const rawOrganiser = items[idx]?.organiser;
     let organiserPayload: Record<string, any> | null = null;
     if (rawOrganiser && typeof rawOrganiser === 'object') {
@@ -8936,6 +8990,7 @@ export const createOrder = functions.https.onCall(async (data, context) => {
       postalCode: itemPostalCode,
       exhibition: exhibitionDetails,
       coverage: coveragePayload,
+      orderFormResponses,
       timeSlot: timeSlotDetails,
       campaignBooking,
       organiser: organiserPayload,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13942,6 +13942,141 @@ export const admin_assignWorkflow = functions.https.onCall(async (data: any, con
   return { ok: true };
 });
 
+const STORYBOARD_IMAGE_ROOT = 'Product_Images';
+
+function escapeForSvg(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function formatStoryboardLabel(seconds: number | null): string {
+  if (seconds === null || seconds === undefined || Number.isNaN(seconds)) {
+    return '';
+  }
+  const clamped = Math.max(0, Math.round(seconds));
+  const hrs = Math.floor(clamped / 3600);
+  const mins = Math.floor((clamped % 3600) / 60);
+  const secs = clamped % 60;
+  if (hrs > 0) {
+    return `${String(hrs).padStart(2, '0')}:${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  }
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+}
+
+export const admin_generateStoryboardSceneImage = functions.https.onCall(async (data: any, context: functions.https.CallableContext) => {
+  await assertStaff(context, ['admin', 'operations']);
+  const rawProductId = typeof data?.productId === 'string' ? data.productId.trim() : '';
+  const rawSceneId = typeof data?.sceneId === 'string' ? data.sceneId.trim() : '';
+  const sceneDescription = typeof data?.sceneDescription === 'string' ? data.sceneDescription.trim() : '';
+  if (!rawProductId || !rawSceneId) {
+    throw new functions.https.HttpsError('invalid-argument', 'productId and sceneId are required.');
+  }
+  if (!sceneDescription) {
+    throw new functions.https.HttpsError('invalid-argument', 'sceneDescription is required.');
+  }
+  const safeId = (value: string, fallback: string) => {
+    const normalised = value.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/-{2,}/g, '-').replace(/^-+|-+$/g, '');
+    return normalised.length > 0 ? normalised.slice(0, 80) : fallback;
+  };
+  const productId = safeId(rawProductId, 'product');
+  const sceneId = safeId(rawSceneId, 'scene');
+  const productName = typeof data?.productName === 'string' ? data.productName.trim() : '';
+  const sceneTitle = typeof data?.sceneTitle === 'string' ? data.sceneTitle.trim() : '';
+  const productTagline = typeof data?.productTagline === 'string' ? data.productTagline.trim() : '';
+  const variationNames = Array.isArray(data?.variationNames)
+    ? (data.variationNames as unknown[])
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter((value) => value.length > 0)
+    : [];
+  const deliverableSummaries = Array.isArray(data?.deliverables)
+    ? (data.deliverables as unknown[])
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter((value) => value.length > 0)
+    : [];
+  const startSeconds =
+    typeof data?.startSeconds === 'number' && Number.isFinite(data.startSeconds) && data.startSeconds >= 0
+      ? Math.round(data.startSeconds)
+      : null;
+  const endSeconds =
+    typeof data?.endSeconds === 'number' && Number.isFinite(data.endSeconds) && data.endSeconds >= 0
+      ? Math.round(data.endSeconds)
+      : null;
+  const accentInput = typeof data?.accentColor === 'string' ? data.accentColor.trim() : '';
+  const accentColor = /^#[0-9a-fA-F]{6}$/.test(accentInput) ? accentInput : '#0ea5e9';
+  const startLabel = formatStoryboardLabel(startSeconds);
+  const endLabel = formatStoryboardLabel(endSeconds);
+  let durationLabel = 'Scene timing TBC';
+  if (startLabel && endLabel) {
+    durationLabel = `${startLabel} – ${endLabel}`;
+  } else if (startLabel) {
+    durationLabel = `${startLabel} onwards`;
+  } else if (endLabel) {
+    durationLabel = `0:00 – ${endLabel}`;
+  }
+
+  const width = 1280;
+  const height = 720;
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="scene-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="${accentColor}" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#111827" stop-opacity="0.95" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="${width}" height="${height}" fill="#0f172a" />
+  <rect x="0" y="0" width="${width}" height="${height}" fill="url(#scene-bg)" />
+  <rect x="0" y="${height - 160}" width="${width}" height="160" fill="#0f172a" opacity="0.65" />
+  <text x="60" y="120" fill="#ffffff" font-family="'Helvetica Neue', 'Segoe UI', Arial" font-size="44" font-weight="600">
+    ${escapeForSvg(sceneTitle || productName || 'Storyboard scene')}
+  </text>
+  <text x="60" y="190" fill="#e2e8f0" font-family="'Helvetica Neue', 'Segoe UI', Arial" font-size="24" font-weight="400">
+    ${escapeForSvg(sceneDescription)}
+  </text>
+  <text x="60" y="${height - 115}" fill="#f8fafc" font-family="'Helvetica Neue', 'Segoe UI', Arial" font-size="24" font-weight="500">
+    ${escapeForSvg(durationLabel)}
+  </text>
+  <text x="60" y="${height - 75}" fill="#cbd5f5" font-family="'Helvetica Neue', 'Segoe UI', Arial" font-size="18" font-weight="400">
+    ${escapeForSvg(variationNames.length ? `Variations: ${variationNames.join(', ')}` : productTagline || productName || '')}
+  </text>
+  <text x="60" y="${height - 40}" fill="#a5b4fc" font-family="'Helvetica Neue', 'Segoe UI', Arial" font-size="18" font-weight="400">
+    ${escapeForSvg(deliverableSummaries.length ? `Deliverables: ${deliverableSummaries.join(', ')}` : 'Creative direction locked in by Pineapple')}
+  </text>
+</svg>`;
+
+  const imageBuffer = await sharp(Buffer.from(svg)).png().toBuffer();
+  const storagePath = `${STORYBOARD_IMAGE_ROOT}/${productId}/storyboard-${sceneId}-${Date.now()}.png`;
+  const bucket = admin.storage().bucket();
+  const file = bucket.file(storagePath);
+  await file.save(imageBuffer, {
+    contentType: 'image/png',
+    metadata: { cacheControl: 'public,max-age=31536000' },
+  });
+  const [signedUrl] = await file.getSignedUrl({ action: 'read', expires: '2500-01-01' });
+  if (context.auth?.uid) {
+    await writeAuditLog({
+      actorUid: context.auth.uid,
+      action: 'admin_generate_storyboard_scene_image',
+      entityType: 'product',
+      entityId: productId,
+      metadata: {
+        sceneId,
+        accentColor,
+        startSeconds,
+        endSeconds,
+      },
+    });
+  }
+  return {
+    imageUrl: signedUrl,
+    storagePath,
+  };
+});
+
 /**
  * Create a proposal for a client. Accepts { orgId, clientEmail, items?, agreementIds?,
  * templateId?, customText? }. Items are { type: 'product' | 'custom', productId?,


### PR DESCRIPTION
## Summary
- add an optional quantity field to product deliverables in the admin create/edit flows and persist the value
- surface deliverable quantities across the product detail page, including highlights and the variation comparison table
- include deliverable counts in listing badges so summaries reflect configured quantities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e54e1bc3208323b7d4b6298b7478f9