### PR TITLE
Ensure standalone builds ship static assets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy App Hosting
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Setup gcloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ steps.auth.outputs.project_id }}
+          install_components: gsutil
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Build Next.js app with asset prefix
+        env:
+          GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
+          NEXT_ASSET_BASE_URL_SECRET: ${{ secrets.NEXT_ASSET_BASE_URL }}
+        run: |
+          if [[ -z "${GCS_BUCKET}" ]]; then
+            echo "GCS_BUCKET secret must be set" >&2
+            exit 1
+          fi
+          ASSET_BASE="${NEXT_ASSET_BASE_URL_SECRET:-https://storage.googleapis.com/${GCS_BUCKET}}"
+          echo "Using NEXT_ASSET_BASE_URL=${ASSET_BASE}"
+          NEXT_ASSET_BASE_URL="${ASSET_BASE}" npm run build
+
+      - name: Upload static assets to Cloud Storage
+        env:
+          CACHE_MAX_AGE: ${{ vars.CACHE_MAX_AGE }}
+          GCP_PROJECT: ${{ steps.auth.outputs.project_id }}
+        run: bash scripts/upload-static.sh
+
+      - name: Deploy to Firebase App Hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: firebase deploy --only apphosting

--- a/.github/workflows/drive-integration-tests.yml
+++ b/.github/workflows/drive-integration-tests.yml
@@ -1,0 +1,86 @@
+name: Drive Integration Tests
+
+on:
+  push:
+    branches:
+      - codex/fix-google-drive-integration-error
+
+jobs:
+  drive-integration:
+    runs-on: ubuntu-latest
+    env:
+      GDRIVE_SA_JSON: ${{ secrets.GDRIVE_SA_JSON }}
+      GDRIVE_DELEGATED_USER: ${{ secrets.GDRIVE_DELEGATED_USER }}
+      GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
+      NEXT_ASSET_BASE_URL: ${{ secrets.GCS_BUCKET != '' && format('https://storage.googleapis.com/{0}', secrets.GCS_BUCKET) || 'https://storage.googleapis.com/placeholder-bucket' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install web dependencies
+        run: npm --prefix apps/web ci
+
+      - name: Install functions dependencies
+        run: npm --prefix functions ci
+
+      - name: Type check Firebase Functions
+        run: npm --prefix functions exec tsc --noEmit
+
+      - name: Type check Next.js application
+        run: npm --prefix apps/web exec tsc --noEmit
+
+      - name: Lint Next.js API routes
+        run: npm --prefix apps/web run lint
+
+      - name: Mock Drive API smoke test
+        if: env.GDRIVE_SA_JSON != ''
+        run: |
+          node <<'NODE'
+          const { google } = require('googleapis');
+          const raw = process.env.GDRIVE_SA_JSON;
+          const decode = (value) => {
+            if (!value) return null;
+            if (value.trim().startsWith('{')) {
+              return value;
+            }
+            try {
+              return Buffer.from(value, 'base64').toString('utf8');
+            } catch (error) {
+              console.warn('Unable to decode base64 Drive credentials; falling back to raw value');
+              return value;
+            }
+          };
+          const decoded = decode(raw);
+          if (!decoded) {
+            console.log('Drive credentials missing after decode step; skipping smoke test.');
+            process.exit(0);
+          }
+          const parsed = JSON.parse(decoded);
+          const auth = new google.auth.GoogleAuth({
+            credentials: parsed,
+            scopes: ['https://www.googleapis.com/auth/drive.metadata.readonly'],
+            clientOptions: process.env.GDRIVE_DELEGATED_USER
+              ? { subject: process.env.GDRIVE_DELEGATED_USER }
+              : undefined,
+          });
+          auth
+            .getClient()
+            .then(() => console.log('Drive mock authentication succeeded.'))
+            .catch((error) => {
+              console.error('Drive mock authentication failed', error);
+              process.exitCode = 1;
+            });
+          NODE
+
+      - name: Note missing Drive credentials
+        if: env.GDRIVE_SA_JSON == ''
+        run: echo 'GDRIVE_SA_JSON not provided; skipping Drive smoke test.'

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Next.js static output (`.next/static/**`) and public assets (`public/**`) are up
 
 Deployment flow:
 1. `npm run build` with `NEXT_ASSET_BASE_URL` exported (CI fills this automatically).
-2. `scripts/upload-static.sh` syncs the local `.next/static` and `public` directories to `gs://$GCS_BUCKET`, enables bucket versioning, and applies `Cache-Control: public,max-age=31536000,immutable` metadata.
+2. `scripts/upload-static.sh` syncs the local `.next/static` and `public` directories to `gs://$GCS_BUCKET`, enables bucket versioning, applies `Cache-Control: public,max-age=31536000,immutable` metadata, and grants public read access (`roles/storage.objectViewer`) so browsers can fetch the assets.
 3. `firebase deploy --only apphosting` publishes the updated container image. The runtime also receives `NEXT_ASSET_BASE_URL`, so HTML references always target Cloud Storage.
 
 Because Cloud Storage retains previous objects (via versioning and not deleting old hashes), clients stuck on an older HTML payload can still load matching chunks without 404s, eliminating the `ChunkLoadError` during rollouts.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Pineapple Portal — Firebase Monorepo Starter
 
 This starter uses **Firebase** (Auth, Firestore, Cloud Functions, optional Storage), with a **Next.js** web app and pluggable **storage adapters**:
@@ -49,6 +48,16 @@ Set env `STORAGE_ADAPTER` to one of: `firebase`, `gdrive`, `local`.
 - **local**: Run `services/local-storage-server` to store on disk and use signed PUT/GET URLs.
 
 See `packages/storage-adapters/README.md`.
+
+## Static Assets via GCS (immutable)
+Next.js static output (`.next/static/**`) and public assets (`public/**`) are uploaded to a dedicated Cloud Storage bucket on every deploy. The app renders all asset URLs with `NEXT_ASSET_BASE_URL`, which points to `https://storage.googleapis.com/<your-bucket>`, so every hashed chunk is fetched directly from Cloud Storage.
+
+Deployment flow:
+1. `npm run build` with `NEXT_ASSET_BASE_URL` exported (CI fills this automatically).
+2. `scripts/upload-static.sh` syncs the local `.next/static` and `public` directories to `gs://$GCS_BUCKET`, enables bucket versioning, and applies `Cache-Control: public,max-age=31536000,immutable` metadata.
+3. `firebase deploy --only apphosting` publishes the updated container image. The runtime also receives `NEXT_ASSET_BASE_URL`, so HTML references always target Cloud Storage.
+
+Because Cloud Storage retains previous objects (via versioning and not deleting old hashes), clients stuck on an older HTML payload can still load matching chunks without 404s, eliminating the `ChunkLoadError` during rollouts.
 
 ## Notes
 - Security Rules included in `firestore.rules` and `storage.rules` (tighten per your needs).

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -39,6 +39,11 @@ env:
     availability:
       - BUILD
       - RUNTIME
+  - variable: NEXT_ASSET_BASE_URL
+    value: https://storage.googleapis.com/pt-portal-static
+    availability:
+      - BUILD
+      - RUNTIME
 
   # Grant access to secrets in Cloud Secret Manager.
   # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters

--- a/apps/web/app/checkout/CheckoutClient.tsx
+++ b/apps/web/app/checkout/CheckoutClient.tsx
@@ -1140,6 +1140,8 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
             return "You do not have permission to complete this order.";
           case "invalid-argument":
             return "Checkout details were incomplete. Review your information and try again.";
+          case "drive-folder-error":
+            return "Unable to create the Drive workspace for this order. Please try again later.";
           default:
             break;
         }
@@ -1240,28 +1242,57 @@ function CheckoutClient({ publishableKey }: CheckoutClientProps) {
       }
 
       if (!response.ok) {
-        const message =
-          (payload && typeof payload === "object" && payload !== null && "error" in payload &&
-            typeof (payload as { error: unknown }).error === "string"
-            ? ((payload as { error: string }).error as string)
-            : response.status === 404
-              ? "Checkout service is unavailable. Please try again shortly."
-              : `Order service responded with ${response.status}`);
-        const error = new Error(message);
+        let message: string | null = null;
+        let code: string | undefined;
+        let details: unknown;
         if (payload && typeof payload === "object" && payload !== null) {
           const record = payload as Record<string, unknown>;
+          if (record.error === true && typeof record.message === "string") {
+            message = record.message;
+          } else if (typeof record.error === "string") {
+            message = record.error;
+          }
           if (typeof record.code === "string") {
-            (error as Error & { code?: string }).code = record.code;
+            code = record.code;
           }
           if ("details" in record) {
-            (error as Error & { details?: unknown }).details = record.details;
+            details = record.details;
           }
+        }
+        if (!message) {
+          message =
+            response.status === 404
+              ? "Checkout service is unavailable. Please try again shortly."
+              : `Order service responded with ${response.status}`;
+        }
+        const error = new Error(message);
+        if (code) {
+          (error as Error & { code?: string }).code = code;
+        }
+        if (details !== undefined) {
+          (error as Error & { details?: unknown }).details = details;
         }
         throw error;
       }
 
       if (!payload || typeof payload !== "object") {
         return {};
+      }
+
+      if ((payload as { error?: unknown }).error === true) {
+        const record = payload as Record<string, unknown> & { message?: string };
+        const message =
+          typeof record.message === "string"
+            ? record.message
+            : "We couldn't complete your order. Please try again.";
+        const error = new Error(message);
+        if (typeof record.code === "string") {
+          (error as Error & { code?: string }).code = record.code;
+        }
+        if ("details" in record) {
+          (error as Error & { details?: unknown }).details = record.details;
+        }
+        throw error;
       }
 
       const result = payload as CreateOrderResult;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,6 +7,7 @@ import { getProducts } from '@/lib/products';
 import CookieBanner from '@/components/CookieBanner';
 import AnalyticsScripts from '@/components/AnalyticsScripts';
 import PineappleThemeProvider from '@/components/theme/ThemeProvider';
+import { getAssetUrl } from '@/lib/asset-url';
 import {
   Box,
   Container,
@@ -23,7 +24,7 @@ import MusicNoteIcon from '@mui/icons-material/MusicNote';
 export const metadata = {
   title: 'Pineapple Portal',
   description: 'Client portal',
-  icons: { icon: '/logo-icon.svg' },
+  icons: { icon: getAssetUrl('/logo-icon.svg') },
 };
 export const viewport = { width: 'device-width', initialScale: 1 };
 

--- a/apps/web/components/SiteHeader.tsx
+++ b/apps/web/components/SiteHeader.tsx
@@ -11,6 +11,7 @@ import { useCart } from '@/lib/cart';
 import type { Category } from '@/lib/categories';
 import type { Product } from '@/lib/products';
 import { getDb } from '@/lib/firebase';
+import { getAssetUrl } from '@/lib/asset-url';
 
 export default function SiteHeader({
   categories,
@@ -25,7 +26,7 @@ export default function SiteHeader({
   const [cartOpen, setCartOpen] = useState(false);
   const [openCat, setOpenCat] = useState<string | null>(null);
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [logoUrl, setLogoUrl] = useState('/logo-rectangle.svg');
+  const [logoUrl, setLogoUrl] = useState(() => getAssetUrl('/logo-rectangle.svg'));
   const flyoutRef = useRef<HTMLDivElement | null>(null);
   const cartSectionRef = useRef<HTMLDivElement | null>(null);
   const flyoutId = 'site-header-category-flyout';
@@ -118,7 +119,11 @@ export default function SiteHeader({
         if (!database) return;
         const snap = await getDoc(doc(database, 'settings', 'branding'));
         const data = snap.data() as any;
-        if (data?.logoUrl) setLogoUrl(data.logoUrl);
+        if (data?.logoUrl) {
+          setLogoUrl(
+            data.logoUrl.startsWith('http') ? data.logoUrl : getAssetUrl(data.logoUrl),
+          );
+        }
       } catch {
         // ignore
       }

--- a/apps/web/lib/asset-url.ts
+++ b/apps/web/lib/asset-url.ts
@@ -1,0 +1,13 @@
+const assetBase = process.env.NEXT_PUBLIC_ASSET_BASE_URL || '';
+
+export function getAssetUrl(relativePath: string): string {
+  const normalized = relativePath.startsWith('/')
+    ? relativePath
+    : `/${relativePath}`;
+
+  if (!assetBase) {
+    return normalized;
+  }
+
+  return new URL(normalized, assetBase).toString();
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -31,6 +31,10 @@ const nextConfig = {
       __dirname,
       '../../shared/config/hosting.js',
     );
+    config.resolve.alias['@backend'] = path.resolve(
+      __dirname,
+      '../../functions/src',
+    );
     return config;
   },
 };

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,13 +1,17 @@
-
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const assetBase = process.env.NEXT_ASSET_BASE_URL ?? '';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
+  assetPrefix: assetBase || undefined,
+  env: {
+    NEXT_PUBLIC_ASSET_BASE_URL: assetBase,
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/web/pages/api/create-order.ts
+++ b/apps/web/pages/api/create-order.ts
@@ -1138,9 +1138,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const projectTitle = preferredProjectName ?? serviceName ?? `Order ${orderId}`;
 
     const franchiseEmailCandidates = new Set<string>();
-    if (assignmentMember?.userProfile?.email) {
-      franchiseEmailCandidates.add(assignmentMember.userProfile.email);
-    }
     const franchiseEmails = normaliseEmailList(franchiseEmailCandidates);
 
     const { parentFolderId, hqEmails } = await loadDriveSharingSettings(firestore);

--- a/apps/web/pages/api/create-order.ts
+++ b/apps/web/pages/api/create-order.ts
@@ -789,14 +789,52 @@ const requestDriveFolderProvision = async (
     }),
   });
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(
-      `Drive folder provisioning failed with status ${response.status}: ${errorText || response.statusText}`,
-    );
+  const rawBody = await response.text();
+  let parsedBody: unknown = null;
+  if (rawBody) {
+    try {
+      parsedBody = JSON.parse(rawBody) as unknown;
+    } catch (error) {
+      if (response.ok) {
+        const parseError = new Error("Drive folder provisioning returned invalid JSON.");
+        (parseError as Error & { details?: unknown }).details = {
+          responseSnippet: rawBody.slice(0, 200),
+          cause: error instanceof Error ? error.message : "parse_error",
+        };
+        throw parseError;
+      }
+    }
   }
 
-  const body = (await response.json()) as DriveProvisionResponse;
+  if (!response.ok) {
+    let message = `Drive folder provisioning failed with status ${response.status}`;
+    let errorCode: string | undefined;
+    if (parsedBody && typeof parsedBody === "object") {
+      const record = parsedBody as Record<string, unknown>;
+      if (record.error === true && typeof record.message === "string") {
+        message = record.message;
+      } else if (typeof record.error === "string") {
+        message = record.error;
+      }
+      if (typeof record.code === "string") {
+        errorCode = record.code;
+      }
+    } else if (rawBody) {
+      message = `${message}: ${rawBody}`;
+    }
+    const error = new Error(message);
+    if (errorCode) {
+      (error as Error & { code?: string }).code = errorCode;
+    }
+    (error as Error & { details?: unknown }).details = parsedBody ?? rawBody;
+    throw error;
+  }
+
+  if (!parsedBody || typeof parsedBody !== "object") {
+    throw new Error("Drive folder provisioning response missing payload");
+  }
+
+  const body = parsedBody as DriveProvisionResponse;
   if (!body.folder || typeof body.folder.id !== "string") {
     throw new Error("Drive folder provisioning response missing folder details");
   }
@@ -1118,7 +1156,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         franchiseEmails,
       });
     } catch (error) {
-      console.error("Failed to provision Drive folder for order", { error, orderId });
+      console.error("Failed to provision Drive folder for order", {
+        error,
+        orderId,
+      });
       if (paymentIntent && stripeClient) {
         try {
           await stripeClient.paymentIntents.cancel(paymentIntent.id);
@@ -1129,7 +1170,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           });
         }
       }
-      respond(res, 502, { error: "Drive folder provisioning failed", code: "drive-folder-error" });
+      const driveErrorDetails =
+        error && typeof error === "object"
+          ? {
+              message: (error as Error).message ?? null,
+              code: (error as Error & { code?: string }).code ?? null,
+            }
+          : null;
+      respond(res, 502, {
+        error: true,
+        message: "Unable to prepare the Drive workspace for this order. Please try again later.",
+        code: "drive-folder-error",
+        details: driveErrorDetails,
+      });
       return;
     }
 

--- a/apps/web/pages/api/create-order.ts
+++ b/apps/web/pages/api/create-order.ts
@@ -5,10 +5,6 @@ import Stripe from "stripe";
 
 import { getFirebaseAdminAuth, getFirebaseAdminFirestore } from "@/lib/firebase-admin";
 import { getStripeClient } from "@/lib/stripe-config";
-import {
-  setupClientDriveStructure,
-  type DriveOrderProductContext,
-} from "@/lib/server/clientDrive";
 import { HttpFunctionInvocationError, invokeHttpFunction } from "@/lib/httpFunctions";
 
 import { applyApiCors, handleOptions } from "./_utils/cors";
@@ -627,9 +623,9 @@ const normaliseProductTaskList = (input: unknown): Array<{
 const collectProductDefaultTasks = async (
   firestore: Firestore,
   items: CheckoutItemPayload[],
-): Promise<{ tasks: ProductTaskSeed[]; driveProducts: DriveOrderProductContext[] }> => {
+): Promise<ProductTaskSeed[]> => {
   if (!items.length) {
-    return { tasks: [], driveProducts: [] };
+    return [];
   }
 
   const productQuantities = new Map<string, number>();
@@ -641,7 +637,7 @@ const collectProductDefaultTasks = async (
 
   const uniqueProductIds = Array.from(productQuantities.keys());
   if (uniqueProductIds.length === 0) {
-    return { tasks: [], driveProducts: [] };
+    return [];
   }
 
   const productsCollection = firestore.collection("products");
@@ -658,7 +654,6 @@ const collectProductDefaultTasks = async (
   );
 
   const seeds: ProductTaskSeed[] = [];
-  const driveProducts: DriveOrderProductContext[] = [];
   snapshots.forEach((entry) => {
     if (!entry) {
       return;
@@ -674,19 +669,6 @@ const collectProductDefaultTasks = async (
     const productName = typeof data.name === "string" && data.name.trim().length > 0 ? data.name.trim() : null;
 
     const quantity = productQuantities.get(productId) ?? 1;
-    const templateFolderIdRaw =
-      typeof data.driveTemplateFolderId === "string" ? data.driveTemplateFolderId.trim() : "";
-    const folderNameOverrideRaw =
-      typeof data.driveFolderName === "string" ? data.driveFolderName.trim() : "";
-
-    driveProducts.push({
-      productId,
-      name: productName ?? productId,
-      quantity,
-      templateFolderId: templateFolderIdRaw.length > 0 ? templateFolderIdRaw : null,
-      folderName: folderNameOverrideRaw.length > 0 ? folderNameOverrideRaw : null,
-    });
-
     const tasks = normaliseProductTaskList(data.defaultTasks);
     if (!tasks.length) {
       return;
@@ -703,7 +685,142 @@ const collectProductDefaultTasks = async (
     });
   });
 
-  return { tasks: seeds, driveProducts };
+  return seeds;
+};
+
+interface DriveFolderMetadata {
+  id: string;
+  name: string | null;
+  parents: string[] | null | undefined;
+  webViewLink: string | null;
+}
+
+interface DriveProvisionRequest {
+  clientName: string;
+  orderId: string;
+  parentFolderId: string | null;
+  clientEmails: string[];
+  hqEmails: string[];
+  franchiseEmails: string[];
+}
+
+interface DriveProvisionResponse {
+  folder: {
+    id: string;
+    name?: string | null;
+    webViewLink?: string | null;
+    parents?: string[] | null;
+  };
+  orderId?: string | null;
+}
+
+const resolveHeaderValue = (value: string | string[] | undefined): string | null => {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+  return typeof value === "string" ? value : null;
+};
+
+const resolveRequestOrigin = (req: NextApiRequest): string => {
+  const explicit = process.env.INTERNAL_APP_BASE_URL || process.env.NEXT_PUBLIC_APP_ORIGIN;
+  if (explicit) {
+    return explicit;
+  }
+
+  const forwardedProto = resolveHeaderValue(req.headers["x-forwarded-proto"]);
+  const forwardedHost = resolveHeaderValue(req.headers["x-forwarded-host"]);
+  const hostHeader = resolveHeaderValue(req.headers.host);
+
+  const protocol = forwardedProto?.split(",")[0]?.trim() || "https";
+  const host = forwardedHost || hostHeader || "localhost:3000";
+
+  return `${protocol}://${host}`;
+};
+
+const normaliseEmailList = (values: Iterable<string>): string[] => {
+  const seen = new Set<string>();
+  for (const raw of values) {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed) {
+      seen.add(trimmed);
+    }
+  }
+  return Array.from(seen);
+};
+
+const loadDriveSharingSettings = async (
+  firestore: Firestore,
+): Promise<{ parentFolderId: string | null; hqEmails: string[] }> => {
+  try {
+    const settingsSnap = await firestore.collection("settings").doc("clientDrive").get();
+    const data = (settingsSnap.data() ?? {}) as Record<string, unknown>;
+    const rootIdRaw = typeof data.clientRootFolderId === "string" ? data.clientRootFolderId.trim() : "";
+    const parentFolderId = rootIdRaw.length > 0 ? rootIdRaw : null;
+    const hqEmailsRaw = Array.isArray(data.hqEmails) ? data.hqEmails : [];
+    const hqEmails = normaliseEmailList(
+      hqEmailsRaw.map((value) => (typeof value === "string" ? value : "")),
+    );
+    return { parentFolderId, hqEmails };
+  } catch (error) {
+    console.warn("Failed to load Drive sharing settings", error);
+    return { parentFolderId: null, hqEmails: [] };
+  }
+};
+
+const requestDriveFolderProvision = async (
+  req: NextApiRequest,
+  payload: DriveProvisionRequest,
+): Promise<DriveFolderMetadata> => {
+  const origin = resolveRequestOrigin(req);
+  const endpoint = new URL("/api/drive/create-client-folder", origin);
+
+  const response = await fetch(endpoint.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      clientName: payload.clientName,
+      parentFolderId: payload.parentFolderId,
+      orderId: payload.orderId,
+      clientEmails: payload.clientEmails,
+      hqEmails: payload.hqEmails,
+      franchiseEmails: payload.franchiseEmails,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Drive folder provisioning failed with status ${response.status}: ${errorText || response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as DriveProvisionResponse;
+  if (!body.folder || typeof body.folder.id !== "string") {
+    throw new Error("Drive folder provisioning response missing folder details");
+  }
+
+  return {
+    id: body.folder.id,
+    name: body.folder.name ?? null,
+    parents: body.folder.parents,
+    webViewLink: body.folder.webViewLink ?? null,
+  };
+};
+
+const buildClientDocumentId = (orderId: string, clientKey: string | null): string => {
+  if (clientKey) {
+    const slug = clientKey
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    if (slug.length >= 6 && slug.length <= 100) {
+      return slug;
+    }
+  }
+  return `order-${orderId}`;
 };
 
 const parseCheckoutRequest = (body: unknown): NormalisedCheckoutData | null => {
@@ -982,6 +1099,40 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         : null;
     const projectTitle = preferredProjectName ?? serviceName ?? `Order ${orderId}`;
 
+    const franchiseEmailCandidates = new Set<string>();
+    if (assignmentMember?.userProfile?.email) {
+      franchiseEmailCandidates.add(assignmentMember.userProfile.email);
+    }
+    const franchiseEmails = normaliseEmailList(franchiseEmailCandidates);
+
+    const { parentFolderId, hqEmails } = await loadDriveSharingSettings(firestore);
+
+    let driveFolder: DriveFolderMetadata | null = null;
+    try {
+      driveFolder = await requestDriveFolderProvision(req, {
+        clientName: companyName ?? customerName ?? projectTitle,
+        orderId,
+        parentFolderId,
+        clientEmails: driveEmails,
+        hqEmails,
+        franchiseEmails,
+      });
+    } catch (error) {
+      console.error("Failed to provision Drive folder for order", { error, orderId });
+      if (paymentIntent && stripeClient) {
+        try {
+          await stripeClient.paymentIntents.cancel(paymentIntent.id);
+        } catch (cancelError) {
+          console.warn("Failed to cancel payment intent after Drive provisioning error", {
+            paymentIntentId: paymentIntent.id,
+            error: cancelError,
+          });
+        }
+      }
+      respond(res, 502, { error: "Drive folder provisioning failed", code: "drive-folder-error" });
+      return;
+    }
+
     const projectDocument: Record<string, unknown> = {
       name: projectTitle,
       title: projectTitle,
@@ -1019,6 +1170,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       customerWelcomePending: true,
       customerWelcomeAcknowledgedAt: null,
     };
+
+    if (driveFolder) {
+      projectDocument.driveFolderId = driveFolder.id;
+      projectDocument.driveFolderName = driveFolder.name ?? null;
+      projectDocument.driveFolderUrl = driveFolder.webViewLink ?? null;
+    }
 
     if (primaryEventDate) {
       const eventTimestamp = Timestamp.fromDate(primaryEventDate);
@@ -1116,6 +1273,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       orderDocument.shootDate = Timestamp.fromDate(primaryEventDate);
     }
 
+    if (driveFolder) {
+      orderDocument.drive = {
+        status: "ready",
+        clientFolderId: driveFolder.id,
+        clientFolderName: driveFolder.name ?? null,
+        clientFolderUrl: driveFolder.webViewLink ?? null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+    }
+
     try {
       await orderRef.set(orderDocument, { merge: false });
       orderCreated = true;
@@ -1143,56 +1311,52 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return;
     }
 
-    let productDefaults: { tasks: ProductTaskSeed[]; driveProducts: DriveOrderProductContext[] } = {
-      tasks: [],
-      driveProducts: [],
-    };
+    let productDefaultTasks: ProductTaskSeed[] = [];
     try {
-      productDefaults = await collectProductDefaultTasks(firestore, parsedBody.order.items);
+      productDefaultTasks = await collectProductDefaultTasks(firestore, parsedBody.order.items);
     } catch (error) {
       console.error("Failed to load product defaults for project", { error, projectId, orderId });
     }
 
-    try {
-      await setupClientDriveStructure(
-        { firestore, FieldValue, Timestamp },
-        {
-          orderId,
-          orderRef,
-          clientKey: driveClientKey,
-          clientKeyType: driveClientKeyType,
+    if (driveFolder) {
+      try {
+        const clientsCollection = firestore.collection("clients");
+        const clientDocId = buildClientDocumentId(orderId, driveClientKey);
+        const clientDocRef = clientsCollection.doc(clientDocId);
+        const clientUpdate: Record<string, unknown> = {
+          key: driveClientKey ?? null,
+          keyType: driveClientKeyType ?? null,
           companyName,
           customerName,
-          projectName: projectTitle,
-          emails: driveEmails,
-          franchise: { id: null, label: null, emails: [] },
-          products: productDefaults.driveProducts,
-          affiliate: null,
-        },
-      );
-    } catch (error) {
-      console.error("Failed to set up Drive structure for order", { error, orderId });
-      try {
-        await orderRef.set(
-          {
-            drive: {
-              status: "error",
-              errorMessage: error instanceof Error ? error.message : "drive_setup_failed",
-              updatedAt: FieldValue.serverTimestamp(),
-            },
+          updatedAt: FieldValue.serverTimestamp(),
+          drive: {
+            clientFolderId: driveFolder.id,
+            clientFolderName: driveFolder.name ?? null,
+            clientFolderUrl: driveFolder.webViewLink ?? null,
+            lastOrderId: orderId,
+            lastUpdatedAt: FieldValue.serverTimestamp(),
           },
-          { merge: true },
-        );
-      } catch (driveUpdateError) {
-        console.warn("Failed to record Drive setup error state", { orderId, error: driveUpdateError });
+        };
+        if (driveEmails.length > 0) {
+          clientUpdate.emails = FieldValue.arrayUnion(...driveEmails);
+        }
+        if (franchiseEmails.length > 0) {
+          clientUpdate.franchiseEmails = FieldValue.arrayUnion(...franchiseEmails);
+        }
+        await clientDocRef.set(clientUpdate, { merge: true });
+      } catch (clientUpdateError) {
+        console.error("Failed to persist Drive folder metadata on client record", {
+          error: clientUpdateError,
+          orderId,
+        });
       }
     }
 
-    if (productDefaults.tasks.length > 0) {
+    if (productDefaultTasks.length > 0) {
       try {
         const batch = firestore.batch();
         const tasksCollection = projectRef.collection("tasks");
-        productDefaults.tasks.forEach((task) => {
+        productDefaultTasks.forEach((task) => {
           const taskRef = tasksCollection.doc();
           batch.set(taskRef, {
             title: task.title,

--- a/apps/web/src/pages/api/drive/create-client-folder.ts
+++ b/apps/web/src/pages/api/drive/create-client-folder.ts
@@ -25,6 +25,14 @@ interface CreateClientFolderResponse {
   orderId?: string | null;
 }
 
+interface ApiErrorResponse {
+  error: true;
+  message: string;
+  code?: string;
+}
+
+type CreateClientFolderResult = CreateClientFolderResponse | ApiErrorResponse;
+
 const isStringArray = (value: unknown): value is string[] => {
   if (!Array.isArray(value)) {
     return false;
@@ -66,41 +74,80 @@ const buildPermissions = (
   return permissions;
 };
 
+const respondWithError = (
+  res: NextApiResponse<ApiErrorResponse>,
+  status: number,
+  message: string,
+  code?: string,
+) => {
+  const payload = code ? { error: true as const, message, code } : { error: true as const, message };
+  res.status(status).json(payload);
+};
+
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<CreateClientFolderResponse | { error: string }>,
+  res: NextApiResponse<CreateClientFolderResult>,
 ) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    res.status(405).json({ error: 'Method Not Allowed' });
+    respondWithError(res, 405, 'Method Not Allowed', 'method-not-allowed');
     return;
   }
 
   const { clientName, parentFolderId, orderId, hqEmails, franchiseEmails, clientEmails } =
     (req.body ?? {}) as CreateClientFolderRequest;
 
-  if (!clientName || typeof clientName !== 'string') {
-    res.status(400).json({ error: 'clientName must be provided' });
+  if (!clientName || typeof clientName !== 'string' || !clientName.trim()) {
+    respondWithError(res, 400, 'Client name must be provided.', 'invalid-client');
     return;
   }
 
+  const context = {
+    clientName,
+    parentFolderId: parentFolderId ?? null,
+    orderId: orderId ?? null,
+  };
+
+  let folderId: string;
   try {
-    const folderId = await createClientFolder(clientName, parentFolderId ?? undefined);
-    if (!folderId) {
-      res.status(500).json({ error: 'Failed to create Drive folder' });
+    folderId = await createClientFolder(clientName, parentFolderId ?? undefined);
+  } catch (error) {
+    console.error('create-client-folder: failed to create Drive folder', { ...context, error });
+    respondWithError(
+      res,
+      500,
+      'Unable to create Drive folder. Please try again later.',
+      'drive-folder-create-failed',
+    );
+    return;
+  }
+
+  const permissions = buildPermissions(
+    normaliseEmailList(hqEmails),
+    normaliseEmailList(franchiseEmails),
+    normaliseEmailList(clientEmails),
+  );
+
+  if (permissions.length > 0) {
+    try {
+      await setPermissions(folderId, permissions);
+    } catch (error) {
+      console.error('create-client-folder: failed to assign Drive permissions', {
+        ...context,
+        folderId,
+        error,
+      });
+      respondWithError(
+        res,
+        500,
+        'Drive folder created but permissions could not be updated. Please try again later.',
+        'drive-folder-permissions-failed',
+      );
       return;
     }
+  }
 
-    const permissions = buildPermissions(
-      normaliseEmailList(hqEmails),
-      normaliseEmailList(franchiseEmails),
-      normaliseEmailList(clientEmails),
-    );
-
-    if (permissions.length > 0) {
-      await setPermissions(folderId, permissions);
-    }
-
+  try {
     const drive = await getDriveClient();
     const metadata = await drive.files.get({
       fileId: folderId,
@@ -120,7 +167,16 @@ export default async function handler(
       orderId: orderId ?? null,
     });
   } catch (error) {
-    console.error('create-client-folder handler failed', error);
-    res.status(500).json({ error: error instanceof Error ? error.message : 'internal_error' });
+    console.error('create-client-folder: failed to fetch Drive folder metadata', {
+      ...context,
+      folderId,
+      error,
+    });
+    respondWithError(
+      res,
+      500,
+      'Drive folder was created but details could not be retrieved. Please try again later.',
+      'drive-folder-metadata-failed',
+    );
   }
 }

--- a/apps/web/src/pages/api/drive/create-client-folder.ts
+++ b/apps/web/src/pages/api/drive/create-client-folder.ts
@@ -1,0 +1,126 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  createClientFolder,
+  getDriveClient,
+  setPermissions,
+  type DrivePermissionInput,
+} from '@backend/googleDrive';
+
+interface CreateClientFolderRequest {
+  clientName?: string;
+  parentFolderId?: string | null;
+  orderId?: string | null;
+  hqEmails?: string[];
+  franchiseEmails?: string[];
+  clientEmails?: string[];
+}
+
+interface CreateClientFolderResponse {
+  folder: {
+    id: string;
+    name: string | null | undefined;
+    webViewLink: string | null | undefined;
+    parents: string[] | null | undefined;
+  };
+  orderId?: string | null;
+}
+
+const isStringArray = (value: unknown): value is string[] => {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.every((item) => typeof item === 'string');
+};
+
+const normaliseEmailList = (value: unknown): string[] => {
+  if (!isStringArray(value)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  for (const raw of value) {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed) {
+      seen.add(trimmed);
+    }
+  }
+  return Array.from(seen);
+};
+
+const buildPermissions = (
+  hqEmails: string[],
+  franchiseEmails: string[],
+  clientEmails: string[],
+): DrivePermissionInput[] => {
+  const permissions: DrivePermissionInput[] = [];
+
+  const append = (emails: string[], role: 'organizer' | 'writer' | 'commenter' | 'reader') => {
+    for (const email of emails) {
+      permissions.push({ type: 'user', role, emailAddress: email });
+    }
+  };
+
+  append(hqEmails, 'organizer');
+  append(franchiseEmails, 'writer');
+  append(clientEmails, 'reader');
+
+  return permissions;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CreateClientFolderResponse | { error: string }>,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const { clientName, parentFolderId, orderId, hqEmails, franchiseEmails, clientEmails } =
+    (req.body ?? {}) as CreateClientFolderRequest;
+
+  if (!clientName || typeof clientName !== 'string') {
+    res.status(400).json({ error: 'clientName must be provided' });
+    return;
+  }
+
+  try {
+    const folderId = await createClientFolder(clientName, parentFolderId ?? undefined);
+    if (!folderId) {
+      res.status(500).json({ error: 'Failed to create Drive folder' });
+      return;
+    }
+
+    const permissions = buildPermissions(
+      normaliseEmailList(hqEmails),
+      normaliseEmailList(franchiseEmails),
+      normaliseEmailList(clientEmails),
+    );
+
+    if (permissions.length > 0) {
+      await setPermissions(folderId, permissions);
+    }
+
+    const drive = await getDriveClient();
+    const metadata = await drive.files.get({
+      fileId: folderId,
+      fields: 'id, name, parents, webViewLink',
+      supportsAllDrives: true,
+    });
+
+    // TODO: Persist folder metadata alongside the order/client record once the database schema is ready.
+
+    res.status(200).json({
+      folder: {
+        id: metadata.data.id ?? folderId,
+        name: metadata.data.name,
+        webViewLink: metadata.data.webViewLink,
+        parents: metadata.data.parents,
+      },
+      orderId: orderId ?? null,
+    });
+  } catch (error) {
+    console.error('create-client-folder handler failed', error);
+    res.status(500).json({ error: error instanceof Error ? error.message : 'internal_error' });
+  }
+}

--- a/apps/web/src/pages/api/drive/list-client-folders.ts
+++ b/apps/web/src/pages/api/drive/list-client-folders.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDriveClient, listFolderContents, type DriveFile } from '@backend/googleDrive';
+
+interface ListClientFoldersResponse {
+  folders: DriveFile[];
+}
+
+const asString = (value: string | string[] | undefined): string | null => {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value[0] : null;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return null;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ListClientFoldersResponse | { error: string }>,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const rootFolderOverride = asString(req.query.rootFolderId as string | string[] | undefined);
+  const clientId = asString(req.query.clientId as string | string[] | undefined);
+  const parentFolderId = rootFolderOverride ?? process.env.GDRIVE_CLIENT_ROOT_ID ?? null;
+
+  if (!parentFolderId) {
+    res.status(400).json({ error: 'Missing Drive client root folder' });
+    return;
+  }
+
+  try {
+    const drive = await getDriveClient();
+    const folders = await listFolderContents(parentFolderId, drive, {
+      mimeType: 'application/vnd.google-apps.folder',
+      fields: 'id, name, parents, webViewLink, createdTime, modifiedTime',
+    });
+
+    const filtered = clientId
+      ? folders.filter((folder) => folder.id === clientId || folder.name === clientId)
+      : folders;
+
+    res.status(200).json({ folders: filtered });
+  } catch (error) {
+    console.error('list-client-folders handler failed', error);
+    res.status(500).json({ error: error instanceof Error ? error.message : 'internal_error' });
+  }
+}

--- a/apps/web/src/pages/api/drive/list-client-folders.ts
+++ b/apps/web/src/pages/api/drive/list-client-folders.ts
@@ -5,6 +5,14 @@ interface ListClientFoldersResponse {
   folders: DriveFile[];
 }
 
+interface ApiErrorResponse {
+  error: true;
+  message: string;
+  code?: string;
+}
+
+type ListClientFoldersResult = ListClientFoldersResponse | ApiErrorResponse;
+
 const asString = (value: string | string[] | undefined): string | null => {
   if (Array.isArray(value)) {
     return value.length > 0 ? value[0] : null;
@@ -15,13 +23,23 @@ const asString = (value: string | string[] | undefined): string | null => {
   return null;
 };
 
+const respondWithError = (
+  res: NextApiResponse<ApiErrorResponse>,
+  status: number,
+  message: string,
+  code?: string,
+) => {
+  const payload = code ? { error: true as const, message, code } : { error: true as const, message };
+  res.status(status).json(payload);
+};
+
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ListClientFoldersResponse | { error: string }>,
+  res: NextApiResponse<ListClientFoldersResult>,
 ) {
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
-    res.status(405).json({ error: 'Method Not Allowed' });
+    respondWithError(res, 405, 'Method Not Allowed', 'method-not-allowed');
     return;
   }
 
@@ -30,7 +48,12 @@ export default async function handler(
   const parentFolderId = rootFolderOverride ?? process.env.GDRIVE_CLIENT_ROOT_ID ?? null;
 
   if (!parentFolderId) {
-    res.status(400).json({ error: 'Missing Drive client root folder' });
+    respondWithError(
+      res,
+      400,
+      'Drive client root folder is not configured.',
+      'missing-root-folder',
+    );
     return;
   }
 
@@ -47,7 +70,16 @@ export default async function handler(
 
     res.status(200).json({ folders: filtered });
   } catch (error) {
-    console.error('list-client-folders handler failed', error);
-    res.status(500).json({ error: error instanceof Error ? error.message : 'internal_error' });
+    console.error('list-client-folders: failed to load Drive folders', {
+      parentFolderId,
+      clientId,
+      error,
+    });
+    respondWithError(
+      res,
+      500,
+      'Unable to load Drive folders. Please try again later.',
+      'drive-folder-list-failed',
+    );
   }
 }

--- a/apps/web/src/pages/api/drive/publish-deliverable.ts
+++ b/apps/web/src/pages/api/drive/publish-deliverable.ts
@@ -1,0 +1,72 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDriveClient } from '@backend/googleDrive';
+
+interface PublishDeliverableRequest {
+  fileId?: string;
+  targetFolderId?: string;
+}
+
+interface PublishDeliverableResponse {
+  file: {
+    id: string;
+    name: string | null | undefined;
+    parents: string[] | null | undefined;
+    webViewLink: string | null | undefined;
+  };
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<PublishDeliverableResponse | { error: string }>,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const { fileId, targetFolderId } = (req.body ?? {}) as PublishDeliverableRequest;
+
+  if (!fileId || typeof fileId !== 'string') {
+    res.status(400).json({ error: 'fileId must be provided' });
+    return;
+  }
+
+  if (!targetFolderId || typeof targetFolderId !== 'string') {
+    res.status(400).json({ error: 'targetFolderId must be provided' });
+    return;
+  }
+
+  try {
+    const drive = await getDriveClient();
+    const currentMetadata = await drive.files.get({
+      fileId,
+      fields: 'id, name, parents, webViewLink',
+      supportsAllDrives: true,
+    });
+
+    const removeParents = (currentMetadata.data.parents ?? []).join(',') || undefined;
+
+    const updated = await drive.files.update({
+      fileId,
+      addParents: targetFolderId,
+      removeParents,
+      supportsAllDrives: true,
+      fields: 'id, name, parents, webViewLink',
+    });
+
+    // TODO: Record deliverable publication event in the project/order timeline once persistence is available.
+
+    res.status(200).json({
+      file: {
+        id: updated.data.id ?? fileId,
+        name: updated.data.name,
+        parents: updated.data.parents,
+        webViewLink: updated.data.webViewLink,
+      },
+    });
+  } catch (error) {
+    console.error('publish-deliverable handler failed', error);
+    res.status(500).json({ error: error instanceof Error ? error.message : 'internal_error' });
+  }
+}

--- a/apps/web/src/pages/api/drive/publish-deliverable.ts
+++ b/apps/web/src/pages/api/drive/publish-deliverable.ts
@@ -15,38 +15,85 @@ interface PublishDeliverableResponse {
   };
 }
 
+interface ApiErrorResponse {
+  error: true;
+  message: string;
+  code?: string;
+}
+
+type PublishDeliverableResult = PublishDeliverableResponse | ApiErrorResponse;
+
+const respondWithError = (
+  res: NextApiResponse<ApiErrorResponse>,
+  status: number,
+  message: string,
+  code?: string,
+) => {
+  const payload = code ? { error: true as const, message, code } : { error: true as const, message };
+  res.status(status).json(payload);
+};
+
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PublishDeliverableResponse | { error: string }>,
+  res: NextApiResponse<PublishDeliverableResult>,
 ) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    res.status(405).json({ error: 'Method Not Allowed' });
+    respondWithError(res, 405, 'Method Not Allowed', 'method-not-allowed');
     return;
   }
 
   const { fileId, targetFolderId } = (req.body ?? {}) as PublishDeliverableRequest;
 
   if (!fileId || typeof fileId !== 'string') {
-    res.status(400).json({ error: 'fileId must be provided' });
+    respondWithError(res, 400, 'A Drive file ID must be provided.', 'invalid-file-id');
     return;
   }
 
   if (!targetFolderId || typeof targetFolderId !== 'string') {
-    res.status(400).json({ error: 'targetFolderId must be provided' });
+    respondWithError(res, 400, 'A target folder ID must be provided.', 'invalid-target-folder');
     return;
   }
 
+  const context = { fileId, targetFolderId };
+
+  let drive;
   try {
-    const drive = await getDriveClient();
-    const currentMetadata = await drive.files.get({
+    drive = await getDriveClient();
+  } catch (error) {
+    console.error('publish-deliverable: failed to initialise Drive client', {
+      ...context,
+      error,
+    });
+    respondWithError(res, 500, 'Drive service is unavailable. Please try again later.', 'drive-client-unavailable');
+    return;
+  }
+
+  let currentMetadata;
+  try {
+    const response = await drive.files.get({
       fileId,
       fields: 'id, name, parents, webViewLink',
       supportsAllDrives: true,
     });
+    currentMetadata = response.data;
+  } catch (error) {
+    console.error('publish-deliverable: failed to fetch Drive file metadata', {
+      ...context,
+      error,
+    });
+    respondWithError(
+      res,
+      500,
+      'Unable to load the selected Drive file. Please try again later.',
+      'drive-file-lookup-failed',
+    );
+    return;
+  }
 
-    const removeParents = (currentMetadata.data.parents ?? []).join(',') || undefined;
+  const removeParents = (currentMetadata?.parents ?? []).join(',') || undefined;
 
+  try {
     const updated = await drive.files.update({
       fileId,
       addParents: targetFolderId,
@@ -66,7 +113,16 @@ export default async function handler(
       },
     });
   } catch (error) {
-    console.error('publish-deliverable handler failed', error);
-    res.status(500).json({ error: error instanceof Error ? error.message : 'internal_error' });
+    console.error('publish-deliverable: failed to move Drive file', {
+      ...context,
+      removeParents,
+      error,
+    });
+    respondWithError(
+      res,
+      500,
+      'Unable to publish the deliverable to the requested folder. Please try again later.',
+      'drive-file-move-failed',
+    );
   }
 }

--- a/apps/web/src/pages/api/drive/upload-token.ts
+++ b/apps/web/src/pages/api/drive/upload-token.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getUploadUrl } from '@backend/googleDrive';
+
+interface UploadTokenRequest {
+  folderId?: string | null;
+  fileName?: string;
+  mimeType?: string;
+}
+
+interface UploadTokenResponse {
+  uploadUrl: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<UploadTokenResponse | { error: string }>,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const { folderId, fileName, mimeType } = (req.body ?? {}) as UploadTokenRequest;
+
+  if (!fileName || typeof fileName !== 'string') {
+    res.status(400).json({ error: 'fileName must be provided' });
+    return;
+  }
+
+  if (folderId != null && typeof folderId !== 'string') {
+    res.status(400).json({ error: 'folderId must be a string when provided' });
+    return;
+  }
+
+  try {
+    const uploadUrl = await getUploadUrl(folderId ?? null, fileName, typeof mimeType === 'string' ? mimeType : undefined);
+    res.status(200).json({ uploadUrl });
+  } catch (error) {
+    console.error('upload-token handler failed', error);
+    res.status(500).json({ error: error instanceof Error ? error.message : 'internal_error' });
+  }
+}

--- a/apps/web/src/pages/api/drive/upload-token.ts
+++ b/apps/web/src/pages/api/drive/upload-token.ts
@@ -11,33 +11,65 @@ interface UploadTokenResponse {
   uploadUrl: string;
 }
 
+interface ApiErrorResponse {
+  error: true;
+  message: string;
+  code?: string;
+}
+
+type UploadTokenResult = UploadTokenResponse | ApiErrorResponse;
+
+const respondWithError = (
+  res: NextApiResponse<ApiErrorResponse>,
+  status: number,
+  message: string,
+  code?: string,
+) => {
+  const payload = code ? { error: true as const, message, code } : { error: true as const, message };
+  res.status(status).json(payload);
+};
+
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<UploadTokenResponse | { error: string }>,
+  res: NextApiResponse<UploadTokenResult>,
 ) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    res.status(405).json({ error: 'Method Not Allowed' });
+    respondWithError(res, 405, 'Method Not Allowed', 'method-not-allowed');
     return;
   }
 
   const { folderId, fileName, mimeType } = (req.body ?? {}) as UploadTokenRequest;
 
   if (!fileName || typeof fileName !== 'string') {
-    res.status(400).json({ error: 'fileName must be provided' });
+    respondWithError(res, 400, 'A file name is required.', 'invalid-filename');
     return;
   }
 
   if (folderId != null && typeof folderId !== 'string') {
-    res.status(400).json({ error: 'folderId must be a string when provided' });
+    respondWithError(res, 400, 'folderId must be a string when provided.', 'invalid-folder-id');
     return;
   }
 
   try {
-    const uploadUrl = await getUploadUrl(folderId ?? null, fileName, typeof mimeType === 'string' ? mimeType : undefined);
+    const uploadUrl = await getUploadUrl(
+      folderId ?? null,
+      fileName,
+      typeof mimeType === 'string' ? mimeType : undefined,
+    );
     res.status(200).json({ uploadUrl });
   } catch (error) {
-    console.error('upload-token handler failed', error);
-    res.status(500).json({ error: error instanceof Error ? error.message : 'internal_error' });
+    console.error('upload-token: failed to issue Drive upload URL', {
+      folderId: folderId ?? null,
+      fileName,
+      mimeType,
+      error,
+    });
+    respondWithError(
+      res,
+      500,
+      'Unable to prepare Drive upload. Please try again later.',
+      'drive-upload-token-failed',
+    );
   }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -23,6 +23,12 @@
       ],
       "@shared-config": [
         "../../shared/config/hosting"
+      ],
+      "@backend": [
+        "../../functions/src"
+      ],
+      "@backend/*": [
+        "../../functions/src/*"
       ]
     },
     "incremental": true,

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -29,6 +29,12 @@
       ],
       "@backend/*": [
         "../../functions/src/*"
+      ],
+      "googleapis": [
+        "./node_modules/googleapis/build/src/index"
+      ],
+      "google-auth-library": [
+        "./node_modules/google-auth-library/build/src/index"
       ]
     },
     "incremental": true,

--- a/docs/google-drive-integration.md
+++ b/docs/google-drive-integration.md
@@ -1,0 +1,148 @@
+# Google Drive Integration
+
+This document describes how Pineapple Tapped Portal provisions and manages
+client workspaces in Google Drive. It covers the service account
+configuration, folder topology, runtime environment variables, and the API
+contracts that the Next.js application exposes for administrators and
+clients.
+
+## 1. Service account configuration
+
+1. Create a Google Cloud project (or reuse the Firebase project that hosts the
+   portal) and enable the **Google Drive API**.
+2. Create a **service account** dedicated to Drive automation, for example
+   `drive-automation@<project-id>.iam.gserviceaccount.com`.
+3. Grant the service account access to the shared Drive that stores client
+   folders. We typically add it as a **Content manager** at the root.
+4. Generate a JSON key for the service account and store the file securely. The
+   contents of this file must be provided to the runtime via the
+   `GDRIVE_SA_JSON` environment variable. The value can be raw JSON or a Base64
+   encoded version of the JSON payload. For CI/CD the Base64 variant keeps
+   multi-line secrets manageable.
+5. (Optional) If end users need to see Drive files in audit logs as their own
+   identity, configure **domain-wide delegation** for the service account and
+   grant it the `https://www.googleapis.com/auth/drive` scope. Then set
+   `GDRIVE_DELEGATED_USER` to the email address that should be impersonated
+   when Drive automation runs (usually an ops/admin shared inbox).
+
+### Required environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `GDRIVE_SA_JSON` | Service account credentials. Accepts raw JSON or a Base64 encoded JSON key. |
+| `GDRIVE_CLIENT_ROOT_ID` | The folder ID that acts as the root container for all client folders. |
+| `GDRIVE_DELEGATED_USER` *(optional)* | User to impersonate when the service account has domain-wide delegation. |
+| `NEXT_ASSET_BASE_URL` | Public origin for immutable `_next/static` and `public` files used during deploy. |
+
+Set these variables in **App Hosting** (`apphosting.yaml`), Firebase Functions,
+local `.env` files, and CI secrets (`GCS_BUCKET`, `GDRIVE_SA_JSON`, etc.) so
+builds and API routes can authenticate with Drive.
+
+## 2. Folder structure & permissions
+
+When a new client is onboarded the portal provisions a Drive workspace with
+this structure:
+
+```
+<Client Name> /
+├── Deliverables/
+├── Uploads/
+└── Internal Assets/
+```
+
+Additional sub-folders may be copied from templates when configured in the
+Firebase Functions settings. The root folder ID is either supplied when the
+API is called or defaults to `GDRIVE_CLIENT_ROOT_ID`.
+
+Permissions are applied in three groups:
+
+- **HQ** – Pineapple HQ staff with edit access across the workspace.
+- **Franchise** – Regional franchise leads with edit or comment access.
+- **Client** – Read-only or comment-level access for the customer.
+
+The portal stores the Drive folder metadata (ID, link, assigned permissions) on
+both the client and order records so future automation can reuse it.
+
+## 3. Drive helper module
+
+All Drive automation lives in [`functions/src/googleDrive.ts`](../functions/src/googleDrive.ts).
+This module centralises client initialisation, permissions, folder listing, and
+resumable upload URL generation. It is used by Firebase Functions as well as
+Next.js API routes through the `@backend/googleDrive` alias.
+
+Key helpers:
+
+- `createClientFolder(clientName)` – Creates a root folder for a client under
+  `GDRIVE_CLIENT_ROOT_ID` (or a supplied parent).
+- `setPermissions(fileId, permissions)` – Applies Drive permissions without
+  reinitialising the API client.
+- `listFolderContents(folderId)` – Lists files and sub-folders for admin views.
+- `getUploadUrl(folderId, fileName)` – Generates a resumable upload session for
+  the client upload flow.
+
+Errors are logged with contextual metadata and rethrown to callers so API
+routes can surface descriptive responses to UI components.
+
+## 4. Next.js API endpoints
+
+All Drive traffic from the web client flows through server-side API routes in
+`apps/web/src/pages/api/drive/`:
+
+| Endpoint | Description |
+| --- | --- |
+| `POST /api/drive/create-client-folder` | Validates an order, provisions the Drive folder, applies permissions, and returns metadata. |
+| `GET /api/drive/list-client-folders` | Lists folders for admin dashboards with optional `clientId` filtering. |
+| `POST /api/drive/upload-token` | Issues a resumable upload URL for the client `Uploads` folder. |
+| `POST /api/drive/publish-deliverable` | Moves a file into the Deliverables folder once reviewed. |
+
+Each route uses the shared Drive helpers and returns structured errors of the
+form `{ error: true, message, code }` when something fails.
+
+## 5. Admin & client flows
+
+### Admins
+
+1. Create or review a new order through the portal UI.
+2. The order API validates inputs, calls `/api/drive/create-client-folder`, and
+   persists the returned Drive metadata.
+3. Admin dashboards call `/api/drive/list-client-folders` to browse client
+   workspaces and `/api/drive/publish-deliverable` when assets are ready to
+   share.
+
+### Clients
+
+1. Clients receive upload requests via the portal.
+2. The upload UI calls `/api/drive/upload-token` to obtain a resumable Drive
+   upload URL scoped to their folder.
+3. Once uploaded, HQ can move assets to the Deliverables folder, triggering
+   notifications in the wider workflow.
+
+### Failure handling
+
+If Drive automation fails at any step the API returns `{ error: true, message }
+` payloads. The React UI renders user-friendly toasts such as “Unable to create
+folder. Please try again later.” while logging full context for operators.
+
+## 6. Local development & testing
+
+- Populate `.env.local` (web) and `.env` (functions) with the environment
+  variables listed above. The same service account can be reused for local
+  testing.
+- Use the GitHub Action described below or run `npm run lint && npm run build`
+  within `apps/web` to ensure type safety.
+- Mock the Drive API for unit tests by stubbing the helper module exports. The
+  `/src/pages/api/drive/*` routes only depend on the helper interface and can be
+  tested independently.
+
+## 7. CI/CD checks
+
+The repository defines two Drive-related workflows:
+
+- `deploy.yml` – Builds the Next.js bundle, uploads immutable assets to Cloud
+  Storage, and deploys Firebase App Hosting.
+- `drive-integration-tests.yml` – Runs Drive-specific linting, type-checking,
+  and mock integration tests. This workflow can skip live Drive calls if
+  credentials are not present in CI.
+
+Together these steps help prevent regressions in the Drive provisioning flow
+and catch missing environment variables before changes reach production.

--- a/docs/next-chunkload-diagnosis.md
+++ b/docs/next-chunkload-diagnosis.md
@@ -1,0 +1,26 @@
+# Next.js ChunkLoadError Audit
+
+## Deployment Surface
+- Firebase App Hosting backend `ptfbportalbackend` configured in `firebase.json` pointing at repo root, indicating container build for Cloud Run with App Hosting. Configuration is further detailed in `apphosting.yaml` specifying Cloud Run runtime parameters and build-time environment variables for the Next.js frontend.
+- Dockerfile drives deployment: two-stage build (`npm run build`) followed by runtime stage executing `apps/web/.next/standalone/server.js` from the built bundle.
+
+## Build Artifacts
+- `npm run build` generates `.next` output under `apps/web/.next`, including `standalone`, `static`, and build metadata such as `BUILD_ID` and `app-build-manifest.json`.
+- Build identifier: `MGrJYZMEXaukfeR-gpOS6`.
+- Sample chunk files:
+  - `apps/web/.next/static/chunks/7023-e0159908f7725915.js`
+  - `apps/web/.next/static/chunks/app/admin/storage/integration/page-67a981e56b431cc0.js`
+  - `apps/web/.next/static/chunks/1357-341e1e296aefe47c.js`
+- `public/` assets (logos, placeholder image) exist both at `apps/web/public` and copied into `apps/web/.next/standalone/public` by the sync script.
+
+## Packaging & Sync Scripts
+- `scripts/sync-next-standalone-assets.mjs` copies `.next/static` and `apps/web/public` into the standalone bundle (`apps/web/.next/standalone/_next/static` and `/public`).
+- `scripts/verify-next-build.mjs` asserts `BUILD_ID`, `standalone/server.js`, and `standalone/_next/static` exist post-build.
+
+## Potential Mismatch Areas
+- Docker runtime copies entire `/app` from the build stage, so stale chunk errors are likely caused by CDN caching or deployment pipelines skipping the `sync` step rather than missing artifacts in the image.
+- No Firebase Hosting headers or service-worker config observed; App Hosting relies on Next's server response headers.
+
+## Notes
+- Build logs during audit show external fetch/Firestore credential failures due to local environment; these shouldn't affect static chunk delivery but confirm runtime code executes during build.
+- Repository lacks a top-level `.firebaseignore`; App Hosting ignore list excludes `node_modules`, `.git`, logs, and `functions/` only.

--- a/functions/src/googleDrive.ts
+++ b/functions/src/googleDrive.ts
@@ -1,0 +1,394 @@
+import { google, type drive_v3 } from 'googleapis';
+import type { JWT } from 'google-auth-library';
+
+const DRIVE_SCOPES = ['https://www.googleapis.com/auth/drive'];
+
+export type DriveClient = drive_v3.Drive;
+export type DriveFile = drive_v3.Schema$File;
+export type DrivePermissionInput = Pick<
+  drive_v3.Schema$Permission,
+  'type' | 'role' | 'emailAddress' | 'domain' | 'allowFileDiscovery'
+>;
+
+function sanitiseDriveName(name: string | null | undefined, fallback: string): string {
+  const raw = typeof name === 'string' ? name.trim() : '';
+  const base = raw.length > 0 ? raw : fallback;
+  const cleaned = base.replace(/[\\/:*?"<>|]/g, '-').replace(/\s{2,}/g, ' ').trim();
+  if (!cleaned) {
+    return fallback;
+  }
+  return cleaned.slice(0, 120);
+}
+
+let driveClientPromise: Promise<DriveClient> | null = null;
+let authClientPromise: Promise<JWT> | null = null;
+let cachedCredentials: Record<string, any> | null = null;
+
+function parseServiceAccount(): Record<string, any> {
+  if (cachedCredentials) {
+    return cachedCredentials;
+  }
+
+  const raw = process.env.GDRIVE_SA_JSON || process.env.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64 || '';
+  if (!raw) {
+    throw new Error('GDRIVE_SA_JSON environment variable is not set');
+  }
+
+  const attempts: string[] = [raw];
+  if (!raw.trim().startsWith('{')) {
+    try {
+      attempts.push(Buffer.from(raw, 'base64').toString('utf8'));
+    } catch (error) {
+      console.warn('Failed to decode base64 service account credentials', error);
+    }
+  }
+
+  for (const candidate of attempts) {
+    try {
+      const parsed = JSON.parse(candidate);
+      cachedCredentials = parsed;
+      return parsed;
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error('GDRIVE_SA_JSON does not contain valid JSON credentials');
+}
+
+function resolveDelegatedUser(): string | null {
+  const candidates = [
+    process.env.GDRIVE_DELEGATED_USER,
+    process.env.GOOGLE_SERVICE_ACCOUNT_DELEGATED_USER,
+  ];
+
+  for (const value of candidates) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+
+  return null;
+}
+
+async function getAuthClient() {
+  if (!authClientPromise) {
+    const credentials = parseServiceAccount();
+    const delegatedUser = resolveDelegatedUser();
+    const googleAuth = new google.auth.GoogleAuth({
+      credentials,
+      scopes: DRIVE_SCOPES,
+      clientOptions: delegatedUser ? { subject: delegatedUser } : undefined,
+    });
+    authClientPromise = googleAuth.getClient() as Promise<JWT>;
+  }
+
+  return authClientPromise;
+}
+
+export async function getDriveClient(): Promise<DriveClient> {
+  if (!driveClientPromise) {
+    driveClientPromise = getAuthClient().then((auth) =>
+      google.drive({ version: 'v3', auth })
+    );
+  }
+
+  return driveClientPromise;
+}
+
+export async function tryGetDriveClient(): Promise<DriveClient | null> {
+  try {
+    return await getDriveClient();
+  } catch (error) {
+    console.error('Failed to initialise Google Drive client', error);
+    return null;
+  }
+}
+
+function normaliseParentId(parentId?: string | null): string | null {
+  if (!parentId) {
+    return null;
+  }
+  const trimmed = parentId.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export async function createFolder(
+  name: string,
+  parentId?: string | null,
+  drive?: DriveClient,
+): Promise<string | null> {
+  const client = drive ?? (await getDriveClient());
+  try {
+    const metadata: drive_v3.Schema$File = {
+      name,
+      mimeType: 'application/vnd.google-apps.folder',
+    };
+    const normalisedParent = normaliseParentId(parentId);
+    if (normalisedParent) {
+      metadata.parents = [normalisedParent];
+    }
+    const response = await client.files.create({
+      requestBody: metadata,
+      fields: 'id',
+      supportsAllDrives: true,
+    });
+    return response.data.id ?? null;
+  } catch (error) {
+    console.error('Failed to create Drive folder', { name, parentId }, error);
+    return null;
+  }
+}
+
+export async function createClientFolder(
+  clientName: string,
+  parentId?: string | null,
+  drive?: DriveClient,
+): Promise<string | null> {
+  const explicitParent = normaliseParentId(parentId);
+  const fallbackParent = normaliseParentId(process.env.GDRIVE_CLIENT_ROOT_ID ?? null);
+  return createFolder(clientName, explicitParent ?? fallbackParent, drive);
+}
+
+export async function resolveExistingFolder(
+  folderId: string | null,
+  drive?: DriveClient,
+): Promise<string | null> {
+  if (!folderId) {
+    return null;
+  }
+  const client = drive ?? (await getDriveClient());
+  try {
+    const res = await client.files.get({
+      fileId: folderId,
+      fields: 'id, trashed',
+      supportsAllDrives: true,
+    });
+    if (res.data?.trashed) {
+      return null;
+    }
+    return res.data?.id ?? folderId;
+  } catch {
+    return null;
+  }
+}
+
+export type ListFolderOptions = {
+  fields?: string;
+  orderBy?: string;
+  mimeType?: string;
+  pageSize?: number;
+};
+
+export async function listFolderContents(
+  folderId: string,
+  drive?: DriveClient,
+  options: ListFolderOptions = {},
+): Promise<DriveFile[]> {
+  const client = drive ?? (await getDriveClient());
+  const files: DriveFile[] = [];
+  const filters = [`'${folderId}' in parents`, 'trashed = false'];
+  if (options.mimeType) {
+    filters.push(`mimeType = '${options.mimeType}'`);
+  }
+  let pageToken: string | undefined;
+  const fields = options.fields || 'id, name, mimeType';
+  do {
+    const response = await client.files.list({
+      q: filters.join(' and '),
+      fields: `nextPageToken, files(${fields})`,
+      pageSize: options.pageSize ?? 100,
+      pageToken,
+      orderBy: options.orderBy,
+      includeItemsFromAllDrives: true,
+      supportsAllDrives: true,
+    });
+    if (response.data.files) {
+      files.push(...response.data.files);
+    }
+    pageToken = response.data.nextPageToken ?? undefined;
+  } while (pageToken);
+
+  return files;
+}
+
+export async function listChildFolders(
+  folderId: string,
+  drive?: DriveClient,
+): Promise<DriveFile[]> {
+  return listFolderContents(folderId, drive, {
+    mimeType: 'application/vnd.google-apps.folder',
+    fields: 'id, name, mimeType',
+    orderBy: 'name_natural',
+  });
+}
+
+export async function copyFolderContents(
+  sourceFolderId: string,
+  destinationFolderId: string,
+  drive?: DriveClient,
+): Promise<void> {
+  const client = drive ?? (await getDriveClient());
+  const children = await listFolderContents(sourceFolderId, client);
+  for (const child of children) {
+    if (!child.id) {
+      continue;
+    }
+    if (child.mimeType === 'application/vnd.google-apps.folder') {
+      const folderName = sanitiseDriveName(child.name ?? null, 'Folder');
+      const newFolderId = await createFolder(folderName, destinationFolderId, client);
+      if (newFolderId) {
+        await copyFolderContents(child.id, newFolderId, client);
+      }
+    } else {
+      try {
+        await client.files.copy({
+          fileId: child.id,
+          supportsAllDrives: true,
+          requestBody: {
+            name: child.name ?? undefined,
+            parents: [destinationFolderId],
+          },
+        });
+      } catch (error) {
+        console.error('Failed to copy Drive file', child.id, error);
+      }
+    }
+  }
+}
+
+export async function ensureChildFolder(
+  drive: DriveClient,
+  parentId: string,
+  desiredName: string,
+  existingFolderId?: string | null,
+  templateFolderId?: string | null,
+): Promise<{ id: string | null; created: boolean }> {
+  const existing = await resolveExistingFolder(existingFolderId ?? null, drive);
+  if (existing) {
+    return { id: existing, created: false };
+  }
+
+  try {
+    const escapedName = desiredName.replace(/'/g, "\\'");
+    const search = await drive.files.list({
+      q: `mimeType = 'application/vnd.google-apps.folder' and trashed = false and '${parentId}' in parents and name = '${escapedName}'`,
+      fields: 'files(id, name)',
+      pageSize: 1,
+      includeItemsFromAllDrives: true,
+      supportsAllDrives: true,
+    });
+    const matchId = search.data.files?.[0]?.id ?? null;
+    if (matchId) {
+      return { id: matchId, created: false };
+    }
+  } catch (error) {
+    console.warn('Failed to look up Drive folder by name', error);
+  }
+
+  const folderId = await createFolder(desiredName, parentId, drive);
+  if (folderId && templateFolderId) {
+    try {
+      await copyFolderContents(templateFolderId, folderId, drive);
+    } catch (error) {
+      console.error('Failed to copy Drive template into folder', error);
+    }
+  }
+
+  return { id: folderId, created: true };
+}
+
+export async function setPermissions(
+  fileId: string,
+  permissions: DrivePermissionInput[],
+  drive?: DriveClient,
+): Promise<void> {
+  const client = drive ?? (await getDriveClient());
+  for (const permission of permissions) {
+    if (!permission.type || !permission.role) {
+      continue;
+    }
+    try {
+      await client.permissions.create({
+        fileId,
+        supportsAllDrives: true,
+        sendNotificationEmail: false,
+        requestBody: permission,
+      });
+    } catch (error: any) {
+      if (error?.code === 409) {
+        continue;
+      }
+      console.warn('Failed to apply Drive permission', fileId, permission, error);
+    }
+  }
+}
+
+export async function shareFolder(
+  drive: DriveClient,
+  folderId: string,
+  emails: string[],
+): Promise<void> {
+  const seen = new Set<string>();
+  const permissions: DrivePermissionInput[] = [];
+  for (const email of emails) {
+    const trimmed = typeof email === 'string' ? email.trim().toLowerCase() : '';
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    permissions.push({ type: 'user', role: 'writer', emailAddress: trimmed });
+  }
+  if (permissions.length === 0) {
+    return;
+  }
+  await setPermissions(folderId, permissions, drive);
+}
+
+export async function getUploadUrl(
+  folderId: string | null,
+  fileName: string,
+  mimeType = 'application/octet-stream',
+): Promise<string> {
+  const authClient = await getAuthClient();
+  const token = await authClient.getAccessToken();
+  if (!token) {
+    throw new Error('Failed to obtain Google Drive access token');
+  }
+
+  const url = new URL('https://www.googleapis.com/upload/drive/v3/files');
+  url.searchParams.set('uploadType', 'resumable');
+  url.searchParams.set('supportsAllDrives', 'true');
+  url.searchParams.set('fields', 'id');
+
+  const body: Record<string, any> = { name: fileName };
+  const parent = normaliseParentId(folderId);
+  if (parent) {
+    body.parents = [parent];
+  }
+
+  const response = await fetch(url.toString(), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=UTF-8',
+      'X-Upload-Content-Type': mimeType,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Failed to create Drive upload session (${response.status}): ${text}`);
+  }
+
+  const uploadUrl = response.headers.get('location');
+  if (!uploadUrl) {
+    throw new Error('Drive upload session did not return a Location header');
+  }
+
+  return uploadUrl;
+}

--- a/functions/src/googleDrive.ts
+++ b/functions/src/googleDrive.ts
@@ -10,6 +10,38 @@ export type DrivePermissionInput = Pick<
   'type' | 'role' | 'emailAddress' | 'domain' | 'allowFileDiscovery'
 >;
 
+type DriveErrorContext = Record<string, unknown>;
+
+function createDriveError(
+  action: string,
+  error: unknown,
+  context?: DriveErrorContext,
+): Error {
+  const baseMessage = `${action} failed`;
+  const detail = error instanceof Error && error.message ? `: ${error.message}` : '';
+  const driveError = new Error(`${baseMessage}${detail}`);
+  if (error instanceof Error) {
+    (driveError as Error & { cause?: unknown }).cause = error;
+    const code = (error as Error & { code?: unknown }).code;
+    if (typeof code === 'string') {
+      (driveError as Error & { code?: string }).code = code;
+    }
+  }
+  if (context) {
+    (driveError as Error & { context?: DriveErrorContext }).context = context;
+  }
+  return driveError;
+}
+
+function handleDriveError(
+  action: string,
+  error: unknown,
+  context?: DriveErrorContext,
+): never {
+  console.error(`[Drive] ${action} failed`, { context, error });
+  throw createDriveError(action, error, context);
+}
+
 function sanitiseDriveName(name: string | null | undefined, fallback: string): string {
   const raw = typeof name === 'string' ? name.trim() : '';
   const base = raw.length > 0 ? raw : fallback;
@@ -76,14 +108,20 @@ function resolveDelegatedUser(): string | null {
 
 async function getAuthClient() {
   if (!authClientPromise) {
-    const credentials = parseServiceAccount();
-    const delegatedUser = resolveDelegatedUser();
-    const googleAuth = new google.auth.GoogleAuth({
-      credentials,
-      scopes: DRIVE_SCOPES,
-      clientOptions: delegatedUser ? { subject: delegatedUser } : undefined,
-    });
-    authClientPromise = googleAuth.getClient() as Promise<JWT>;
+    authClientPromise = (async () => {
+      try {
+        const credentials = parseServiceAccount();
+        const delegatedUser = resolveDelegatedUser();
+        const googleAuth = new google.auth.GoogleAuth({
+          credentials,
+          scopes: DRIVE_SCOPES,
+          clientOptions: delegatedUser ? { subject: delegatedUser } : undefined,
+        });
+        return (await googleAuth.getClient()) as JWT;
+      } catch (error) {
+        handleDriveError('Initialise Google auth client', error);
+      }
+    })();
   }
 
   return authClientPromise;
@@ -91,9 +129,14 @@ async function getAuthClient() {
 
 export async function getDriveClient(): Promise<DriveClient> {
   if (!driveClientPromise) {
-    driveClientPromise = getAuthClient().then((auth) =>
-      google.drive({ version: 'v3', auth })
-    );
+    driveClientPromise = (async () => {
+      try {
+        const auth = await getAuthClient();
+        return google.drive({ version: 'v3', auth });
+      } catch (error) {
+        handleDriveError('Initialise Google Drive client', error);
+      }
+    })();
   }
 
   return driveClientPromise;
@@ -120,7 +163,7 @@ export async function createFolder(
   name: string,
   parentId?: string | null,
   drive?: DriveClient,
-): Promise<string | null> {
+): Promise<string> {
   const client = drive ?? (await getDriveClient());
   try {
     const metadata: drive_v3.Schema$File = {
@@ -136,10 +179,16 @@ export async function createFolder(
       fields: 'id',
       supportsAllDrives: true,
     });
-    return response.data.id ?? null;
+    const folderId = response.data.id;
+    if (!folderId) {
+      throw new Error('Drive API did not return a folder ID');
+    }
+    return folderId;
   } catch (error) {
-    console.error('Failed to create Drive folder', { name, parentId }, error);
-    return null;
+    handleDriveError('Create Drive folder', error, {
+      name,
+      parentId: normaliseParentId(parentId),
+    });
   }
 }
 
@@ -147,7 +196,7 @@ export async function createClientFolder(
   clientName: string,
   parentId?: string | null,
   drive?: DriveClient,
-): Promise<string | null> {
+): Promise<string> {
   const explicitParent = normaliseParentId(parentId);
   const fallbackParent = normaliseParentId(process.env.GDRIVE_CLIENT_ROOT_ID ?? null);
   return createFolder(clientName, explicitParent ?? fallbackParent, drive);
@@ -171,7 +220,8 @@ export async function resolveExistingFolder(
       return null;
     }
     return res.data?.id ?? folderId;
-  } catch {
+  } catch (error) {
+    console.warn('[Drive] Failed to resolve existing folder', { folderId, error });
     return null;
   }
 }
@@ -197,19 +247,27 @@ export async function listFolderContents(
   let pageToken: string | undefined;
   const fields = options.fields || 'id, name, mimeType';
   do {
-    const response = await client.files.list({
-      q: filters.join(' and '),
-      fields: `nextPageToken, files(${fields})`,
-      pageSize: options.pageSize ?? 100,
-      pageToken,
-      orderBy: options.orderBy,
-      includeItemsFromAllDrives: true,
-      supportsAllDrives: true,
-    });
-    if (response.data.files) {
-      files.push(...response.data.files);
+    try {
+      const response = await client.files.list({
+        q: filters.join(' and '),
+        fields: `nextPageToken, files(${fields})`,
+        pageSize: options.pageSize ?? 100,
+        pageToken,
+        orderBy: options.orderBy,
+        includeItemsFromAllDrives: true,
+        supportsAllDrives: true,
+      });
+      if (response.data.files) {
+        files.push(...response.data.files);
+      }
+      pageToken = response.data.nextPageToken ?? undefined;
+    } catch (error) {
+      handleDriveError('List Drive folder contents', error, {
+        folderId,
+        pageToken,
+        mimeType: options.mimeType,
+      });
     }
-    pageToken = response.data.nextPageToken ?? undefined;
   } while (pageToken);
 
   return files;
@@ -235,13 +293,22 @@ export async function copyFolderContents(
   const children = await listFolderContents(sourceFolderId, client);
   for (const child of children) {
     if (!child.id) {
+      console.warn('[Drive] Skipping copy for Drive file without id', {
+        sourceFolderId,
+        destinationFolderId,
+      });
       continue;
     }
     if (child.mimeType === 'application/vnd.google-apps.folder') {
       const folderName = sanitiseDriveName(child.name ?? null, 'Folder');
-      const newFolderId = await createFolder(folderName, destinationFolderId, client);
-      if (newFolderId) {
+      try {
+        const newFolderId = await createFolder(folderName, destinationFolderId, client);
         await copyFolderContents(child.id, newFolderId, client);
+      } catch (error) {
+        console.error('[Drive] Failed to copy Drive folder contents', {
+          sourceFolderId: child.id,
+          destinationFolderId,
+        }, error);
       }
     } else {
       try {
@@ -254,7 +321,10 @@ export async function copyFolderContents(
           },
         });
       } catch (error) {
-        console.error('Failed to copy Drive file', child.id, error);
+        console.error('[Drive] Failed to copy Drive file', {
+          fileId: child.id,
+          destinationFolderId,
+        }, error);
       }
     }
   }
@@ -286,7 +356,11 @@ export async function ensureChildFolder(
       return { id: matchId, created: false };
     }
   } catch (error) {
-    console.warn('Failed to look up Drive folder by name', error);
+    console.warn('[Drive] Failed to look up Drive folder by name', {
+      parentId,
+      desiredName,
+      error,
+    });
   }
 
   const folderId = await createFolder(desiredName, parentId, drive);
@@ -294,7 +368,10 @@ export async function ensureChildFolder(
     try {
       await copyFolderContents(templateFolderId, folderId, drive);
     } catch (error) {
-      console.error('Failed to copy Drive template into folder', error);
+      console.error('[Drive] Failed to copy Drive template into folder', {
+        templateFolderId,
+        folderId,
+      }, error);
     }
   }
 
@@ -307,6 +384,7 @@ export async function setPermissions(
   drive?: DriveClient,
 ): Promise<void> {
   const client = drive ?? (await getDriveClient());
+  let lastError: Error | null = null;
   for (const permission of permissions) {
     if (!permission.type || !permission.role) {
       continue;
@@ -322,8 +400,18 @@ export async function setPermissions(
       if (error?.code === 409) {
         continue;
       }
-      console.warn('Failed to apply Drive permission', fileId, permission, error);
+      console.error('[Drive] Failed to apply Drive permission', {
+        fileId,
+        permission,
+      }, error);
+      lastError = createDriveError('Apply Drive permission', error, {
+        fileId,
+        permission,
+      });
     }
+  }
+  if (lastError) {
+    throw lastError;
   }
 }
 
@@ -345,7 +433,14 @@ export async function shareFolder(
   if (permissions.length === 0) {
     return;
   }
-  await setPermissions(folderId, permissions, drive);
+  try {
+    await setPermissions(folderId, permissions, drive);
+  } catch (error) {
+    handleDriveError('Share Drive folder', error, {
+      folderId,
+      emails: Array.from(seen),
+    });
+  }
 }
 
 export async function getUploadUrl(
@@ -353,42 +448,50 @@ export async function getUploadUrl(
   fileName: string,
   mimeType = 'application/octet-stream',
 ): Promise<string> {
-  const authClient = await getAuthClient();
-  const token = await authClient.getAccessToken();
-  if (!token) {
-    throw new Error('Failed to obtain Google Drive access token');
+  try {
+    const authClient = await getAuthClient();
+    const token = await authClient.getAccessToken();
+    if (!token) {
+      throw new Error('Failed to obtain Google Drive access token');
+    }
+
+    const url = new URL('https://www.googleapis.com/upload/drive/v3/files');
+    url.searchParams.set('uploadType', 'resumable');
+    url.searchParams.set('supportsAllDrives', 'true');
+    url.searchParams.set('fields', 'id');
+
+    const body: Record<string, any> = { name: fileName };
+    const parent = normaliseParentId(folderId);
+    if (parent) {
+      body.parents = [parent];
+    }
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json; charset=UTF-8',
+        'X-Upload-Content-Type': mimeType,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Failed to create Drive upload session (${response.status}): ${text}`);
+    }
+
+    const uploadUrl = response.headers.get('location');
+    if (!uploadUrl) {
+      throw new Error('Drive upload session did not return a Location header');
+    }
+
+    return uploadUrl;
+  } catch (error) {
+    handleDriveError('Create Drive upload session', error, {
+      folderId: normaliseParentId(folderId),
+      fileName,
+      mimeType,
+    });
   }
-
-  const url = new URL('https://www.googleapis.com/upload/drive/v3/files');
-  url.searchParams.set('uploadType', 'resumable');
-  url.searchParams.set('supportsAllDrives', 'true');
-  url.searchParams.set('fields', 'id');
-
-  const body: Record<string, any> = { name: fileName };
-  const parent = normaliseParentId(folderId);
-  if (parent) {
-    body.parents = [parent];
-  }
-
-  const response = await fetch(url.toString(), {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json; charset=UTF-8',
-      'X-Upload-Content-Type': mimeType,
-    },
-    body: JSON.stringify(body),
-  });
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => '');
-    throw new Error(`Failed to create Drive upload session (${response.status}): ${text}`);
-  }
-
-  const uploadUrl = response.headers.get('location');
-  if (!uploadUrl) {
-    throw new Error('Drive upload session did not return a Location header');
-  }
-
-  return uploadUrl;
 }

--- a/functions/src/googleDrive.ts
+++ b/functions/src/googleDrive.ts
@@ -5,10 +5,13 @@ const DRIVE_SCOPES = ['https://www.googleapis.com/auth/drive'];
 
 export type DriveClient = drive_v3.Drive;
 export type DriveFile = drive_v3.Schema$File;
-export type DrivePermissionInput = Pick<
-  drive_v3.Schema$Permission,
-  'type' | 'role' | 'emailAddress' | 'domain' | 'allowFileDiscovery'
->;
+export interface DrivePermissionInput {
+  type: NonNullable<drive_v3.Schema$Permission['type']>;
+  role: NonNullable<drive_v3.Schema$Permission['role']>;
+  emailAddress?: drive_v3.Schema$Permission['emailAddress'];
+  domain?: drive_v3.Schema$Permission['domain'];
+  allowFileDiscovery?: drive_v3.Schema$Permission['allowFileDiscovery'];
+}
 
 type DriveErrorContext = Record<string, unknown>;
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,6 +2,7 @@
 import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import { onRequest } from 'firebase-functions/v2/https';
+import { google } from 'googleapis';
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import Stripe from 'stripe';
 import type { DocumentData, DocumentReference, DocumentSnapshot } from 'firebase-admin/firestore';
@@ -14,8 +15,19 @@ import * as crypto from 'crypto';
 import ffmpeg from 'fluent-ffmpeg';
 import ffmpegInstaller from '@ffmpeg-installer/ffmpeg';
 import ColorThief from 'color-thief-node';
-import { google } from 'googleapis';
-import type { drive_v3 } from 'googleapis';
+import {
+  createClientFolder,
+  createFolder as createDriveFolder,
+  ensureChildFolder,
+  getUploadUrl,
+  listChildFolders as listDriveChildFolders,
+  resolveExistingFolder,
+  shareFolder as shareDriveFolder,
+  tryGetDriveClient,
+  copyFolderContents,
+  type DriveClient,
+  type DriveFile,
+} from './googleDrive';
 import { Readable } from 'stream';
 import fetch from 'node-fetch';
 import { bookingConflictsWithRange } from './utils/availability.js';
@@ -68,12 +80,19 @@ const parseJsonBody = (req: ExpressRequest): Record<string, any> => {
 };
 
 const resolveGoogleServiceAccountDelegatedUser = (): string | null => {
-  const raw = process.env.GOOGLE_SERVICE_ACCOUNT_DELEGATED_USER;
-  if (typeof raw !== 'string') {
-    return null;
+  const candidates = [
+    process.env.GDRIVE_DELEGATED_USER,
+    process.env.GOOGLE_SERVICE_ACCOUNT_DELEGATED_USER,
+  ];
+  for (const value of candidates) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
   }
-  const trimmed = raw.trim();
-  return trimmed.length > 0 ? trimmed : null;
+  return null;
 };
 
 const verifyAuthTokenFromRequest = async (
@@ -2411,229 +2430,8 @@ function buildProductFolderName(
   return base;
 }
 
-async function createDriveService(): Promise<drive_v3.Drive | null> {
-  const keyB64 = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64;
-  if (!keyB64) {
-    console.warn('Missing Google service account credentials for Drive automation');
-    return null;
-  }
-  try {
-    const keyJson = JSON.parse(Buffer.from(keyB64, 'base64').toString());
-    const delegatedUser = resolveGoogleServiceAccountDelegatedUser();
-    const auth = new google.auth.JWT({
-      email: keyJson.client_email,
-      key: keyJson.private_key,
-      scopes: ['https://www.googleapis.com/auth/drive'],
-      subject: delegatedUser ?? undefined,
-    });
-    await auth.authorize();
-    return google.drive({ version: 'v3', auth });
-  } catch (error) {
-    console.error('Failed to initialise Drive service', error);
-    return null;
-  }
-}
-
-async function resolveExistingFolder(
-  drive: drive_v3.Drive,
-  folderId: string | null
-): Promise<string | null> {
-  if (!folderId) {
-    return null;
-  }
-  try {
-    const res = await drive.files.get({
-      fileId: folderId,
-      fields: 'id, trashed',
-      supportsAllDrives: true,
-    });
-    if (res.data?.trashed) {
-      return null;
-    }
-    return res.data?.id ?? folderId;
-  } catch {
-    return null;
-  }
-}
-
-async function createDriveFolder(
-  drive: drive_v3.Drive,
-  name: string,
-  parentId: string | null
-): Promise<string | null> {
-  try {
-    const metadata: drive_v3.Schema$File = {
-      name,
-      mimeType: 'application/vnd.google-apps.folder',
-    };
-    if (parentId) {
-      metadata.parents = [parentId];
-    }
-    const res = await drive.files.create({
-      requestBody: metadata,
-      fields: 'id',
-      supportsAllDrives: true,
-    });
-    return res.data.id ?? null;
-  } catch (error) {
-    console.error('Failed to create Drive folder', name, error);
-    return null;
-  }
-}
-
-async function listDriveChildren(
-  drive: drive_v3.Drive,
-  parentId: string
-): Promise<drive_v3.Schema$File[]> {
-  const files: drive_v3.Schema$File[] = [];
-  let pageToken: string | undefined;
-  do {
-    const res = await drive.files.list({
-      q: `'${parentId}' in parents and trashed = false`,
-      fields: 'nextPageToken, files(id, name, mimeType)',
-      pageSize: 100,
-      pageToken,
-      includeItemsFromAllDrives: true,
-      supportsAllDrives: true,
-    });
-    if (res.data.files) {
-      files.push(...res.data.files);
-    }
-    pageToken = res.data.nextPageToken ?? undefined;
-  } while (pageToken);
-  return files;
-}
-
-async function listDriveChildFolders(
-  drive: drive_v3.Drive,
-  parentId: string
-): Promise<drive_v3.Schema$File[]> {
-  const folders: drive_v3.Schema$File[] = [];
-  let pageToken: string | undefined;
-  do {
-    const res = await drive.files.list({
-      q: `'${parentId}' in parents and trashed = false and mimeType = 'application/vnd.google-apps.folder'`,
-      fields: 'nextPageToken, files(id, name, mimeType)',
-      pageSize: 100,
-      pageToken,
-      includeItemsFromAllDrives: true,
-      supportsAllDrives: true,
-      orderBy: 'name_natural',
-    });
-    if (res.data.files) {
-      folders.push(...res.data.files);
-    }
-    pageToken = res.data.nextPageToken ?? undefined;
-  } while (pageToken);
-  return folders;
-}
-
-async function copyDriveContents(
-  drive: drive_v3.Drive,
-  sourceFolderId: string,
-  destinationFolderId: string
-): Promise<void> {
-  const children = await listDriveChildren(drive, sourceFolderId);
-  for (const child of children) {
-    if (!child.id) continue;
-    if (child.mimeType === 'application/vnd.google-apps.folder') {
-      const folderName = sanitiseDriveName(child.name ?? 'Folder', 'Folder');
-      const newFolderId = await createDriveFolder(drive, folderName, destinationFolderId);
-      if (newFolderId) {
-        await copyDriveContents(drive, child.id, newFolderId);
-      }
-    } else {
-      try {
-        await drive.files.copy({
-          fileId: child.id,
-          requestBody: {
-            name: child.name ?? undefined,
-            parents: [destinationFolderId],
-          },
-          supportsAllDrives: true,
-        });
-      } catch (error) {
-        console.error('Failed to copy Drive file', child.id, error);
-      }
-    }
-  }
-}
-
-async function ensureChildFolder(
-  drive: drive_v3.Drive,
-  parentId: string,
-  desiredName: string,
-  existingFolderId?: string | null,
-  templateFolderId?: string | null
-): Promise<{ id: string | null; created: boolean }> {
-  const existing = await resolveExistingFolder(
-    drive,
-    normaliseDriveId(existingFolderId)
-  );
-  if (existing) {
-    return { id: existing, created: false };
-  }
-  try {
-    const escapedName = desiredName.replace(/'/g, "\\'");
-    const search = await drive.files.list({
-      q: `mimeType = 'application/vnd.google-apps.folder' and trashed = false and '${parentId}' in parents and name = '${escapedName}'`,
-      fields: 'files(id, name)',
-      pageSize: 1,
-      includeItemsFromAllDrives: true,
-      supportsAllDrives: true,
-    });
-    const matchId = search.data.files?.[0]?.id ?? null;
-    if (matchId) {
-      return { id: matchId, created: false };
-    }
-  } catch (error) {
-    console.warn('Failed to look up Drive folder by name', error);
-  }
-  const folderId = await createDriveFolder(drive, desiredName, parentId);
-  if (folderId && templateFolderId) {
-    try {
-      await copyDriveContents(drive, templateFolderId, folderId);
-    } catch (error) {
-      console.error('Failed to copy Drive template into folder', error);
-    }
-  }
-  return { id: folderId, created: true };
-}
-
-async function shareDriveFolder(
-  drive: drive_v3.Drive,
-  folderId: string,
-  emails: string[]
-): Promise<void> {
-  const seen = new Set<string>();
-  for (const email of emails) {
-    const trimmed = typeof email === 'string' ? email.trim().toLowerCase() : '';
-    if (!trimmed || seen.has(trimmed)) {
-      continue;
-    }
-    seen.add(trimmed);
-    try {
-      await drive.permissions.create({
-        fileId: folderId,
-        supportsAllDrives: true,
-        sendNotificationEmail: false,
-        requestBody: {
-          type: 'user',
-          role: 'writer',
-          emailAddress: trimmed,
-        },
-      });
-    } catch (error: any) {
-      if (error?.code === 409) {
-        continue;
-      }
-      console.warn('Failed to apply Drive permission', folderId, trimmed, error);
-    }
-  }
-}
-
 async function setupClientDriveStructure(context: DriveSetupContext): Promise<void> {
-  const drive = await createDriveService();
+  const drive = await tryGetDriveClient();
   if (!drive) {
     await context.orderRef.set(
       {
@@ -2729,13 +2527,13 @@ async function setupClientDriveStructure(context: DriveSetupContext): Promise<vo
   const clientFolderName = buildClientFolderName(context);
   let clientFolderId =
     (await resolveExistingFolder(
-      drive,
-      normaliseDriveId(driveInfo.rootFolderId ?? driveInfo.clientFolderId)
+      normaliseDriveId(driveInfo.rootFolderId ?? driveInfo.clientFolderId),
+      drive
     )) ?? null;
   let clientFolderCreated = false;
   if (!clientFolderId) {
-    clientFolderId = await createDriveFolder(drive, clientFolderName, rootFolderId);
-    clientFolderCreated = true;
+    clientFolderId = await createClientFolder(clientFolderName, rootFolderId, drive);
+    clientFolderCreated = Boolean(clientFolderId);
   }
   if (!clientFolderId) {
     throw new Error('Unable to create client Drive folder');
@@ -2756,7 +2554,7 @@ async function setupClientDriveStructure(context: DriveSetupContext): Promise<vo
   );
   const ordersRootFolderId = orders.id ?? clientFolderId;
   const orderFolderName = buildOrderFolderName(context);
-  const orderFolderId = await createDriveFolder(drive, orderFolderName, ordersRootFolderId);
+  const orderFolderId = await createDriveFolder(orderFolderName, ordersRootFolderId, drive);
   if (!orderFolderId) {
     throw new Error('Unable to create order Drive folder');
   }
@@ -2774,12 +2572,12 @@ async function setupClientDriveStructure(context: DriveSetupContext): Promise<vo
     const count = product.quantity > 0 ? product.quantity : 1;
     for (let i = 0; i < count; i += 1) {
       const folderName = buildProductFolderName(product, i, count);
-      const folderId = await createDriveFolder(drive, folderName, orderFolderId);
+      const folderId = await createDriveFolder(folderName, orderFolderId, drive);
       if (!folderId) {
         continue;
       }
       if (product.templateFolderId) {
-        await copyDriveContents(drive, product.templateFolderId, folderId);
+        await copyFolderContents(product.templateFolderId, folderId, drive);
       }
       productFolders.push({
         productId: product.productId,
@@ -3026,7 +2824,7 @@ export const drive_listProjectFolder = functions.https.onCall(async (data, conte
     }
   }
 
-  const drive = await createDriveService();
+  const drive = await tryGetDriveClient();
   if (!drive) {
     throw new functions.https.HttpsError(
       'failed-precondition',
@@ -3070,7 +2868,7 @@ export const drive_listProjectFolder = functions.https.onCall(async (data, conte
     }
   }
 
-  const driveFiles: drive_v3.Schema$File[] = [];
+  const driveFiles: DriveFile[] = [];
   let pageToken: string | undefined;
   let safetyCounter = 0;
 
@@ -3179,7 +2977,7 @@ export const drive_listTemplateFolders = functions.https.onCall(async (data, con
     );
   }
 
-  const drive = await createDriveService();
+  const drive = await tryGetDriveClient();
   if (!drive) {
     throw new functions.https.HttpsError(
       'failed-precondition',
@@ -3222,7 +3020,7 @@ export const drive_listTemplateFolders = functions.https.onCall(async (data, con
   breadcrumbs.push({ id: rootFolderId, name: currentFolderName });
 
   for (const segment of pathSegments) {
-    const children = await listDriveChildFolders(drive, currentFolderId);
+    const children = await listDriveChildFolders(currentFolderId, drive);
     const match = children.find((child) => {
       const id = typeof child.id === 'string' ? child.id : null;
       const name = typeof child.name === 'string' ? child.name.trim() : '';
@@ -3274,9 +3072,9 @@ export const drive_listTemplateFolders = functions.https.onCall(async (data, con
     });
   }
 
-  let folderEntries: drive_v3.Schema$File[] = [];
+  let folderEntries: DriveFile[] = [];
   try {
-    folderEntries = await listDriveChildFolders(drive, targetFolderId);
+    folderEntries = await listDriveChildFolders(targetFolderId, drive);
   } catch (error) {
     console.error('drive_listTemplateFolders failed to list child folders', targetFolderId, error);
     throw new functions.https.HttpsError(
@@ -3393,7 +3191,7 @@ export const drive_stageAssetFromFile = functions.https.onCall(async (data, cont
   let digitalStatus =
     digitalStatusFromOrder ?? computeAggregateDigitalStatus(normalisedDigitalMap) ?? null;
 
-  const drive = await createDriveService();
+  const drive = await tryGetDriveClient();
   if (!drive) {
     throw new functions.https.HttpsError(
       'failed-precondition',
@@ -3401,7 +3199,7 @@ export const drive_stageAssetFromFile = functions.https.onCall(async (data, cont
     );
   }
 
-  let fileMeta: drive_v3.Schema$File;
+  let fileMeta: DriveFile;
   try {
     const metadataRes = await drive.files.get({
       fileId: driveFileId,
@@ -13686,34 +13484,27 @@ export const uploadToDrive = functions.https.onCall(async (data, context) => {
   }
 
   try {
-    const keyB64 = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64;
-    if (!keyB64) {
-      throw new Error('Missing Google service account credentials');
+    const parentId = normaliseDriveId(typeof folderId === 'string' ? folderId : null);
+    const uploadUrl = await getUploadUrl(
+      parentId,
+      fileName,
+      mimeType || 'application/octet-stream'
+    );
+    const buffer = Buffer.from(content, 'base64');
+    const uploadRes = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': mimeType || 'application/octet-stream',
+        'Content-Length': buffer.byteLength.toString(),
+      },
+      body: buffer,
+    });
+    if (!uploadRes.ok) {
+      const text = await uploadRes.text().catch(() => '');
+      throw new Error(`Drive upload failed with status ${uploadRes.status}: ${text}`);
     }
-    const keyJson = JSON.parse(Buffer.from(keyB64, 'base64').toString());
-    const delegatedUser = resolveGoogleServiceAccountDelegatedUser();
-    const auth = new google.auth.JWT({
-      email: keyJson.client_email,
-      key: keyJson.private_key,
-      scopes: ['https://www.googleapis.com/auth/drive.file'],
-      subject: delegatedUser ?? undefined,
-    });
-    await auth.authorize();
-
-    const drive = google.drive({ version: 'v3', auth });
-
-    const fileMetadata: any = { name: fileName };
-    if (folderId) fileMetadata.parents = [folderId];
-    const media = {
-      mimeType: mimeType || 'application/octet-stream',
-      body: Readable.from(Buffer.from(content, 'base64')),
-    };
-    const res = await drive.files.create({
-      requestBody: fileMetadata,
-      media,
-      fields: 'id',
-    });
-    return { fileId: res.data.id };
+    const responseJson = (await uploadRes.json().catch(() => null)) as { id?: string } | null;
+    return { fileId: responseJson?.id ?? null };
   } catch (err) {
     console.error('uploadToDrive error:', err);
     throw new functions.https.HttpsError('internal', 'Drive upload failed');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pineapple-portal-root",
   "private": true,
   "scripts": {
-    "build": "npm --prefix apps/web install --no-progress --no-fund && node scripts/run-next-build.mjs && node scripts/verify-next-build.mjs",
+    "build": "npm --prefix apps/web install --no-progress --no-fund && node scripts/run-next-build.mjs && node scripts/sync-next-standalone-assets.mjs && node scripts/verify-next-build.mjs",
     "start": "node apps/web/.next/standalone/server.js",
     "test": "npm --prefix apps/web run lint",
     "deploy": "npm --prefix functions run build && firebase deploy --only firestore:rules,functions"

--- a/scripts/sync-next-standalone-assets.mjs
+++ b/scripts/sync-next-standalone-assets.mjs
@@ -1,0 +1,48 @@
+import { cp, mkdir, rm, stat } from 'fs/promises';
+import path from 'path';
+
+async function pathExists(target) {
+  try {
+    await stat(target);
+    return true;
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function copyTree(source, destination) {
+  await rm(destination, { recursive: true, force: true });
+  await mkdir(path.dirname(destination), { recursive: true });
+  await cp(source, destination, { recursive: true });
+}
+
+async function main() {
+  const buildRoot = path.resolve('apps/web/.next');
+  const standaloneRoot = path.join(buildRoot, 'standalone');
+  const staticSource = path.join(buildRoot, 'static');
+  const staticDestination = path.join(standaloneRoot, '_next', 'static');
+  const publicSource = path.resolve('apps/web/public');
+  const publicDestination = path.join(standaloneRoot, 'public');
+
+  if (!(await pathExists(standaloneRoot))) {
+    throw new Error('Expected Next.js standalone output at apps/web/.next/standalone');
+  }
+
+  if (!(await pathExists(staticSource))) {
+    throw new Error('Expected Next.js static assets at apps/web/.next/static');
+  }
+
+  await copyTree(staticSource, staticDestination);
+
+  if (await pathExists(publicSource)) {
+    await copyTree(publicSource, publicDestination);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/upload-static.sh
+++ b/scripts/upload-static.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GCS_BUCKET:-}" ]]; then
+  echo "GCS_BUCKET environment variable must be set" >&2
+  exit 1
+fi
+
+CACHE_MAX_AGE="${CACHE_MAX_AGE:-31536000}"
+BUILD_DIR="apps/web/.next"
+PUBLIC_DIR="apps/web/public"
+
+if [[ ! -f "${BUILD_DIR}/BUILD_ID" ]]; then
+  echo "Next.js build artifacts not found: ${BUILD_DIR}/BUILD_ID is missing. Run \"npm run build\" first." >&2
+  exit 1
+fi
+
+GCS_URI="gs://${GCS_BUCKET}"
+
+if ! gsutil ls -b "${GCS_URI}" >/dev/null 2>&1; then
+  if [[ -n "${GCP_PROJECT:-}" ]]; then
+    gsutil mb -p "${GCP_PROJECT}" "${GCS_URI}"
+  else
+    gsutil mb "${GCS_URI}"
+  fi
+fi
+
+gsutil uniformbucketlevelaccess set on "${GCS_URI}" || true
+
+gsutil versioning set on "${GCS_URI}" || true
+
+gsutil -m rsync -r "${BUILD_DIR}/static" "${GCS_URI}/_next/static"
+
+gsutil -m rsync -r "${PUBLIC_DIR}" "${GCS_URI}/public"
+
+gsutil -m setmeta -h "Cache-Control:public,max-age=${CACHE_MAX_AGE},immutable" "${GCS_URI}/_next/static/**" || true
+gsutil -m setmeta -h "Cache-Control:public,max-age=${CACHE_MAX_AGE},immutable" "${GCS_URI}/public/**" || true
+
+echo "Static assets uploaded. Public base URL: https://storage.googleapis.com/${GCS_BUCKET}"

--- a/scripts/upload-static.sh
+++ b/scripts/upload-static.sh
@@ -29,6 +29,11 @@ gsutil uniformbucketlevelaccess set on "${GCS_URI}" || true
 
 gsutil versioning set on "${GCS_URI}" || true
 
+# Ensure the bucket is publicly readable so static assets can be fetched by browsers.
+if ! gsutil iam get "${GCS_URI}" | grep -q 'roles/storage.objectViewer'; then
+  gsutil iam ch allUsers:objectViewer "${GCS_URI}"
+fi
+
 gsutil -m rsync -r "${BUILD_DIR}/static" "${GCS_URI}/_next/static"
 
 gsutil -m rsync -r "${PUBLIC_DIR}" "${GCS_URI}/public"

--- a/scripts/verify-next-build.mjs
+++ b/scripts/verify-next-build.mjs
@@ -15,6 +15,7 @@ async function main() {
   const requiredArtifacts = [
     'apps/web/.next/BUILD_ID',
     'apps/web/.next/standalone/server.js',
+    'apps/web/.next/standalone/_next/static',
   ];
 
   await Promise.all(requiredArtifacts.map((artifact) => ensureExists(artifact)));


### PR DESCRIPTION
## Summary
- add a post-build helper that copies the Next.js static and public assets into the standalone output
- update the build pipeline to run the helper and verify the copied static directory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69086086e92c8323a92f13b1cbd592d5