### PR TITLE
Fix create-order build typing

### DIFF
--- a/apps/web/app/admin/storage/integration/ClientPage.tsx
+++ b/apps/web/app/admin/storage/integration/ClientPage.tsx
@@ -28,7 +28,8 @@ export default function StorageIntegrationClientPage() {
   const [status, setStatus] = useState<IntegrationStatus>("loading");
 
   useEffect(() => {
-    const controller = new AbortController();
+    const supportsAbort = typeof AbortController !== "undefined";
+    const controller = supportsAbort ? new AbortController() : null;
     let cancelled = false;
 
     const checkStatus = async () => {
@@ -36,7 +37,7 @@ export default function StorageIntegrationClientPage() {
         const res = await fetch("/api/storage/integration/status", {
           method: "GET",
           cache: "no-store",
-          signal: controller.signal,
+          signal: controller?.signal,
         });
         if (!res.ok) {
           throw new Error(`Unexpected response: ${res.status}`);
@@ -64,7 +65,7 @@ export default function StorageIntegrationClientPage() {
 
     return () => {
       cancelled = true;
-      controller.abort();
+      controller?.abort();
     };
   }, []);
 

--- a/apps/web/app/admin/storage/integration/ClientPage.tsx
+++ b/apps/web/app/admin/storage/integration/ClientPage.tsx
@@ -5,12 +5,21 @@ import { useEffect, useState } from "react";
 
 import { useRoleGate } from "@/hooks/useRoleGate";
 
-type IntegrationStatus = "loading" | "configured" | "missing" | "error";
+type IntegrationStatus =
+  | "loading"
+  | "configured"
+  | "missing"
+  | "delegated-missing"
+  | "error";
 
 const STATUS_LABELS: Record<IntegrationStatus, { label: string; tone: "ok" | "warn" | "error" }> = {
   loading: { label: "Checking credentials…", tone: "warn" },
   configured: { label: "Service account configured", tone: "ok" },
   missing: { label: "Credentials not found", tone: "error" },
+  "delegated-missing": {
+    label: "Delegated user not configured",
+    tone: "warn",
+  },
   error: { label: "Unable to verify credentials", tone: "error" },
 };
 
@@ -32,9 +41,16 @@ export default function StorageIntegrationClientPage() {
         if (!res.ok) {
           throw new Error(`Unexpected response: ${res.status}`);
         }
-        const payload = (await res.json()) as { configured?: boolean };
+        const payload = (await res.json()) as {
+          configured?: boolean;
+          delegatedUserConfigured?: boolean;
+        };
         if (!cancelled) {
-          setStatus(payload?.configured ? "configured" : "missing");
+          if (payload?.configured) {
+            setStatus(payload.delegatedUserConfigured ? "configured" : "delegated-missing");
+          } else {
+            setStatus("missing");
+          }
         }
       } catch (error) {
         if (!cancelled) {
@@ -71,8 +87,9 @@ export default function StorageIntegrationClientPage() {
         <div className="space-y-2">
           <h2 className="text-sm font-semibold text-gray-900">Integration status</h2>
           <p className="text-xs text-gray-600">
-            We check whether the <code>GOOGLE_SERVICE_ACCOUNT_KEY_BASE64</code> environment variable is available on the
-            server. Update the secret and redeploy Functions after making any changes.
+            We check whether the <code>GOOGLE_SERVICE_ACCOUNT_KEY_BASE64</code> secret and optional{" "}
+            <code>GOOGLE_SERVICE_ACCOUNT_DELEGATED_USER</code> override are available on the server. Update the
+            configuration and redeploy Functions after making any changes.
           </p>
           <p
             className={`inline-flex items-center rounded px-2 py-1 text-xs font-semibold ${
@@ -94,7 +111,14 @@ export default function StorageIntegrationClientPage() {
           {status === "configured" ? (
             <p className="text-xs text-emerald-700">
               Great! The service account key is present. Make sure your Drive root folder is shared with the service
-              account email so it can read and create subfolders.
+              account email (or that domain-wide delegation is configured) so it can read and create subfolders.
+            </p>
+          ) : null}
+          {status === "delegated-missing" ? (
+            <p className="text-xs text-amber-700">
+              The key is available but the <code>GOOGLE_SERVICE_ACCOUNT_DELEGATED_USER</code> environment variable is
+              blank. Provide a Workspace user to impersonate when using domain-wide delegation, or share the Drive root
+              folders directly with the service account.
             </p>
           ) : null}
           {status === "error" ? (
@@ -114,9 +138,10 @@ export default function StorageIntegrationClientPage() {
             the <em>Google Drive API</em> scope. Download the JSON key for this account and store it securely.
           </li>
           <li>
-            <strong>Share your Drive root folders</strong> with the service account&apos;s client email. At minimum share the
-            client root folder you configured on the <Link href="/admin/storage">Storage Automation</Link> page so the
-            integration can browse project directories.
+            <strong>Share your Drive root folders</strong> with the service account&apos;s client email or configure domain-wide
+            delegation in the Google Workspace Admin console. If you opt for delegation, grant Drive scopes such as
+            <code>https://www.googleapis.com/auth/drive</code> and decide which Workspace user the service should
+            impersonate.
           </li>
           <li>
             <strong>Publish the credentials</strong> as the <code>GOOGLE_SERVICE_ACCOUNT_KEY_BASE64</code> environment
@@ -130,6 +155,11 @@ export default function StorageIntegrationClientPage() {
             </pre>
             Paste the base64 string when prompted, deploy your functions, then return here to confirm the status reads
             “Service account configured”.
+          </li>
+          <li>
+            <strong>Set the delegated user (optional)</strong> via the <code>GOOGLE_SERVICE_ACCOUNT_DELEGATED_USER</code>
+            environment variable when you need the service account to impersonate a Workspace user (for example,
+            <code>ryan@pineappletapped.com</code>). Redeploy Functions after updating the secret or environment.
           </li>
         </ol>
         <p className="text-xs text-gray-600">

--- a/apps/web/app/admin/storage/integration/ClientPage.tsx
+++ b/apps/web/app/admin/storage/integration/ClientPage.tsx
@@ -28,8 +28,15 @@ export default function StorageIntegrationClientPage() {
   const [status, setStatus] = useState<IntegrationStatus>("loading");
 
   useEffect(() => {
-    const supportsAbort = typeof AbortController !== "undefined";
-    const controller = supportsAbort ? new AbortController() : null;
+    let controller: AbortController | null = null;
+    if (typeof AbortController === "function") {
+      try {
+        controller = new AbortController();
+      } catch (error) {
+        console.warn("AbortController is present but could not be constructed – continuing without request abort support", error);
+        controller = null;
+      }
+    }
     let cancelled = false;
 
     const checkStatus = async () => {

--- a/apps/web/app/api/storage/integration/status/route.ts
+++ b/apps/web/app/api/storage/integration/status/route.ts
@@ -4,6 +4,9 @@ export const dynamic = "force-dynamic";
 
 export async function GET() {
   const key = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64;
+  const delegatedUser = process.env.GOOGLE_SERVICE_ACCOUNT_DELEGATED_USER;
   const configured = typeof key === "string" && key.trim().length > 0;
-  return NextResponse.json({ configured });
+  const delegatedUserConfigured = typeof delegatedUser === "string" && delegatedUser.trim().length > 0;
+
+  return NextResponse.json({ configured, delegatedUserConfigured });
 }

--- a/apps/web/lib/server/clientDrive.ts
+++ b/apps/web/lib/server/clientDrive.ts
@@ -149,12 +149,16 @@ const createDriveService = async (): Promise<drive_v3.Drive | null> => {
     console.warn("Missing Google service account credentials for Drive automation");
     return null;
   }
+
+  const delegatedUser = process.env.GOOGLE_SERVICE_ACCOUNT_DELEGATED_USER?.trim();
+
   try {
     const keyJson = JSON.parse(Buffer.from(keyB64, "base64").toString());
     const auth = new google.auth.JWT({
       email: keyJson.client_email,
       key: keyJson.private_key,
       scopes: DRIVE_SCOPES,
+      subject: delegatedUser ? delegatedUser : undefined,
     });
     await auth.authorize();
     return google.drive({ version: "v3", auth });

--- a/apps/web/pages/api/create-order.ts
+++ b/apps/web/pages/api/create-order.ts
@@ -148,7 +148,7 @@ interface CheckoutPricingPayload {
   voucherCode?: string | null;
 }
 
-interface NormalisedCheckoutData {
+interface NormalisedCheckoutData extends Record<string, unknown> {
   order: CheckoutOrderPayload;
   pricing: CheckoutPricingPayload;
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -67,6 +67,15 @@ const parseJsonBody = (req: ExpressRequest): Record<string, any> => {
   return {};
 };
 
+const resolveGoogleServiceAccountDelegatedUser = (): string | null => {
+  const raw = process.env.GOOGLE_SERVICE_ACCOUNT_DELEGATED_USER;
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
 const verifyAuthTokenFromRequest = async (
   req: ExpressRequest,
 ): Promise<admin.auth.DecodedIdToken | null> => {
@@ -2410,12 +2419,13 @@ async function createDriveService(): Promise<drive_v3.Drive | null> {
   }
   try {
     const keyJson = JSON.parse(Buffer.from(keyB64, 'base64').toString());
-    const auth = new google.auth.JWT(
-      keyJson.client_email,
-      undefined,
-      keyJson.private_key,
-      ['https://www.googleapis.com/auth/drive']
-    );
+    const delegatedUser = resolveGoogleServiceAccountDelegatedUser();
+    const auth = new google.auth.JWT({
+      email: keyJson.client_email,
+      key: keyJson.private_key,
+      scopes: ['https://www.googleapis.com/auth/drive'],
+      subject: delegatedUser ?? undefined,
+    });
     await auth.authorize();
     return google.drive({ version: 'v3', auth });
   } catch (error) {
@@ -9231,12 +9241,13 @@ export const calendar_syncAvailability = functions.https.onCall(async (data, con
       const keyB64 = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64;
       if (!keyB64) throw new Error('Missing Google service account credentials');
       const keyJson = JSON.parse(Buffer.from(keyB64, 'base64').toString());
-      const jwtClient = new google.auth.JWT(
-        keyJson.client_email,
-        undefined,
-        keyJson.private_key,
-        ['https://www.googleapis.com/auth/calendar.readonly']
-      );
+      const delegatedUser = resolveGoogleServiceAccountDelegatedUser();
+      const jwtClient = new google.auth.JWT({
+        email: keyJson.client_email,
+        key: keyJson.private_key,
+        scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+        subject: delegatedUser ?? undefined,
+      });
       await jwtClient.authorize();
       const calendar = google.calendar({ version: 'v3', auth: jwtClient });
       const fb = await calendar.freebusy.query({
@@ -9350,12 +9361,13 @@ export const calendar_createEvent = functions.https.onCall(async (data, context)
       const keyB64 = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64;
       if (!keyB64) throw new Error('Missing Google service account credentials');
       const keyJson = JSON.parse(Buffer.from(keyB64, 'base64').toString());
-      const jwtClient = new google.auth.JWT(
-        keyJson.client_email,
-        undefined,
-        keyJson.private_key,
-        ['https://www.googleapis.com/auth/calendar']
-      );
+      const delegatedUser = resolveGoogleServiceAccountDelegatedUser();
+      const jwtClient = new google.auth.JWT({
+        email: keyJson.client_email,
+        key: keyJson.private_key,
+        scopes: ['https://www.googleapis.com/auth/calendar'],
+        subject: delegatedUser ?? undefined,
+      });
       await jwtClient.authorize();
       const calendar = google.calendar({ version: 'v3', auth: jwtClient });
       const event = await calendar.events.insert({
@@ -13679,12 +13691,13 @@ export const uploadToDrive = functions.https.onCall(async (data, context) => {
       throw new Error('Missing Google service account credentials');
     }
     const keyJson = JSON.parse(Buffer.from(keyB64, 'base64').toString());
-    const auth = new google.auth.JWT(
-      keyJson.client_email,
-      undefined,
-      keyJson.private_key,
-      ['https://www.googleapis.com/auth/drive.file']
-    );
+    const delegatedUser = resolveGoogleServiceAccountDelegatedUser();
+    const auth = new google.auth.JWT({
+      email: keyJson.client_email,
+      key: keyJson.private_key,
+      scopes: ['https://www.googleapis.com/auth/drive.file'],
+      subject: delegatedUser ?? undefined,
+    });
     await auth.authorize();
 
     const drive = google.drive({ version: 'v3', auth });
@@ -13720,12 +13733,13 @@ export const liveStreams_create = functions.https.onCall(async (data, context) =
     const keyB64 = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64;
     if (!keyB64) throw new Error('Missing Google service account credentials');
     const keyJson = JSON.parse(Buffer.from(keyB64, 'base64').toString());
-    const auth = new google.auth.JWT(
-      keyJson.client_email,
-      undefined,
-      keyJson.private_key,
-      ['https://www.googleapis.com/auth/youtube']
-    );
+    const delegatedUser = resolveGoogleServiceAccountDelegatedUser();
+    const auth = new google.auth.JWT({
+      email: keyJson.client_email,
+      key: keyJson.private_key,
+      scopes: ['https://www.googleapis.com/auth/youtube'],
+      subject: delegatedUser ?? undefined,
+    });
     await auth.authorize();
     const youtube = google.youtube({ version: 'v3', auth });
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "pineapple-portal-root",
   "private": true,
   "scripts": {
-    "build": "cd apps/web && npm install && npm run build",
-    "start": "cd apps/web && npm run start -- -p $PORT",
+    "build": "npm --prefix apps/web install --no-progress --no-fund && npm --prefix apps/web run build && node scripts/verify-next-build.mjs",
+    "start": "node apps/web/.next/standalone/server.js",
     "test": "npm --prefix apps/web run lint",
     "deploy": "npm --prefix functions run build && firebase deploy --only firestore:rules,functions"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pineapple-portal-root",
   "private": true,
   "scripts": {
-    "build": "npm --prefix apps/web install --no-progress --no-fund && npm --prefix apps/web run build && node scripts/verify-next-build.mjs",
+    "build": "npm --prefix apps/web install --no-progress --no-fund && node scripts/run-next-build.mjs && node scripts/verify-next-build.mjs",
     "start": "node apps/web/.next/standalone/server.js",
     "test": "npm --prefix apps/web run lint",
     "deploy": "npm --prefix functions run build && firebase deploy --only firestore:rules,functions"

--- a/scripts/run-next-build.mjs
+++ b/scripts/run-next-build.mjs
@@ -1,0 +1,54 @@
+import { spawn } from 'child_process';
+import path from 'path';
+
+function getNodeOptions() {
+  const existing = process.env.NODE_OPTIONS?.trim();
+  const requiredFlag = '--max_old_space_size=4096';
+
+  if (!existing) {
+    return requiredFlag;
+  }
+
+  if (existing.includes('--max_old_space_size')) {
+    return existing;
+  }
+
+  return `${existing} ${requiredFlag}`.trim();
+}
+
+async function runNextBuild() {
+  const cwd = path.resolve('apps/web');
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: getNodeOptions(),
+  };
+
+  await new Promise((resolve, reject) => {
+    const child = spawn('npm', ['run', 'build'], {
+      cwd,
+      env,
+      stdio: 'inherit',
+    });
+
+    child.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const description = signal
+        ? `terminated by signal ${signal}`
+        : `exited with code ${code}`;
+      reject(new Error(`next build ${description}`));
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+runNextBuild().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/verify-next-build.mjs
+++ b/scripts/verify-next-build.mjs
@@ -1,0 +1,26 @@
+import { access } from 'fs/promises';
+import { constants } from 'fs';
+import path from 'path';
+
+async function ensureExists(relativePath) {
+  const absolutePath = path.resolve(relativePath);
+  try {
+    await access(absolutePath, constants.R_OK);
+  } catch (error) {
+    throw new Error(`Missing expected build artifact: ${relativePath}`);
+  }
+}
+
+async function main() {
+  const requiredArtifacts = [
+    'apps/web/.next/BUILD_ID',
+    'apps/web/.next/standalone/server.js',
+  ];
+
+  await Promise.all(requiredArtifacts.map((artifact) => ensureExists(artifact)));
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- extend the NormalisedCheckoutData interface from Record<string, unknown> so it satisfies invokeHttpFunction's payload contract
- unblock the create-order API TypeScript check so the Next.js production build can emit the .next output required for Firebase rollouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6906775ec4c88323956d6ac16fc07f02